### PR TITLE
Require label for autoscaling to be enabled

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -53,6 +53,7 @@ func vmIsOurResponsibility(vm *vmapi.VirtualMachine, config *Config, nodeName st
 	return vm.Status.Node == nodeName &&
 		vm.Status.Phase == vmapi.VmRunning &&
 		vm.Status.PodIP != "" &&
+		api.HasAutoscalingEnabled(vm) &&
 		vm.Spec.SchedulerName == config.Scheduler.SchedulerName
 }
 

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -17,7 +17,7 @@ const (
 )
 
 // HasAutoscalingEnabled returns true iff the object has the label that enables autoscaling
-func HasAutoscalingEnabled[T metav1.ObjectMetaAccessor](obj T) bool {
+func HasAutoscalingEnabled(obj metav1.ObjectMetaAccessor) bool {
 	labels := obj.GetObjectMeta().GetLabels()
 	value, ok := labels[LabelEnableAutoscaling]
 	return ok && value == "true"

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -19,8 +19,8 @@ const (
 // HasAutoscalingEnabled returns true iff the object has the label that enables autoscaling
 func HasAutoscalingEnabled[T metav1.ObjectMetaAccessor](obj T) bool {
 	labels := obj.GetObjectMeta().GetLabels()
-	_, enabled := labels[LabelEnableAutoscaling]
-	return enabled
+	value, ok := labels[LabelEnableAutoscaling]
+	return ok && value == "true"
 }
 
 // VmInfo is the subset of vmapi.VirtualMachineSpec that the scheduler plugin and autoscaler agent
@@ -93,7 +93,7 @@ func ExtractVmInfo(vm *vmapi.VirtualMachine) (*VmInfo, error) {
 	}
 
 	_, alwaysMigrate := vm.Labels[LabelTestingOnlyAlwaysMigrate]
-	_, scalingEnabled := vm.Labels[LabelEnableAutoscaling]
+	scalingEnabled := HasAutoscalingEnabled(vm)
 
 	info := VmInfo{
 		Name:      vm.Name,

--- a/pkg/plugin/trans.go
+++ b/pkg/plugin/trans.go
@@ -215,6 +215,33 @@ func (r resourceTransition[T]) handleDeleted(currentlyMigrating bool) (verdict s
 	return verdict
 }
 
+// handleAutoscalingDisabled updates r.node with changes to clear any buffer and capacityPressure
+// from r.pod
+//
+// A pretty-formatted summary of the changes is returned as the verdict, for logging.
+func (r resourceTransition[T]) handleAutoscalingDisabled() (verdict string) {
+	// buffer is included in reserved, so we reduce everything by buffer.
+	buffer := r.pod.Buffer
+	valuesToReduce := []*T{&r.node.Reserved, &r.node.Buffer, &r.pod.Reserved, &r.pod.Buffer}
+	for _, v := range valuesToReduce {
+		*v -= buffer
+	}
+
+	r.node.CapacityPressure -= r.pod.CapacityPressure
+	r.pod.CapacityPressure = 0
+
+	fmtString := "pod had buffer %d, capacityPressure %d; " +
+		"node reserved %d -> %d, capacityPressure %d -> %d"
+	verdict = fmt.Sprintf(
+		fmtString,
+		// pod had buffer %d, capacityPressure %d;
+		r.oldPod.buffer, r.oldPod.capacityPressure,
+		// node reserved %d -> %d, capacityPressure %d -> %d
+		r.oldNode.reserved, r.node.Reserved, r.oldNode.capacityPressure, r.node.CapacityPressure,
+	)
+	return verdict
+}
+
 // handleDeletedPod is kind of like handleDeleted, except that it returns both verdicts side by
 // side instead of being generic over the resource
 func handleDeletedPod(

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -1,5 +1,8 @@
 package plugin
 
+// Implementation of watching Pods for Pod/VM deletions and changes so that a VM's autoscaling is
+// disabled.
+
 // Implementation of watching for VM deletions and VM migration completions, so we can unreserve the
 // associated resources
 
@@ -11,20 +14,47 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klog "k8s.io/klog/v2"
 
+	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
-// watchPodDeletions continuously tracks pod deletion events and sends each deleted podName on
-// either vmDeletions or podDeletions as they occur, depending on whether the pod has the LabelVM
-// label.
+// watchPodEvents continuously tracks a handful of Pod-related events that we care about. These
+// events are: non-VM pod deletion, VM deletion, and VMs that disable scaling.
 //
 // This method starts its own goroutine, and guarantees that we have started listening for FUTURE
 // events once it returns (unless it returns error).
 //
 // Events occurring before this method is called will not be sent.
-func (e *AutoscaleEnforcer) watchPodDeletions(
+//
+// The reason we care about when scaling is disabled is that if we don't, we can run into the
+// following race condition:
+//
+//  1. VM created with autoscaling enabled
+//  2. Scheduler restarts and reads the state of the cluster. It records the difference between the
+//     VM's current and maximum usage as "buffer"
+//  3. Before the autoscaler-agent runner for the VM connects to the scheduler, the VM's label to
+//     enable autoscaling is removed, and the autoscaler-agent's runner exits.
+//  4. final state: The scheduler retains buffer for a VM that can't scale.
+//
+// To avoid (4) occurring, we track events where autoscaling is disabled for a VM and remove its
+// "buffer" when that happens. There's still some other possibilities for race conditions (FIXME),
+// but those are a little harder to handlle - in particular:
+//
+//  1. Scheduler exits
+//  2. autoscaler-agent runner downscales
+//  3. Scheduler starts, reads cluster state
+//  4. VM gets autoscaling disabled
+//  5. Scheduler removes the VM's buffer
+//  6. Before noticing that event, the autoscaler-agent upscales the VM and informs the scheduler of
+//     its current allocation (which it can do, because it was approved by a previous scheduler).
+//  7. The scheduler denies what it sees as upscaling.
+//
+// This one requires a very unlikely sequence of events to occur, that should be appropriately
+// handled by cancelled contexts in *almost all* cases.
+func (e *AutoscaleEnforcer) watchPodEvents(
 	ctx context.Context,
 	vmDeletions chan<- util.NamespacedName,
+	vmDisabledScaling chan<- util.NamespacedName,
 	podDeletions chan<- util.NamespacedName,
 ) error {
 	_, err := util.Watch(
@@ -44,6 +74,19 @@ func (e *AutoscaleEnforcer) watchPodDeletions(
 		util.InitWatchModeSync, // note: doesn't matter, because AddFunc = nil.
 		metav1.ListOptions{},
 		util.WatchHandlerFuncs[*corev1.Pod]{
+			UpdateFunc: func(oldPod, newPod *corev1.Pod) {
+				// note: it doesn't matter whether we use newPod or oldPod for the name here; the
+				// pod name and namespace aren't allowed to change.
+				name := util.NamespacedName{Name: newPod.Name, Namespace: newPod.Namespace}
+				_, isVM := oldPod.Labels[LabelVM]
+				if isVM && api.HasAutoscalingEnabled(oldPod) && !api.HasAutoscalingEnabled(newPod) {
+					klog.Infof(
+						"[autoscale-enforcer] watch: Received update to disable autoscaling for pod %v",
+						name,
+					)
+					vmDisabledScaling <- name
+				}
+			},
 			DeleteFunc: func(pod *corev1.Pod, mayBeStale bool) {
 				name := util.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 				klog.Infof("[autoscale-enforcer] watch: Received delete event for pod %v", name)

--- a/tests/e2e/autoscaling/00-create-vm.yaml
+++ b/tests/e2e/autoscaling/00-create-vm.yaml
@@ -21,7 +21,7 @@ kind: VirtualMachine
 metadata:
   name: example
   labels:
-    autoscaling.neon.tech/enabled: ""
+    autoscaling.neon.tech/enabled: "true"
 spec:
   schedulerName: autoscale-scheduler
   guest:

--- a/tests/e2e/autoscaling/00-create-vm.yaml
+++ b/tests/e2e/autoscaling/00-create-vm.yaml
@@ -20,6 +20,8 @@ apiVersion: vm.neon.tech/v1
 kind: VirtualMachine
 metadata:
   name: example
+  labels:
+    autoscaling.neon.tech/enabled: ""
 spec:
   schedulerName: autoscale-scheduler
   guest:

--- a/vm-deploy.yaml
+++ b/vm-deploy.yaml
@@ -4,6 +4,7 @@ kind: VirtualMachine
 metadata:
   name: postgres14-disk-test
   labels:
+    autoscaling.neon.tech/enabled: ""
     # Uncomment the line below to continuously migrate the VM (TESTING ONLY)
     # autoscaler/testing-only-always-migrate: ""
 spec:

--- a/vm-deploy.yaml
+++ b/vm-deploy.yaml
@@ -4,7 +4,7 @@ kind: VirtualMachine
 metadata:
   name: postgres14-disk-test
   labels:
-    autoscaling.neon.tech/enabled: ""
+    autoscaling.neon.tech/enabled: "true"
     # Uncomment the line below to continuously migrate the VM (TESTING ONLY)
     # autoscaler/testing-only-always-migrate: ""
 spec:


### PR DESCRIPTION
Adds the `autoscaling.neon.tech/enabled` label and requires that it's present for the autoscaler-agent to run.