### PR TITLE
Do not require root user for build on macOS

### DIFF
--- a/scripts-common.sh
+++ b/scripts-common.sh
@@ -11,7 +11,7 @@ indent () {
 #
 # Helper function to require that the script is being run as root
 require_root () {
-    if [[ "$EUID" != 0 ]]; then
+    if [[ "$OSTYPE" != "darwin"* && "$EUID" != 0 ]]; then
         echo "Must be running as root (EUID != 0)"
         exit 1
     fi

--- a/vm_image/build.sh
+++ b/vm_image/build.sh
@@ -5,7 +5,7 @@
 
 set -eu -o pipefail
 
-if [[ "$EUID" != '0' ]]; then
+if [[ "$OSTYPE" != "darwin"* && "$EUID" != 0 ]]; then
     echo "Must be running as root (EUID != 0)"
     exit 1
 fi


### PR DESCRIPTION
Usual docker setup on macOS does not require root access as there are no native containers and all docker api reuests served by linux VM.