### PR TITLE
Increase lint timeout: 5m -> 10m

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
Currently, the workflow sometimes times out (e.g. https://github.com/neondatabase/autoscaling/actions/runs/4338216813/attempts/1).

My best guess is that linting from scratch would actually take longer than 5 minutes every time, but usually the cache brings it under.

It's worth looking into this properly, but bumping the lint timeout gives a ok-enough fix for now.