### PR TITLE
Add exhaustruct lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - dupword          # things like 'the the' in comments/strings
     - durationcheck    # bad time.Duration arithmetic
     - errorlint        # common errors with Go 1.13+ error wrapping
+    - exhaustruct      # all struct fields are initialized
     - exportloopref    # escaping pointers to loop variables
     - predeclared      # no identifiers in Go's list of predeclared identifiers, see <https://go.dev/ref/spec#Predeclared_identifiers>
     - gci              # deterministic import ordering
@@ -35,14 +36,21 @@ linters:
     - noctx            # HTTP requests are passed a Context
     - nolintlint       # bad "nolint" directives
 
-    # maybe in the future:
-    # - exhaustruct     # all struct fields are initialized
-
 linters-settings:
   # see: <https://golangci-lint.run/usage/linters/#dupword>, <https://github.com/Abirdcfly/dupword>
   dupword:
     # only enable a few common cases here. Typically, duplicated words will be short
     keywords: ["a", "and", "at", "for", "from", "the"]
+
+  # see: <https://golangci-lint.run/usage/linters/#exhaustruct>
+  exhaustruct:
+    exclude:
+      - '^net/http\.(Client|Server)'
+      - '^net\.TCPAddr$'
+      # metav1.{GetOptions,ListOptions,WatchOptions,PatchOptions}
+      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.(Get|List|Watch|Patch)Options$'
+      - '^k8s\.io/apimachinery/pkg/api/resource\.Quantity$'
+      - '^github\.com/tychoish/fun\.BrokerOptions$'
 
   # see: <https://golangci-lint.run/usage/linters/#gci>
   gci:

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -92,6 +92,8 @@ func (s *agentState) handleEvent(event podEvent) {
 			logger: RunnerLogger{
 				prefix: fmt.Sprintf("Runner %v: ", event.podName),
 			},
+			// note: vm is expected to be nil before (*Runner).Run
+			vm:                    nil,
 			podName:               event.podName,
 			podIP:                 event.podIP,
 			lock:                  util.NewChanMutex(),
@@ -103,6 +105,7 @@ func (s *agentState) handleEvent(event podEvent) {
 			computeUnit:           nil,
 			lastApproved:          nil,
 			lastSchedulerError:    nil,
+			lastInformantError:    nil,
 			backgroundWorkerCount: atomic.Int64{},
 			backgroundPanic:       make(chan error),
 		}
@@ -110,6 +113,7 @@ func (s *agentState) handleEvent(event podEvent) {
 		state = &podState{
 			podName: event.podName,
 			stop:    cancelRunnerContext,
+			runner:  runner,
 			status:  status,
 		}
 		s.pods[event.podName] = state
@@ -123,7 +127,7 @@ type podState struct {
 	podName api.PodName
 
 	stop   context.CancelFunc
-	runner *Runner //nolint:unused // this will be used soon, with an HTTP endpoint to dump state
+	runner *Runner
 	status *podStatus
 }
 

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -136,13 +136,14 @@ func NewInformantServer(
 			MinProtoVersion: MinInformantProtocolVersion,
 			MaxProtoVersion: MaxInformantProtocolVersion,
 		},
-		seqNum:          0,
-		receivedIDCheck: false,
-		madeContact:     false,
-		mode:            InformantServerUnconfirmed,
-		requestLock:     util.NewChanMutex(),
-		exitStatus:      nil,
-		exit:            nil, // see below.
+		seqNum:           0,
+		receivedIDCheck:  false,
+		madeContact:      false,
+		mode:             InformantServerUnconfirmed,
+		updatedInformant: updatedInformant,
+		requestLock:      util.NewChanMutex(),
+		exitStatus:       nil,
+		exit:             nil, // see below.
 	}
 
 	runner.logger.Infof("Starting Informant server, desc = %+v", server.desc)

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -281,9 +281,12 @@ func (r *Runner) State() RunnerState {
 	var serverState *InformantServerState
 	if r.server != nil {
 		serverState = &InformantServerState{
-			Desc:   r.server.desc,
-			SeqNum: r.server.seqNum,
-			Mode:   r.server.mode,
+			Desc:            r.server.desc,
+			SeqNum:          r.server.seqNum,
+			ReceivedIDCheck: r.server.receivedIDCheck,
+			MadeContact:     r.server.madeContact,
+			Mode:            r.server.mode,
+			ExitStatus:      r.server.exitStatus,
 		}
 	}
 
@@ -295,6 +298,7 @@ func (r *Runner) State() RunnerState {
 		ComputeUnit:           r.computeUnit,
 		LastApproved:          r.lastApproved,
 		LastSchedulerError:    r.lastSchedulerError,
+		LastInformantError:    r.lastInformantError,
 		VM:                    *r.vm,
 		PodIP:                 r.podIP,
 		LogPrefix:             r.logger.prefix,

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -68,7 +68,7 @@ func NewAutoscaleEnforcerPlugin(obj runtime.Object, h framework.Handle) (framewo
 		handle:   h,
 		vmClient: vmClient,
 		// fields are set by p.setConfigAndStartWatcher, p.readClusterState
-		state: pluginState{},
+		state: pluginState{}, //nolint:exhaustruct // see above.
 	}
 
 	klog.Infof("[autoscale-enforcer] Starting config watcher")
@@ -567,7 +567,10 @@ func (e *AutoscaleEnforcer) Reserve(
 			vCPU:                     podResourceState[uint16]{reserved: vmInfo.Cpu.Use, capacityPressure: 0},
 			memSlots:                 podResourceState[uint16]{reserved: vmInfo.Mem.Use, capacityPressure: 0},
 			testingOnlyAlwaysMigrate: vmInfo.AlwaysMigrate,
+			mostRecentComputeUnit:    nil,
+			metrics:                  nil,
 			mqIndex:                  -1,
+			migrationState:           nil,
 		}
 		node.pods[pName] = ps
 		e.state.podMap[pName] = ps

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -229,6 +229,9 @@ func (r nodeOtherResourceState) addPod(
 		rawMemory:    r.rawMemory.DeepCopy(),
 		marginCpu:    r.marginCpu,
 		marginMemory: r.marginMemory,
+		// reserved amounts set by calculateReserved()
+		reservedCpu:      0,
+		reservedMemSlots: 0,
 	}
 
 	newState.rawCpu.Add(p.rawCpu)
@@ -269,6 +272,9 @@ func (r nodeOtherResourceState) subPod(
 		rawMemory:    r.rawMemory.DeepCopy(),
 		marginCpu:    r.marginCpu,
 		marginMemory: r.marginMemory,
+		// reserved amounts set by calculateReserved()
+		reservedCpu:      0,
+		reservedMemSlots: 0,
 	}
 
 	newState.rawCpu.Sub(p.rawCpu)
@@ -520,6 +526,7 @@ func buildInitialNodeState(node *corev1.Node, conf *config) (*nodeState, error) 
 			marginMemory:     marginMemory,
 		},
 		computeUnit: &nodeConf.ComputeUnit,
+		mq:          migrationQueue{},
 	}
 
 	fmtString := "[autoscale-enforcer] Built initial node state for %s:\n" +


### PR DESCRIPTION
I know this is generally unpopular in the go world. I think they're probably right in the general case. For this repo, however, given the prevalence of big state objects (and the number of bugs I've run into where I forgot a field), I feel it's better to have this strict exhaustiveness checking here.

The regexes for types to exclude are intended to be added to whenever necessary.

This already caught a couple things that would have been hard to detect otherwise. Looks like most old, high-usage code (i.e. stuff in `pkg/plugin`) was already fine.

Haven't yet run tests to double-check everything's ok.