### PR TITLE
agent/billing: fix panic on adding active time event

### DIFF
--- a/pkg/agent/billing.go
+++ b/pkg/agent/billing.go
@@ -59,6 +59,8 @@ type vmMetricsSeconds struct {
 	// cpu stores the CPU seconds allocated to the VM, roughly equivalent to the integral of CPU
 	// usage over time.
 	cpu uint32
+	// activeTime stores the total time that the VM was active
+	activeTime time.Duration
 }
 
 const (
@@ -153,7 +155,7 @@ func (s *billingMetricsState) collect(conf *BillingConfig, targetNode string, st
 			if !ok {
 				vmHistory = vmMetricsHistory{
 					lastSlice: nil,
-					total:     vmMetricsSeconds{cpu: 0},
+					total:     vmMetricsSeconds{cpu: 0, activeTime: time.Duration(0)},
 				}
 			}
 			// append the slice, merging with the previous if the resource usage was the same
@@ -196,9 +198,11 @@ func (h *vmMetricsHistory) finalizeCurrentTimeSlice() {
 	// TODO: This approach is imperfect. Floating-point math is probably *fine*, but really not
 	// something we want to rely on. A "proper" solution is a lot of work, but long-term valuable.
 	metricsSeconds := vmMetricsSeconds{
-		cpu: uint32(math.Round(float64(h.lastSlice.metrics.cpu) * seconds)),
+		cpu:        uint32(math.Round(float64(h.lastSlice.metrics.cpu) * seconds)),
+		activeTime: duration,
 	}
 	h.total.cpu += metricsSeconds.cpu
+	h.total.activeTime += metricsSeconds.activeTime
 
 	h.lastSlice = nil
 }
@@ -240,7 +244,7 @@ func (s *billingMetricsState) drainAppendToBatch(conf *BillingConfig, batch *bil
 			EndpointID:     key.endpointID,
 			StartTime:      s.pushWindowStart,
 			StopTime:       now,
-			Value:          int(history.lastSlice.Duration().Seconds()),
+			Value:          int(history.total.activeTime.Seconds()),
 		})
 	}
 

--- a/pkg/agent/billing.go
+++ b/pkg/agent/billing.go
@@ -244,7 +244,7 @@ func (s *billingMetricsState) drainAppendToBatch(conf *BillingConfig, batch *bil
 			EndpointID:     key.endpointID,
 			StartTime:      s.pushWindowStart,
 			StopTime:       now,
-			Value:          int(history.total.activeTime.Seconds()),
+			Value:          int(math.Round(history.total.activeTime.Seconds())),
 		})
 	}
 


### PR DESCRIPTION
Panic on staging:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x13ba760]

    goroutine 28 [running]:
    github.com/neondatabase/autoscaling/pkg/agent.(*metricsTimeSlice).Duration(...)
        /workspace/pkg/agent/billing.go:50
    github.com/neondatabase/autoscaling/pkg/agent.(*billingMetricsState).drainAppendToBatch(0xc000017eb0,
    0xc00010f270, 0xc000017f40)
        /workspace/pkg/agent/billing.go:243 +0x380
    github.com/neondatabase/autoscaling/pkg/agent.RunBillingMetricsCollector({0x1993200,
    0xc0004293e0}, 0xc00010f270, {0xc00004800e, 0x28}, 0x0?)
        /workspace/pkg/agent/billing.go:100 +0x42c
    created by github.com/neondatabase/autoscaling/pkg/agent.MainRunner.Run
        /workspace/pkg/agent/entrypoint.go:60 +0x79b

Basically: lastSlice is often nil, and we were assuming it wasn't. But activeTime shouldn't have been fetched from lastSlice anyways (it would be inaccurate), so it's better for us to just store it in the totals.