### PR TITLE
Move makeDeadlockChecker to util, use it for plugin

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -229,7 +229,7 @@ func NewInformantServer(
 	// Deadlock checker for server.requestLock
 	//
 	// FIXME: make these timeouts/delays separately defined constants, or configurable
-	deadlockChecker := makeDeadlockChecker(&server.requestLock, 5*time.Second, time.Second)
+	deadlockChecker := server.requestLock.DeadlockChecker(5*time.Second, time.Second)
 	deadlockWorkerName := fmt.Sprintf("InformantServer deadlock checker (%s)", server.desc.AgentID)
 	runner.spawnBackgroundWorker(backgroundCtx, deadlockWorkerName, deadlockChecker)
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -74,7 +74,9 @@ func makeAutoscaleEnforcerPlugin(ctx context.Context, obj runtime.Object, h fram
 		handle:   h,
 		vmClient: vmClient,
 		// fields are set by p.setConfigAndStartWatcher, p.readClusterState
-		state: pluginState{}, //nolint:exhaustruct // see above.
+		state: pluginState{ //nolint:exhaustruct // see above.
+			lock: util.NewChanMutex(),
+		},
 	}
 
 	klog.Infof("[autoscale-enforcer] Starting config watcher")
@@ -117,30 +119,14 @@ func makeAutoscaleEnforcerPlugin(ctx context.Context, obj runtime.Object, h fram
 
 	// Periodically check that we're not deadlocked
 	go func() {
-		checkDelay := 5 * time.Second
-		timeout := 1 * time.Second
-		timer := time.NewTimer(checkDelay)
-		defer timer.Stop()
-		for {
-			success := make(chan struct{})
-
-			go func() {
-				p.state.lock.Lock()
-				defer p.state.lock.Unlock()
-				close(success)
-			}()
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-success:
-				// all good
-				timer.Reset(checkDelay)
-			case <-timer.C:
-				// not all good
-				klog.Fatalf("deadlock detected, could not get lock after %s", timeout)
+		defer func() {
+			if err := recover(); err != nil {
+				klog.Errorf("deadlock checker for AutoscaleEnforcer.state.lock panicked")
+				panic(err)
 			}
-		}
+		}()
+
+		p.state.lock.DeadlockChecker(time.Second, 5*time.Second)(ctx)
 	}()
 
 	klog.Info("[autoscale-enforcer] Plugin initialization complete")

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -26,7 +25,7 @@ import (
 //
 // Accessing the individual fields MUST be done while holding a lock.
 type pluginState struct {
-	lock sync.Mutex
+	lock util.ChanMutex
 
 	podMap  map[api.PodName]*podState
 	nodeMap map[string]*nodeState


### PR DESCRIPTION
Also fixes #39, which was occurring because of the change to the plugin's deadlock checker in #32.