### PR TITLE
plugin: Use non-VM pod resource requests, not limits

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -253,6 +253,10 @@ _An alternate name for this section:_ Things to watch out for
 * Creating a pod with `PodSpec.Node` set will bypass the scheduler (even if `SchedulerName` is set),
   so we cannot prevent it from overcommitting node resources. **Do not do this except for "system"
   functions.**
-* Non-VM pods must have `resources.limits` equal to `resources.requests` — otherwise, we wouldn't be
-  able to guarantee that resources aren't overcommitted. For more, see
-  [`pkg/plugin/ARCHITECTURE.md`](pkg/plugin/ARCHITECTURE.md).
+* Non-VM pods will be accounted for _only_ by their `resources.requests` — this is for compatibility
+  with tools like [cluster autoscaler], but allows potentially overcommitting memory. To avoid
+  overcommitting in this way, set `resources.requests` equal to `resources.limits`. For more, see
+  [`pkg/plugin/ARCHITECTURE.md`]
+
+[cluster autoscaler]: https://github.com/kubernetes/autoscaler
+[`pkg/plugin/ARCHITECTURE.md`]: pkg/plugin/ARCHITECTURE.md

--- a/pkg/plugin/ARCHITECTURE.md
+++ b/pkg/plugin/ARCHITECTURE.md
@@ -80,9 +80,13 @@ _all other resource usage_ is within the bounds of the configured per-node "syst
 best to deploy as much as possible through the scheduler.
 
 VM pods have an associated NeonVM `VirtualMachine` object, so we can fetch the resources from there.
-For non-VM pods, we use the value of `resources.limits` and expect it to be equal to
-`resources.requests`. It must be equal because otherwise to prevent resource overcommitting, we'd
-have to assume that it's always using `resources.limits`, which is unintuitive.
+For non-VM pods, we use the values from `resources.requests` for compatibility with other systems
+(e.g., [cluster-autoscaler]). This can lead to overcommitting, but it isn't _really_ worth being
+strict about this. If a resource is not present in `resources.requests`, we fallback on
+`resources.limits`. If any container in a pod has no value for one of its resources, the pod will be
+rejected; the scheduler doesn't have enough information to make accurate decisions.
+
+[cluster autoscaler]: https://github.com/kubernetes/autoscaler
 
 ## Deep dive into resource management
 

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -552,46 +552,28 @@ func extractPodOtherPodResourceState(pod *corev1.Pod) (podOtherResourceState, er
 	var cpu resource.Quantity
 	var mem resource.Quantity
 
-	podName := api.PodName{Name: pod.Name, Namespace: pod.Namespace}
-
 	for i, container := range pod.Spec.Containers {
-		// For each resource, we must have (a) limit is provided and (b) if requests is provided,
-		// it must be equal to the limit.
+		// For each resource, use requests if it's provided, or fallback on the limit.
 
 		cpuRequest := container.Resources.Requests.Cpu()
 		cpuLimit := container.Resources.Limits.Cpu()
-		// note: Cpu() always returns a non-nil pointer.
-		if cpuLimit.IsZero() && cpuRequest.IsZero() {
+		if cpuRequest.IsZero() && cpuLimit.IsZero() {
 			err := fmt.Errorf("containers[%d] (%q) missing resources.requests.cpu AND resources.limits.cpu", i, container.Name)
 			return podOtherResourceState{}, err
-		} else if cpuLimit.IsZero() && !cpuRequest.IsZero() {
-			klog.Warningf(
-				"[autoscale-enforcer] non-VM pod %v containers[%d] (%q) missing resources.limits.cpu, using request as limit",
-				podName, i, container.Name,
-			)
-			cpuLimit = cpuRequest
-		} else if !cpuRequest.IsZero() && !cpuLimit.Equal(*cpuRequest) {
-			klog.Warningf(
-				"[autoscale-enforcer] non-VM pod %v containers[%d] (%q) resources.requests.cpu != resources.limits.cpu, using request as limit",
-				podName, i, container.Name,
-			)
-			cpuLimit = cpuRequest
+		} else if cpuRequest.IsZero() /* && !cpuLimit.IsZero() */ {
+			cpuRequest = cpuLimit
 		}
-		cpu.Add(*cpuLimit)
+		cpu.Add(*cpuRequest)
 
 		memRequest := container.Resources.Requests.Memory()
 		memLimit := container.Resources.Limits.Memory()
-		// note: Memory() always returns a non-nil pointer.
-		if memLimit.IsZero() {
+		if memRequest.IsZero() && memLimit.IsZero() {
 			err := fmt.Errorf("containers[%d] (%q) missing resources.limits.memory", i, container.Name)
 			return podOtherResourceState{}, err
-		} else if !memRequest.IsZero() && !memLimit.Equal(*memRequest) {
-			klog.Warningf(
-				"[autoscale-enforcer] non-VM pod %v containers[%d] (%q) resources.requests.memory != resources.limits.memory, using limits",
-				podName, i, container.Name,
-			)
+		} else if memRequest.IsZero() /* && !memLimit.IsZero() */ {
+			memRequest = memLimit
 		}
-		mem.Add(*memLimit)
+		mem.Add(*memRequest)
 	}
 
 	return podOtherResourceState{rawCpu: cpu, rawMemory: mem}, nil


### PR DESCRIPTION
Should address the immediate concerns of #64, but I'm not sure it'll actually allow compatibility with cluster-autoscaler.

This PR also happens to remove the majority of log lines we're currently getting on staging.