### PR TITLE
testing: provide handcrank test watcher

### DIFF
--- a/pkg/testutil/watch.go
+++ b/pkg/testutil/watch.go
@@ -1,0 +1,38 @@
+package testutil
+
+import (
+	"context"
+	"sync"
+
+	"github.com/tychoish/fun/erc"
+
+	"github.com/neondatabase/autoscaling/pkg/util"
+)
+
+func Watch[T any, P util.WatchObject[T]](
+	ctx context.Context,
+	stream <-chan util.ProcessEventArgs[T, P],
+	handlers util.WatchHandlerFuncs[P],
+) (*util.WatchStore[T], func() error) {
+	store := util.NewWatchStore[T]()
+
+	wg := &sync.WaitGroup{}
+	ec := &erc.Collector{}
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		defer func() { erc.Recover(ec) }()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case args := <-stream:
+				ec.Add(util.ProcessEvent[T, P](store, handlers, args))
+			}
+		}
+	}()
+
+	return store, func() error { wg.Wait(); return ec.Resolve() }
+}

--- a/pkg/testutil/watch.go
+++ b/pkg/testutil/watch.go
@@ -28,7 +28,10 @@ func Watch[T any, P util.WatchObject[T]](
 			select {
 			case <-ctx.Done():
 				return
-			case args := <-stream:
+			case args, ok := <-stream:
+				if !ok || ctx.Err() != nil {
+					return
+				}
 				ec.Add(util.ProcessEvent[T, P](store, handlers, args))
 			}
 		}

--- a/pkg/testutil/watch_test.go
+++ b/pkg/testutil/watch_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/neondatabase/autoscaling/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
 func TestWatch(t *testing.T) {
@@ -24,6 +25,7 @@ func TestWatch(t *testing.T) {
 		UpdateFunc: func(*corev1.Pod, *corev1.Pod) { calledUpdate++ },
 	})
 	ch <- util.ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+		//nolint:exhaustruct  // for testing
 		Event: watch.Event{
 			Type: watch.Added,
 		},
@@ -35,6 +37,7 @@ func TestWatch(t *testing.T) {
 	}
 
 	ch <- util.ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+		//nolint:exhaustruct  // for testing
 		Event: watch.Event{
 			Type: watch.Deleted,
 		},

--- a/pkg/testutil/watch_test.go
+++ b/pkg/testutil/watch_test.go
@@ -1,0 +1,60 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/neondatabase/autoscaling/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestWatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	ch := make(chan util.ProcessEventArgs[corev1.Pod, *corev1.Pod], 1)
+
+	calledDelete := 0
+	calledAdd := 0
+	calledUpdate := 0
+	store, wait := Watch(ctx, ch, util.WatchHandlerFuncs[*corev1.Pod]{
+		DeleteFunc: func(*corev1.Pod, bool) { calledDelete++ },
+		AddFunc:    func(*corev1.Pod, bool) { calledAdd++ },
+		UpdateFunc: func(*corev1.Pod, *corev1.Pod) { calledUpdate++ },
+	})
+	ch <- util.ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+		Event: watch.Event{
+			Type: watch.Added,
+		},
+	}
+	time.Sleep(time.Millisecond) // to let to worker run the handcrank
+
+	if items := store.Items(); len(items) != 1 {
+		t.Error(items)
+	}
+
+	ch <- util.ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+		Event: watch.Event{
+			Type: watch.Deleted,
+		},
+	}
+	time.Sleep(time.Millisecond) // to let to worker run the handcrank
+
+	if items := store.Items(); len(items) != 0 {
+		t.Error(items)
+	}
+	if err := wait(); err != nil {
+		t.Error(err)
+	}
+	if calledAdd != 1 {
+		t.Error("did not call add handler")
+	}
+	if calledDelete != 1 {
+		t.Error("did not call delete handler")
+	}
+	if calledUpdate != 1 {
+		t.Error("did not call update handler")
+	}
+
+}

--- a/pkg/util/watch.go
+++ b/pkg/util/watch.go
@@ -263,7 +263,6 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 					}
 				}
 			}
-
 		relist:
 			klog.Infof("watch %s: re-listing", config.LogName)
 			for {

--- a/pkg/util/watch_test.go
+++ b/pkg/util/watch_test.go
@@ -1,0 +1,159 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tychoish/fun"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestProcessEvent(t *testing.T) {
+	t.Run("Add", func(t *testing.T) {
+		store := NewWatchStore[corev1.Pod]()
+		calledHandler := false
+		err := ProcessEvent(
+			store,
+			WatchHandlerFuncs[*corev1.Pod]{
+				AddFunc: func(*corev1.Pod, bool) { calledHandler = true },
+			},
+			ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+				Event: watch.Event{
+					Type: watch.Added,
+				},
+			},
+		)
+		t.Run("AddedOneEvent", func(t *testing.T) {
+			if err != nil {
+				t.Error(err)
+			}
+			if !calledHandler {
+				t.Error("event hook was not called")
+			}
+			if len(store.objects) != 1 {
+				t.Error("store not updated")
+			}
+		})
+		t.Run("DuplicateEvent", func(t *testing.T) {
+			err := ProcessEvent(
+				store,
+				WatchHandlerFuncs[*corev1.Pod]{
+					AddFunc: func(*corev1.Pod, bool) { calledHandler = true },
+				},
+				ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+					Event: watch.Event{
+						Type: watch.Added,
+					},
+				},
+			)
+			if err == nil {
+				t.Error("expected error")
+			}
+		})
+	})
+	t.Run("Delete", func(t *testing.T) {
+		store := NewWatchStore[corev1.Pod]()
+		calledDelete := 0
+		calledAdd := 0
+		calledUpdate := 0
+		handlers := WatchHandlerFuncs[*corev1.Pod]{
+			DeleteFunc: func(*corev1.Pod, bool) { calledDelete++ },
+			AddFunc:    func(*corev1.Pod, bool) { calledAdd++ },
+			UpdateFunc: func(*corev1.Pod, *corev1.Pod) { calledUpdate++ },
+		}
+
+		err := ProcessEvent(
+			store,
+			handlers,
+			ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+				Event: watch.Event{
+					Type: watch.Added,
+				},
+			},
+		)
+		if err != nil {
+			t.Error(err)
+		}
+		if calledDelete > 0 {
+			t.Error("should not have called handler yet")
+		}
+		if len(store.objects) != 1 {
+			t.Error(len(store.objects))
+		}
+
+		t.Run("DeleteObject", func(t *testing.T) {
+			err := ProcessEvent(
+				store,
+				handlers,
+				ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+					Event: watch.Event{
+						Type: watch.Deleted,
+					},
+				},
+			)
+			if err != nil {
+				t.Error(err)
+			}
+			if calledDelete != 1 {
+				t.Error("should have called handler once")
+			}
+			if calledUpdate != 1 {
+				t.Error("should have called update handler once")
+			}
+			if len(store.objects) != 0 {
+				t.Error(len(store.objects))
+			}
+		})
+		t.Run("DeleteNonExistingObject", func(t *testing.T) {
+			err := ProcessEvent(
+				store,
+				handlers,
+				ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+					Event: watch.Event{
+						Type: watch.Deleted,
+					},
+				},
+			)
+			if err == nil {
+				t.Error(err)
+			}
+
+			if calledDelete != 1 {
+				t.Error("should only have called handler once")
+			}
+			if len(store.objects) != 0 {
+				t.Error(len(store.objects))
+			}
+		})
+	})
+	t.Run("PanicsForErrors", func(t *testing.T) {
+		store := NewWatchStore[corev1.Pod]()
+		calledHandler := false
+		err, perr := fun.Safe(func() error {
+			return ProcessEvent(
+				store,
+				WatchHandlerFuncs[*corev1.Pod]{
+					AddFunc: func(*corev1.Pod, bool) { calledHandler = true },
+				},
+				ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+					Event: watch.Event{
+						Type: watch.Error,
+					},
+				},
+			)
+		})
+		if err != nil {
+			t.Error("we caught the panic so we don't expect an error")
+		}
+		if perr == nil {
+			t.Fatal("expected panic")
+		}
+		if !strings.Contains(perr.Error(), "unreachable code") {
+			t.Error(perr)
+		}
+		if calledHandler {
+			t.Error("should not have called")
+		}
+	})
+}

--- a/pkg/util/watch_test.go
+++ b/pkg/util/watch_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/tychoish/fun"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -19,6 +20,7 @@ func TestProcessEvent(t *testing.T) {
 				AddFunc: func(*corev1.Pod, bool) { calledHandler = true },
 			},
 			ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+				//nolint:exhaustruct  // for testing
 				Event: watch.Event{
 					Type: watch.Added,
 				},
@@ -42,6 +44,7 @@ func TestProcessEvent(t *testing.T) {
 					AddFunc: func(*corev1.Pod, bool) { calledHandler = true },
 				},
 				ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+					//nolint:exhaustruct  // for testing
 					Event: watch.Event{
 						Type: watch.Added,
 					},
@@ -67,6 +70,7 @@ func TestProcessEvent(t *testing.T) {
 			store,
 			handlers,
 			ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+				//nolint:exhaustruct  // for testing
 				Event: watch.Event{
 					Type: watch.Added,
 				},
@@ -87,6 +91,7 @@ func TestProcessEvent(t *testing.T) {
 				store,
 				handlers,
 				ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+					//nolint:exhaustruct  // for testing
 					Event: watch.Event{
 						Type: watch.Deleted,
 					},
@@ -110,6 +115,7 @@ func TestProcessEvent(t *testing.T) {
 				store,
 				handlers,
 				ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+					//nolint:exhaustruct  // for testing
 					Event: watch.Event{
 						Type: watch.Deleted,
 					},
@@ -137,6 +143,7 @@ func TestProcessEvent(t *testing.T) {
 					AddFunc: func(*corev1.Pod, bool) { calledHandler = true },
 				},
 				ProcessEventArgs[corev1.Pod, *corev1.Pod]{
+					//nolint:exhaustruct  // for testing
 					Event: watch.Event{
 						Type: watch.Error,
 					},


### PR DESCRIPTION
This just pulls apart some of the util.Watcher parts to make it
possible to have a `testutil.Watch` that can produce a `WatchStore`
populated by mock events from a channel.