### PR TITLE
billing: set content type on requests

### DIFF
--- a/pkg/billing/client.go
+++ b/pkg/billing/client.go
@@ -76,6 +76,7 @@ func (b *Batch) Send(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	r.Header.Set("content-type", "application/json")
 
 	resp, err := b.c.httpc.Do(r)
 	if err != nil {


### PR DESCRIPTION
Missed this before. Currently causing the console to reject/400 our requests.