### PR TITLE
Allow nil metrics in agent->plugin messages

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -69,7 +69,7 @@ import (
 //
 // Currently, each autoscaler-agent supports only one version at a time. In the future, this may
 // change.
-const PluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV1_0
+const PluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV1_1
 
 // Runner is per-VM Pod god object responsible for handling everything
 //

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -33,7 +33,7 @@ number.
 
 | Release | autoscaler-agent | Scheduler plugin |
 |---------|------------------|------------------|
-| _Current_ | v1.0 only | v1.0 only |
+| _Current_ | **v1.1** only | **v1.0-v1.1** |
 | v0.1.8 | **v1.0** only | **v1.0** only |
 | v0.1.7 | v0.0 only | **v0.0-v1.0** |
 | v0.1.6 | v0.0 only | v0.0 only |

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -42,8 +42,17 @@ const (
 	// PluginProtoV1_0 represents v1.0 of the agent<->scheduler plugin protocol - the initial
 	// version.
 	//
-	// Currently the latest version.
+	// Last used in release version <FIXME>
 	PluginProtoV1_0 PluginProtoVersion = iota + 1 // start from zero, for backwards compatibility with pre-versioned messages
+
+	// PluginProtoV1_1 represents v1.1 of the agent<->scheduler plugin protocol.
+	//
+	// Changes from v1.0:
+	//
+	// * Allows a nil value of the AgentRequest.Metrics field.
+	//
+	// Currently the latest version.
+	PluginProtoV1_1
 
 	// latestPluginProtoVersion represents the latest version of the agent<->scheduler plugin
 	// protocol
@@ -73,6 +82,14 @@ func (v PluginProtoVersion) IsValid() bool {
 	return uint(v) != 0
 }
 
+// AllowsNilMetrics returns whether this version of the protocol allows the autoscaler-agent to send
+// a nil metrics field.
+//
+// This is true for version v1.1 and greater.
+func (v PluginProtoVersion) AllowsNilMetrics() bool {
+	return v >= PluginProtoV1_1
+}
+
 // AgentRequest is the type of message sent from an autoscaler-agent to the scheduler plugin
 //
 // All AgentRequests expect a PluginResponse.
@@ -93,7 +110,9 @@ type AgentRequest struct {
 	Resources Resources `json:"resources"`
 	// Metrics provides information about the VM's current load, so that the scheduler may
 	// prioritize which pods to migrate
-	Metrics Metrics `json:"metrics"`
+	//
+	// In some protocol versions, this field may be nil.
+	Metrics *Metrics `json:"metrics"`
 }
 
 // ProtocolRange returns a VersionRange exactly equal to r.ProtoVersion

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -42,7 +42,7 @@ const (
 	// PluginProtoV1_0 represents v1.0 of the agent<->scheduler plugin protocol - the initial
 	// version.
 	//
-	// Last used in release version <FIXME>
+	// Last used in release version v0.1.8.
 	PluginProtoV1_0 PluginProtoVersion = iota + 1 // start from zero, for backwards compatibility with pre-versioned messages
 
 	// PluginProtoV1_1 represents v1.1 of the agent<->scheduler plugin protocol.
@@ -71,6 +71,8 @@ func (v PluginProtoVersion) String() string {
 		return "<invalid: zero>"
 	case PluginProtoV1_0:
 		return "v1.0"
+	case PluginProtoV1_1:
+		return "v1.1"
 	default:
 		diff := v - latestPluginProtoVersion
 		return fmt.Sprintf("<unknown = %v + %d>", latestPluginProtoVersion, diff)

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -23,7 +23,7 @@ var ContentTypeError string = "text/plain"
 // If you update either of these values, make sure to also update VERSIONING.md.
 const (
 	MinPluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV1_0
-	MaxPluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV1_0
+	MaxPluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV1_1
 )
 
 // runPermitHandler runs the server for handling each resourceRequest from a pod

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -18,7 +18,7 @@ var MaxHTTPBodySize int64 = 1 << 10 // 1 KiB
 var ContentTypeJSON string = "application/json"
 var ContentTypeError string = "text/plain"
 
-// The scheduler plugin currently supports v1.0 of the agent<->scheduler plugin protoco.
+// The scheduler plugin currently supports v1.0 to v1.1 of the agent<->scheduler plugin protocol.
 //
 // If you update either of these values, make sure to also update VERSIONING.md.
 const (

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -391,7 +391,7 @@ func (s *nodeState) tooMuchPressure() bool {
 // A returned error indicates that the pod's resource usage has changed enough that we should try to
 // migrate something else first. The error provides justification for this.
 func (s *podState) checkOkToMigrate(oldMetrics api.Metrics) error {
-	// TODO
+	// TODO. Note: s.metrics may be nil.
 	return nil
 }
 


### PR DESCRIPTION
Builds on #50, fixes some annoyances around restart.

Will merge after #50 and its repo version bump.