### PR TITLE
agent, plugin: Add "dump state" endpoints

### DIFF
--- a/deploy/autoscale-scheduler.yaml
+++ b/deploy/autoscale-scheduler.yaml
@@ -134,6 +134,10 @@ data:
       },
       "nodeOverrides": [],
       "schedulerName": "autoscale-scheduler",
+      "dumpState": {
+        "port": 10298,
+        "timeoutSeconds": 5
+      },
       "doMigration": false
     }
 ---

--- a/deploy/autoscaler-agent.yaml
+++ b/deploy/autoscaler-agent.yaml
@@ -67,6 +67,10 @@ data:
       "schedulerName": "autoscale-scheduler",
       "requestTimeoutSeconds": 2,
       "requestPort": 10299
+    },
+    "dumpState": {
+      "port": 10300,
+      "timeoutSeconds": 5
     }
   }'
 ---

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -7,11 +7,21 @@ import (
 )
 
 type Config struct {
-	Scaling   ScalingConfig   `json:"scaling"`
-	Informant InformantConfig `json:"informant"`
-	Metrics   MetricsConfig   `json:"metrics"`
-	Scheduler SchedulerConfig `json:"scheduler"`
-	Billing   *BillingConfig  `json:"billing,omitempty"`
+	Scaling   ScalingConfig    `json:"scaling"`
+	Informant InformantConfig  `json:"informant"`
+	Metrics   MetricsConfig    `json:"metrics"`
+	Scheduler SchedulerConfig  `json:"scheduler"`
+	Billing   *BillingConfig   `json:"billing,omitempty"`
+	DumpState *DumpStateConfig `json:"dumpState"`
+}
+
+// DumpStateConfig configures the endpoint to dump all internal state
+type DumpStateConfig struct {
+	// Port is the port to serve on
+	Port uint16 `json:"port"`
+	// TimeoutSeconds gives the maximum duration, in seconds, that we allow for a request to dump
+	// internal state.
+	TimeoutSeconds uint `json:"timeoutSeconds"`
 }
 
 // ScalingConfig defines the scheduling we use for scaling up and down
@@ -143,6 +153,10 @@ func (c *Config) validate() error {
 		return cannotBeZero(".billing.pushEverySeconds")
 	} else if c.Billing != nil && c.Billing.PushTimeoutSeconds == 0 {
 		return cannotBeZero(".billing.pushTimeoutSeconds")
+	} else if c.DumpState != nil && c.DumpState.Port == 0 {
+		return cannotBeZero(".dumpState.port")
+	} else if c.DumpState != nil && c.DumpState.TimeoutSeconds == 0 {
+		return cannotBeZero(".dumpState.timeoutSeconds")
 	}
 
 	return nil

--- a/pkg/agent/dumpstate.go
+++ b/pkg/agent/dumpstate.go
@@ -73,7 +73,7 @@ func (s *agentState) DumpState(ctx context.Context, stopped bool) (*StateDump, e
 		}
 		defer s.lock.Unlock()
 
-		var list []*podState
+		list := make([]*podState, 0, len(s.pods))
 		for name := range s.pods {
 			list = append(list, s.pods[name])
 		}

--- a/pkg/agent/dumpstate.go
+++ b/pkg/agent/dumpstate.go
@@ -1,0 +1,115 @@
+package agent
+
+// Utilities for dumping internal state
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/neondatabase/autoscaling/pkg/util"
+)
+
+type StateDump struct {
+	Stopped   bool           `json:"stopped"`
+	BuildInfo util.BuildInfo `json:"buildInfo"`
+	Pods      []podStateDump `json:"pods"`
+}
+
+func (s *agentState) StartDumpStateServer(shutdownCtx context.Context, config *DumpStateConfig) error {
+	// Manually start the TCP listener so we can minimize errors in the background thread.
+	addr := net.TCPAddr{IP: net.IPv4zero, Port: int(config.Port)}
+	listener, err := net.ListenTCP("tcp", &addr)
+	if err != nil {
+		return fmt.Errorf("Error binding to %v", addr)
+	}
+
+	go func() {
+		mux := http.NewServeMux()
+		util.AddHandler("dump-state: ", mux, "/", http.MethodGet, "<empty>", func(ctx context.Context, body *struct{}) (*StateDump, int, error) {
+			timeout := time.Duration(config.TimeoutSeconds) * time.Second
+
+			startTime := time.Now()
+			ctx, cancel := context.WithDeadline(ctx, startTime.Add(timeout))
+			defer cancel()
+
+			state, err := s.DumpState(ctx, shutdownCtx.Err() != nil)
+			if err != nil {
+				totalDuration := time.Since(startTime)
+				if totalDuration >= timeout {
+					return nil, 500, fmt.Errorf("timed out after %s while getting state", totalDuration)
+				} else {
+					// some other type of cancel; 400 is a little weird, but there isn't a great
+					// option here.
+					return nil, 400, fmt.Errorf("error while getting state: %w", err)
+				}
+			}
+
+			return state, 200, nil
+		})
+		// note: we don't shut down this server. It should be possible to continue fetching the
+		// internal state after shutdown has started.
+		server := &http.Server{Handler: mux}
+		if err := server.Serve(listener); err != nil {
+			klog.Errorf("dump-state server exited: %w", err)
+		}
+	}()
+
+	return nil
+}
+
+func (s *agentState) DumpState(ctx context.Context, stopped bool) (*StateDump, error) {
+	// Copy the high-level state, then process it
+	podList, err := func() ([]*podState, error) {
+		if err := s.lock.TryLock(ctx); err != nil {
+			return nil, err
+		}
+		defer s.lock.Unlock()
+
+		var list []*podState
+		for name := range s.pods {
+			list = append(list, s.pods[name])
+		}
+		return list, nil
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	results := make(chan podStateDump)
+
+	// TODO: We should have some concurrency limit on the number of active goroutines while fetching
+	// state.
+	for _, pod := range podList {
+		// pass pod through explicitly, so we avoid variable reuse issues
+		go func(p *podState) {
+			results <- p.Dump(ctx)
+		}(pod)
+	}
+
+	state := StateDump{
+		Stopped:   stopped,
+		BuildInfo: util.GetBuildInfo(),
+		Pods:      nil,
+	}
+
+	cleanupCourtesy := time.NewTimer(0)
+	cleanupCourtesy.Stop()
+
+	for i := 0; i < len(podList); i += 1 {
+		select {
+		case <-ctx.Done():
+			cleanupCourtesy.Reset(100 * time.Millisecond)
+		case <-cleanupCourtesy.C:
+			break
+		case pod := <-results:
+			state.Pods = append(state.Pods, pod)
+		}
+	}
+
+	return &state, nil
+}

--- a/pkg/agent/dumpstate.go
+++ b/pkg/agent/dumpstate.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"k8s.io/klog/v2"
 
 	"github.com/neondatabase/autoscaling/pkg/util"
@@ -112,6 +114,11 @@ func (s *agentState) DumpState(ctx context.Context, stopped bool) (*StateDump, e
 	// that to make it back to state.Pods when the context expires, instead of proactively aborting
 	// in *this* thread.
 	wg.Wait()
+
+	// Sort the pods by name, so that we produce a deterministic ordering
+	slices.SortFunc(state.Pods, func(a, b podStateDump) (less bool) {
+		return a.PodName.Namespace < b.PodName.Namespace && a.PodName.Name < b.PodName.Name
+	})
 
 	return &state, nil
 }

--- a/pkg/agent/dumpstate.go
+++ b/pkg/agent/dumpstate.go
@@ -103,7 +103,7 @@ func (s *agentState) DumpState(ctx context.Context, stopped bool) (*StateDump, e
 				wg.Done()
 			}()
 
-			state.Pods[i] = pod.Dump(ctx)
+			state.Pods[i] = pod.dump(ctx)
 		}()
 	}
 

--- a/pkg/agent/entrypoint.go
+++ b/pkg/agent/entrypoint.go
@@ -62,6 +62,13 @@ func (r MainRunner) Run(ctx context.Context) error {
 
 	globalState := r.newAgentState(r.EnvArgs.K8sPodIP, broker, schedulerStore)
 
+	if r.Config.DumpState != nil {
+		klog.Info("Starting 'dump state' server")
+		if err := globalState.StartDumpStateServer(ctx, r.Config.DumpState); err != nil {
+			return fmt.Errorf("Error starting dump state server: %w", err)
+		}
+	}
+
 	klog.Info("Entering main loop")
 	for {
 		select {

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -23,7 +23,10 @@ import (
 //
 // All fields are immutable, except pods.
 type agentState struct {
-	pods                 map[api.PodName]*podState
+	// lock guards access to pods
+	lock util.ChanMutex
+	pods map[api.PodName]*podState
+
 	podIP                string
 	config               *Config
 	kubeClient           *kubernetes.Clientset
@@ -34,6 +37,7 @@ type agentState struct {
 
 func (r MainRunner) newAgentState(podIP string, broker *pubsub.Broker[watchEvent], schedulerStore *util.WatchStore[corev1.Pod]) agentState {
 	return agentState{
+		lock:                 util.NewChanMutex(),
 		pods:                 make(map[api.PodName]*podState),
 		config:               r.Config,
 		kubeClient:           r.KubeClient,
@@ -52,6 +56,9 @@ func podIsOurResponsibility(pod *corev1.Pod, config *Config, nodeName string) bo
 }
 
 func (s *agentState) Stop() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	for _, pod := range s.pods {
 		pod.stop()
 	}
@@ -59,6 +66,12 @@ func (s *agentState) Stop() {
 
 func (s *agentState) handleEvent(ctx context.Context, event podEvent) {
 	klog.Infof("Handling pod event %+v", event)
+
+	if err := s.lock.TryLock(ctx); err != nil {
+		klog.Warningf("context canceled while starting to handle event: %s", err)
+		return
+	}
+	defer s.lock.Unlock()
 
 	state, hasPod := s.pods[event.podName]
 
@@ -132,9 +145,47 @@ type podState struct {
 	status *podStatus
 }
 
+type podStateDump struct {
+	PodName         api.PodName   `json:"podName"`
+	Status          podStatusDump `json:"status"`
+	Runner          *RunnerState  `json:"runner,omitempty"`
+	CollectionError error         `json:"collectionError,omitempty"`
+}
+
+func (p *podState) Dump(ctx context.Context) podStateDump {
+	status := p.status.Dump()
+	runner, collectErr := p.runner.State(ctx)
+	if collectErr != nil {
+		collectErr = fmt.Errorf("error reading runner state: %w", collectErr)
+	}
+	return podStateDump{
+		PodName:         p.podName,
+		Status:          status,
+		Runner:          runner,
+		CollectionError: collectErr,
+	}
+}
+
 type podStatus struct {
 	lock     sync.Mutex
 	done     bool // if true, the runner finished
 	errored  error
 	panicked bool // if true, errored will be non-nil
+}
+
+type podStatusDump struct {
+	Done     bool  `json:"done"`
+	Errored  error `json:"errored"`
+	Panicked bool  `json:"panicked"`
+}
+
+func (s *podStatus) Dump() podStatusDump {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return podStatusDump{
+		Done:     s.done,
+		Errored:  s.errored,
+		Panicked: s.panicked,
+	}
 }

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -152,8 +152,8 @@ type podStateDump struct {
 	CollectionError error         `json:"collectionError,omitempty"`
 }
 
-func (p *podState) Dump(ctx context.Context) podStateDump {
-	status := p.status.Dump()
+func (p *podState) dump(ctx context.Context) podStateDump {
+	status := p.status.dump()
 	runner, collectErr := p.runner.State(ctx)
 	if collectErr != nil {
 		collectErr = fmt.Errorf("error reading runner state: %w", collectErr)
@@ -179,7 +179,7 @@ type podStatusDump struct {
 	Panicked bool  `json:"panicked"`
 }
 
-func (s *podStatus) Dump() podStatusDump {
+func (s *podStatus) dump() podStatusDump {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -50,6 +50,9 @@ type config struct {
 	// re-enable it.
 	DoMigration *bool `json:"doMigration"`
 
+	// DumpState, if provided, enables a server to dump internal state
+	DumpState *dumpStateConfig `json:"dumpState"`
+
 	// JSONString is the JSON string that was used to generate this config struct
 	JSONString string `json:"-"`
 }
@@ -109,6 +112,12 @@ func (c *config) validate() (string, error) {
 
 	if c.SchedulerName == "" {
 		return "schedulerName", errors.New("string cannot be empty")
+	}
+
+	if c.DumpState != nil {
+		if path, err := c.DumpState.validate(); err != nil {
+			return fmt.Sprintf("dumpState.%s", path), err
+		}
 	}
 
 	return "", nil

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -1,0 +1,255 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/neondatabase/autoscaling/pkg/api"
+	"github.com/neondatabase/autoscaling/pkg/util"
+)
+
+type dumpStateConfig struct {
+	Port           uint16 `json:"port"`
+	TimeoutSeconds uint   `json:"timeoutSeconds"`
+}
+
+func (c *dumpStateConfig) validate() (string, error) {
+	if c.Port == 0 {
+		return "port", errors.New("value must be > 0")
+	} else if c.TimeoutSeconds == 0 {
+		return "timeoutSeconds", errors.New("value must be > 0")
+	}
+
+	return "", nil
+}
+
+type stateDump struct {
+	Stopped   bool            `json:"stopped"`
+	BuildInfo util.BuildInfo  `json:"buildInfo"`
+	State     pluginStateDump `json:"state"`
+}
+
+func (p *AutoscaleEnforcer) startDumpStateServer(shutdownCtx context.Context) error {
+	// Manually start the TCP listener so we can minimize errors in the background thread.
+	addr := net.TCPAddr{IP: net.IPv4zero, Port: int(p.state.conf.DumpState.Port)}
+	listener, err := net.ListenTCP("tcp", &addr)
+	if err != nil {
+		return fmt.Errorf("Error binding to %v", addr)
+	}
+
+	go func() {
+		mux := http.NewServeMux()
+		util.AddHandler("dump-state: ", mux, "/", http.MethodGet, "<empty>", func(ctx context.Context, body *struct{}) (*stateDump, int, error) {
+			timeout := time.Duration(p.state.conf.DumpState.TimeoutSeconds) * time.Second
+
+			startTime := time.Now()
+			ctx, cancel := context.WithDeadline(ctx, startTime.Add(timeout))
+			defer cancel()
+
+			state, err := p.dumpState(ctx, shutdownCtx.Err() != nil)
+			if err != nil {
+				totalDuration := time.Since(startTime)
+				if totalDuration >= timeout {
+					return nil, 500, fmt.Errorf("timed out after %s while getting state", totalDuration)
+				} else {
+					// some other type of cancel; 400 is a little weird, but there isn't a great
+					// option here.
+					return nil, 400, fmt.Errorf("error while getting state: %w", err)
+				}
+			}
+
+			return state, 200, nil
+		})
+		// note: we don't shut down this server. It should be possible to continue fetching the
+		// internal state after shutdown has started.
+		server := &http.Server{Handler: mux}
+		if err := server.Serve(listener); err != nil {
+			klog.Errorf("dump-state server exited: %w", err)
+		}
+	}()
+
+	return nil
+}
+
+func (p *AutoscaleEnforcer) dumpState(ctx context.Context, stopped bool) (*stateDump, error) {
+	state, err := p.state.dump(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &stateDump{
+		Stopped:   stopped,
+		BuildInfo: util.GetBuildInfo(),
+		State:     *state,
+	}, nil
+}
+
+type keyed[K any, V any] struct {
+	Key   K `json:"key"`
+	Value V `json:"value"`
+}
+
+type pluginStateDump struct {
+	Nodes []keyed[string, nodeStateDump] `json:"nodes"`
+
+	VMPods    []podNameAndPointer `json:"vmPods"`
+	OtherPods []podNameAndPointer `json:"otherPods"`
+
+	MaxTotalReservableCPU      uint16 `json:"maxTotalReservableCPU"`
+	MaxTotalReservableMemSlots uint16 `json:"maxTotalReservableMemSlots"`
+
+	Conf config `json:"config"`
+}
+
+type podNameAndPointer struct {
+	Obj     pointerString `json:"obj"`
+	PodName api.PodName   `json:"podName"`
+}
+
+type pointerString string
+
+type nodeStateDump struct {
+	Obj       pointerString                           `json:"obj"`
+	Name      string                                  `json:"name"`
+	VCPU      nodeResourceState[uint16]               `json:"vCPU"`
+	MemSlots  nodeResourceState[uint16]               `json:"memSlots"`
+	Pods      []keyed[api.PodName, podStateDump]      `json:"pods"`
+	OtherPods []keyed[api.PodName, otherPodStateDump] `json:"otherPods"`
+	Mq        []*podNameAndPointer                    `json:"mq"`
+}
+
+type podStateDump struct {
+	Obj                      pointerString            `json:"obj"`
+	Name                     api.PodName              `json:"name"`
+	VMName                   string                   `json:"vmName"`
+	Node                     pointerString            `json:"node"`
+	TestingOnlyAlwaysMigrate bool                     `json:"testingOnlyAlwaysMigrate"`
+	VCPU                     podResourceState[uint16] `json:"vCPU"`
+	MemSlots                 podResourceState[uint16] `json:"memSlots"`
+	MostRecentComputeUnit    *api.Resources           `json:"mostRecentComputeUnit"`
+	Metrics                  *api.Metrics             `json:"metrics"`
+	MqIndex                  int                      `json:"mqIndex"`
+	MigrationState           *podMigrationStateDump   `json:"migrationState"`
+}
+
+type podMigrationStateDump struct{}
+
+type otherPodStateDump struct {
+	Obj       pointerString         `json:"obj"`
+	Node      pointerString         `json:"node"`
+	Resources podOtherResourceState `json:"resources"`
+}
+
+func makePointerString[T any](t *T) pointerString {
+	return pointerString(fmt.Sprintf("%p", t))
+}
+
+func (s *pluginState) dump(ctx context.Context) (*pluginStateDump, error) {
+	if err := s.lock.TryLock(ctx); err != nil {
+		return nil, err
+	}
+	defer s.lock.Unlock()
+
+	var vmPods []podNameAndPointer
+	for _, p := range s.podMap {
+		vmPods = append(vmPods, podNameAndPointer{Obj: makePointerString(p), PodName: p.name})
+	}
+
+	var otherPods []podNameAndPointer
+	for _, p := range s.otherPods {
+		otherPods = append(otherPods, podNameAndPointer{Obj: makePointerString(p), PodName: p.name})
+	}
+
+	var nodes []keyed[string, nodeStateDump]
+	for k, n := range s.nodeMap {
+		nodes = append(nodes, keyed[string, nodeStateDump]{Key: k, Value: n.dump()})
+	}
+
+	return &pluginStateDump{
+		Nodes:                      nodes,
+		VMPods:                     vmPods,
+		OtherPods:                  otherPods,
+		MaxTotalReservableCPU:      s.maxTotalReservableCPU,
+		MaxTotalReservableMemSlots: s.maxTotalReservableMemSlots,
+		Conf:                       *s.conf,
+	}, nil
+}
+
+func (s *nodeState) dump() nodeStateDump {
+
+	var pods []keyed[api.PodName, podStateDump]
+	for k, p := range s.pods {
+		pods = append(pods, keyed[api.PodName, podStateDump]{Key: k, Value: p.dump()})
+	}
+
+	var otherPods []keyed[api.PodName, otherPodStateDump]
+	for k, p := range s.otherPods {
+		otherPods = append(otherPods, keyed[api.PodName, otherPodStateDump]{Key: k, Value: p.dump()})
+	}
+
+	var mq []*podNameAndPointer
+	for _, p := range s.mq {
+		if p == nil {
+			mq = append(mq, nil)
+		} else {
+			v := podNameAndPointer{Obj: makePointerString(p), PodName: p.name}
+			mq = append(mq, &v)
+		}
+	}
+
+	return nodeStateDump{
+		Obj:       makePointerString(s),
+		Name:      s.name,
+		VCPU:      s.vCPU,
+		MemSlots:  s.memSlots,
+		Pods:      pods,
+		OtherPods: otherPods,
+		Mq:        mq,
+	}
+}
+
+func (s *podState) dump() podStateDump {
+	// Copy some of the "may be nil" pointer fields
+	var mostRecentComputeUnit *api.Resources
+	if s.mostRecentComputeUnit != nil {
+		mrcu := *s.mostRecentComputeUnit
+		mostRecentComputeUnit = &mrcu
+	}
+	var metrics *api.Metrics
+	if s.metrics != nil {
+		m := *s.metrics
+		metrics = &m
+	}
+	var migrationState *podMigrationStateDump
+	if s.migrationState != nil {
+		migrationState = &podMigrationStateDump{}
+	}
+
+	return podStateDump{
+		Obj:                      makePointerString(s),
+		Name:                     s.name,
+		VMName:                   s.vmName,
+		Node:                     makePointerString(s.node),
+		TestingOnlyAlwaysMigrate: s.testingOnlyAlwaysMigrate,
+		VCPU:                     s.vCPU,
+		MemSlots:                 s.memSlots,
+		MostRecentComputeUnit:    mostRecentComputeUnit,
+		Metrics:                  metrics,
+		MqIndex:                  s.mqIndex,
+		MigrationState:           migrationState,
+	}
+}
+
+func (s *otherPodState) dump() otherPodStateDump {
+	return otherPodStateDump{
+		Obj:       makePointerString(s),
+		Node:      makePointerString(s.node),
+		Resources: s.resources,
+	}
+}

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -156,17 +156,17 @@ func (s *pluginState) dump(ctx context.Context) (*pluginStateDump, error) {
 	}
 	defer s.lock.Unlock()
 
-	var vmPods []podNameAndPointer
+	vmPods := make([]podNameAndPointer, 0, len(s.podMap))
 	for _, p := range s.podMap {
 		vmPods = append(vmPods, podNameAndPointer{Obj: makePointerString(p), PodName: p.name})
 	}
 
-	var otherPods []podNameAndPointer
+	otherPods := make([]podNameAndPointer, 0, len(s.otherPods))
 	for _, p := range s.otherPods {
 		otherPods = append(otherPods, podNameAndPointer{Obj: makePointerString(p), PodName: p.name})
 	}
 
-	var nodes []keyed[string, nodeStateDump]
+	nodes := make([]keyed[string, nodeStateDump], 0, len(s.nodeMap))
 	for k, n := range s.nodeMap {
 		nodes = append(nodes, keyed[string, nodeStateDump]{Key: k, Value: n.dump()})
 	}
@@ -182,18 +182,17 @@ func (s *pluginState) dump(ctx context.Context) (*pluginStateDump, error) {
 }
 
 func (s *nodeState) dump() nodeStateDump {
-
-	var pods []keyed[api.PodName, podStateDump]
+	pods := make([]keyed[api.PodName, podStateDump], 0, len(s.pods))
 	for k, p := range s.pods {
 		pods = append(pods, keyed[api.PodName, podStateDump]{Key: k, Value: p.dump()})
 	}
 
-	var otherPods []keyed[api.PodName, otherPodStateDump]
+	otherPods := make([]keyed[api.PodName, otherPodStateDump], 0, len(s.otherPods))
 	for k, p := range s.otherPods {
 		otherPods = append(otherPods, keyed[api.PodName, otherPodStateDump]{Key: k, Value: p.dump()})
 	}
 
-	var mq []*podNameAndPointer
+	mq := make([]*podNameAndPointer, 0, len(s.mq))
 	for _, p := range s.mq {
 		if p == nil {
 			mq = append(mq, nil)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -85,6 +85,13 @@ func makeAutoscaleEnforcerPlugin(ctx context.Context, obj runtime.Object, h fram
 		return nil, err
 	}
 
+	if p.state.conf.DumpState != nil {
+		klog.Infof("[autoscale-enforcer] Starting 'dump state' server")
+		if err := p.startDumpStateServer(ctx); err != nil {
+			return nil, fmt.Errorf("Error starting 'dump state' server: %w", err)
+		}
+	}
+
 	// Start watching deletion events...
 	vmDeletions := make(chan api.PodName)
 	podDeletions := make(chan api.PodName)

--- a/pkg/util/buildinfo.go
+++ b/pkg/util/buildinfo.go
@@ -18,9 +18,9 @@ var BuildGitInfo string
 //
 // All strings are guaranteed to be non-empty.
 type BuildInfo struct {
-	GitInfo   string
-	NeonVM    string
-	GoVersion string
+	GitInfo   string `json:"gitInfo"`
+	NeonVM    string `json:"neonvmVersion"`
+	GoVersion string `json:"goVersion"`
 }
 
 // GetBuildInfo makes a best-effort attempt to return some information about how the currently


### PR DESCRIPTION
There was some bulk renaming required in the plugin, so I extracted that into a separate PR (#75) to make reviewing / blame nicer.

I've done a little bit of manual testing for it, seems fine. The JSON output isn't small, so... thorough testing will probably be easier with a dedicated tool to analyze the output.

For now, due to "quirks" of `util.AddHandler`, the body of the request is expected to be "{}". So, example usage would be something like:
```
curl -X GET -d '{}' 'http://localhost:10300/"
```
(for the current default autoscaler-agent port)