### PR TITLE
Add versioning to agent<->plugin protocol

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -64,6 +64,13 @@ import (
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
+// PluginProtocolVersion is the current version of the agent<->scheduler plugin in use by this
+// autoscaler-agent.
+//
+// Currently, each autoscaler-agent supports only one version at a time. In the future, this may
+// change.
+const PluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV1_0
+
 // Runner is per-VM Pod god object responsible for handling everything
 //
 // It primarily operates as a source of shared data for a number of long-running tasks. For
@@ -1322,9 +1329,10 @@ retry:
 			}
 
 			request := api.AgentRequest{
-				Pod:       r.podName,
-				Resources: target,
-				Metrics:   state.metrics, // FIXME: the metrics here *might* be a little out of date.
+				ProtoVersion: PluginProtocolVersion,
+				Pod:          r.podName,
+				Resources:    target,
+				Metrics:      state.metrics, // FIXME: the metrics here *might* be a little out of date.
 			}
 			response, err := sched.DoRequest(ctx, &request)
 			if err != nil {
@@ -1756,9 +1764,10 @@ func (s *Scheduler) Register(ctx context.Context, signalOk func()) error {
 	}
 
 	req := api.AgentRequest{
-		Pod:       s.runner.podName,
-		Resources: resources,
-		Metrics:   *metrics,
+		ProtoVersion: PluginProtocolVersion,
+		Pod:          s.runner.podName,
+		Resources:    resources,
+		Metrics:      *metrics,
 	}
 	if _, err := s.DoRequest(ctx, &req); err != nil {
 		return err

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -26,14 +26,17 @@ commit in this repository, possibly unreleased.
 ## agent<->scheduler plugin protocol
 
 Note: v0.1.6 and below did not have a versioned protocol between the agent and scheduler plugin.
+We've marked those as protoco version v0.0. Scheduler plugins v0.1.6 and below implicitly support
+v1.0 because the only change from v0.0 to v1.0 was having the scheduler plugin check the version
+number.
 
 | Release | autoscaler-agent | Scheduler plugin |
 |---------|------------------|------------------|
 | _Current_ | **v1.0** only | **v1.0** only |
-| v0.1.6 | none | none |
-| v0.1.5 | none | none |
-| v0.1.4 | none | none |
-| v0.1.3 | none | none |
-| 0.1.2 | none | none |
-| 0.1.1 | none | none |
-| 0.1.0 | none | none |
+| v0.1.6 | v0.0 | v0.0-v1.0 |
+| v0.1.5 | v0.0 | v0.0-v1.0 |
+| v0.1.4 | v0.0 | v0.0-v1.0 |
+| v0.1.3 | v0.0 | v0.0-v1.0 |
+| 0.1.2 | v0.0 | v0.0-v1.0 |
+| 0.1.1 | v0.0 | v0.0-v1.0 |
+| 0.1.0 | **v0.0** only | **v0.0-v1.0** |

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -22,3 +22,18 @@ commit in this repository, possibly unreleased.
 | 0.1.2 | v1.0 only | v1.0 only |
 | 0.1.1 | v1.0 only | v1.0 only |
 | 0.1.0 | **v1.0** only | **v1.0** only |
+
+## agent<->scheduler plugin protocol
+
+Note: v0.1.6 and below did not have a versioned protocol between the agent and scheduler plugin.
+
+| Release | autoscaler-agent | Scheduler plugin |
+|---------|------------------|------------------|
+| _Current_ | **v1.0** only | **v1.0** only |
+| v0.1.6 | none | none |
+| v0.1.5 | none | none |
+| v0.1.4 | none | none |
+| v0.1.3 | none | none |
+| 0.1.2 | none | none |
+| 0.1.1 | none | none |
+| 0.1.0 | none | none |

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -25,18 +25,19 @@ commit in this repository, possibly unreleased.
 
 ## agent<->scheduler plugin protocol
 
-Note: v0.1.6 and below did not have a versioned protocol between the agent and scheduler plugin.
-We've marked those as protoco version v0.0. Scheduler plugins v0.1.6 and below implicitly support
-v1.0 because the only change from v0.0 to v1.0 was having the scheduler plugin check the version
+Note: Components v0.1.7 and below did not have a versioned protocol between the agent and scheduler
+plugin. We've marked those as protocol version v0.0. Scheduler plugin v0.1.7 implicitly supports
+v1.0 because the only change from v0.0 to v1.0 is having the scheduler plugin check the version
 number.
 
 | Release | autoscaler-agent | Scheduler plugin |
 |---------|------------------|------------------|
 | _Current_ | **v1.0** only | **v1.0** only |
-| v0.1.6 | v0.0 | v0.0-v1.0 |
-| v0.1.5 | v0.0 | v0.0-v1.0 |
-| v0.1.4 | v0.0 | v0.0-v1.0 |
-| v0.1.3 | v0.0 | v0.0-v1.0 |
-| 0.1.2 | v0.0 | v0.0-v1.0 |
-| 0.1.1 | v0.0 | v0.0-v1.0 |
-| 0.1.0 | **v0.0** only | **v0.0-v1.0** |
+| v0.1.7 | v0.0 only | **v0.0-v1.0** |
+| v0.1.6 | v0.0 only | v0.0 only |
+| v0.1.5 | v0.0 only | v0.0 only |
+| v0.1.4 | v0.0 only | v0.0 only |
+| v0.1.3 | v0.0 only | v0.0 only |
+| 0.1.2 | v0.0 only | v0.0 only |
+| 0.1.1 | v0.0 only | v0.0 only |
+| 0.1.0 | **v0.0** only | **v0.0** only |

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -28,10 +28,54 @@ func (n PodName) String() string {
 // (Autoscaler) Agent Messages //
 /////////////////////////////////
 
+// PluginProtoVersion represents a single version of the agent<->scheduler plugin protocol
+//
+// Each version of the agent<->scheduler plugin protocol is named independently from releases of the
+// repository containing this code. Names follow semver, although this does not necessarily
+// guarantee support - for example, the plugin may only support a single version, even though others
+// may appear to be semver-compatible.
+//
+// Version compatibility is documented in the neighboring file VERSIONING.md.
+type PluginProtoVersion uint32
+
+const (
+	// PluginProtoV1_0 represents v1.0 of the agent<->scheduler plugin protocol - the initial
+	// version.
+	//
+	// Currently the latest version.
+	PluginProtoV1_0 PluginProtoVersion = iota + 1 // start from zero, for backwards compatibility with pre-versioned messages
+
+	// latestPluginProtoVersion represents the latest version of the agent<->scheduler plugin
+	// protocol
+	//
+	// This value is kept private because it should not be used externally; any desired
+	// functionality that could be implemented with it should instead be a method on
+	// PluginProtoVersion.
+	latestPluginProtoVersion PluginProtoVersion = iota // excluding +1 makes it equal to previous
+)
+
+func (v PluginProtoVersion) String() string {
+	var zero PluginProtoVersion
+
+	switch v {
+	case zero:
+		return "<invalid: zero>"
+	case PluginProtoV1_0:
+		return "v1.0"
+	default:
+		diff := v - latestPluginProtoVersion
+		return fmt.Sprintf("<unknown = %v + %d>", latestPluginProtoVersion, diff)
+	}
+}
+
 // AgentRequest is the type of message sent from an autoscaler-agent to the scheduler plugin
 //
 // All AgentRequests expect a PluginResponse.
 type AgentRequest struct {
+	// ProtoVersion is the version of the protocol that the autoscaler-agent is expecting to use
+	//
+	// If the scheduler does not support this version, then it will respond with a 400 status.
+	ProtoVersion PluginProtoVersion `json:"protoVersion"`
 	// Pod is the namespaced name of the pod making the request
 	Pod PodName `json:"pod"`
 	// Resources gives a requested or notified change in resources allocated to the VM.
@@ -45,6 +89,14 @@ type AgentRequest struct {
 	// Metrics provides information about the VM's current load, so that the scheduler may
 	// prioritize which pods to migrate
 	Metrics Metrics `json:"metrics"`
+}
+
+// ProtocolRange returns a VersionRange exactly equal to r.ProtoVersion
+func (r AgentRequest) ProtocolRange() VersionRange[PluginProtoVersion] {
+	return VersionRange[PluginProtoVersion]{
+		Min: r.ProtoVersion,
+		Max: r.ProtoVersion,
+	}
 }
 
 // Resources represents an amount of CPU and memory (via memory slots)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -68,6 +68,11 @@ func (v PluginProtoVersion) String() string {
 	}
 }
 
+// IsValid returns whether the protocol version is valid. The zero value is not valid.
+func (v PluginProtoVersion) IsValid() bool {
+	return uint(v) != 0
+}
+
 // AgentRequest is the type of message sent from an autoscaler-agent to the scheduler plugin
 //
 // All AgentRequests expect a PluginResponse.

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -18,6 +18,14 @@ var MaxHTTPBodySize int64 = 1 << 10 // 1 KiB
 var ContentTypeJSON string = "application/json"
 var ContentTypeError string = "text/plain"
 
+// The scheduler plugin currently supports v1.0 of the agent<->scheduler plugin protoco.
+//
+// If you update either of these values, make sure to also update VERSIONING.md.
+const (
+	MinPluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV1_0
+	MaxPluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV1_0
+)
+
 // runPermitHandler runs the server for handling each resourceRequest from a pod
 func (e *AutoscaleEnforcer) runPermitHandler(ctx context.Context) {
 	mux := http.NewServeMux()
@@ -107,6 +115,19 @@ func (e *AutoscaleEnforcer) runPermitHandler(ctx context.Context) {
 
 // Returns body (if successful), status code, error (if unsuccessful)
 func (e *AutoscaleEnforcer) handleAgentRequest(req api.AgentRequest) (*api.PluginResponse, int, error) {
+	// Before doing anything, check that the version is within the range we're expecting.
+	expectedProtoRange := api.VersionRange[api.PluginProtoVersion]{
+		Min: MinPluginProtocolVersion,
+		Max: MaxPluginProtocolVersion,
+	}
+
+	reqProtoRange := req.ProtocolRange()
+	if _, ok := expectedProtoRange.LatestSharedVersion(reqProtoRange); !ok {
+		return nil, 400, fmt.Errorf(
+			"Protocol version mismatch: Need %v but got %v", expectedProtoRange, reqProtoRange,
+		)
+	}
+
 	e.state.lock.Lock()
 	defer e.state.lock.Unlock()
 

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -121,6 +121,9 @@ func (e *AutoscaleEnforcer) handleAgentRequest(req api.AgentRequest) (*api.Plugi
 		Max: MaxPluginProtocolVersion,
 	}
 
+	if !req.ProtoVersion.IsValid() {
+		return nil, 400, fmt.Errorf("Invalid protocol version %v", req.ProtoVersion)
+	}
 	reqProtoRange := req.ProtocolRange()
 	if _, ok := expectedProtoRange.LatestSharedVersion(reqProtoRange); !ok {
 		return nil, 400, fmt.Errorf(


### PR DESCRIPTION
Mirrors the versioning for the agent<->informant protocol. Versioning here is required in some form to fix the "allow nil metrics" issue from #27.

Current plan is to release+deploy a new version _just_ with this change (requires autoscaler-agent first, then scheduler), then add the option for nil metrics in a follow-up PR + release.