### PR TITLE
plugin: Remove unused config watcher

### DIFF
--- a/cmd/autoscale-scheduler/main.go
+++ b/cmd/autoscale-scheduler/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os/signal"
 	"syscall"
@@ -26,6 +27,11 @@ func main() {
 // runProgram is the "real" main, but returning an error means that
 // the shutdown handling code doesn't have to call os.Exit, even indirectly.
 func runProgram() (err error) {
+	conf, err := plugin.ReadConfig(plugin.DefaultConfigPath)
+	if err != nil {
+		return fmt.Errorf("Error reading config at %q: %w", plugin.DefaultConfigPath, err)
+	}
+
 	// this: listens for sigterm, when we catch that signal, the
 	// context gets canceled, a go routine waits for half a second, and
 	// then closes the signal channel, which we block on in a
@@ -47,7 +53,7 @@ func runProgram() (err error) {
 		return err
 	}
 
-	command := app.NewSchedulerCommand(app.WithPlugin(plugin.Name, plugin.NewAutoscaleEnforcerPlugin(ctx)))
+	command := app.NewSchedulerCommand(app.WithPlugin(plugin.Name, plugin.NewAutoscaleEnforcerPlugin(ctx, conf)))
 	if err := command.ExecuteContext(ctx); err != nil {
 		return err
 	}

--- a/deploy/autoscale-scheduler.yaml
+++ b/deploy/autoscale-scheduler.yaml
@@ -124,7 +124,7 @@ metadata:
   name: scheduler-plugin-config
   namespace: kube-system
 data:
-  autoscaler-enforcer-config.json: |
+  autoscale-enforcer-config.json: |
     {
       "memBlockSize": "1Gi",
       "nodeDefaults": {
@@ -184,9 +184,14 @@ spec:
         volumeMounts:
           - name: scheduler-config-volume
             mountPath: /etc/kubernetes/autoscale-scheduler-config
+          - name: plugin-config-volume
+            mountPath: /etc/scheduler-plugin-config
       hostNetwork: false
       hostPID: false
       volumes:
         - name: scheduler-config-volume
           configMap:
             name: autoscale-scheduler-config
+        - name: plugin-config-volume
+          configMap:
+            name: scheduler-plugin-config

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -42,7 +42,7 @@ type pluginState struct {
 	// conf stores the current configuration, and is nil if the configuration has not yet been set
 	//
 	// Proper initialization of the plugin guarantees conf is not nil.
-	conf *config
+	conf *Config
 }
 
 // nodeState is the information that we track for a particular
@@ -468,7 +468,7 @@ func (s *pluginState) getOrFetchNodeState(
 //
 // Note: buildInitialNodeState does not take any of the pods or VMs on the node into account; it
 // only examines the total resources available to the node.
-func buildInitialNodeState(node *corev1.Node, conf *config) (*nodeState, error) {
+func buildInitialNodeState(node *corev1.Node, conf *Config) (*nodeState, error) {
 	// Fetch this upfront, because we'll need it a couple times later.
 	nodeConf := conf.forNode(node.Name)
 
@@ -1002,15 +1002,4 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (s *pluginState) handleUpdatedConf() {
-	// It's possible for this method to be called before readClusterState, in which case there's
-	// nothing for us to do. We don't want to access nil data if that happens though, so we
-	// special-case it:
-	if s.podMap == nil {
-		return
-	}
-
-	klog.Warningf("Ignoring updated configuration, runtime config updates are unimplemented")
 }


### PR DESCRIPTION
This was previously planned, and would have allowed config updates without restart. No work had been done on that for a while, though, so this half-done feature was adding unnecessary tech debt.