### PR TITLE
Custom task management

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,6 +83,7 @@ discussed more in the [high-level consequences] section below.
         protocol-relevant types independently used by both.
     * `pkg/informant/` — implementation of the VM informant
     * `pkg/plugin/` — implementation of the scheduler plugin
+    * `pkg/task/` — tools for managing goroutine lifecycle and service shutdown
     * `pkg/util/` — miscellaneous utilities that are too general to be included in `agent` or
       `plugin`.
 * `scripts/` — a collection of scripts for common tasks. Items of note:

--- a/cmd/autoscale-scheduler/main.go
+++ b/cmd/autoscale-scheduler/main.go
@@ -25,7 +25,7 @@ func main() {
 		ctx, cancel := makeShutdownContext()
 		defer cancel()
 		if err := tm.Shutdown(ctx); err != nil {
-			shutdownErrorHandler(err)
+			_ = shutdownErrorHandler(err)
 		}
 	}()
 

--- a/cmd/autoscale-scheduler/main.go
+++ b/cmd/autoscale-scheduler/main.go
@@ -2,45 +2,44 @@ package main
 
 import (
 	"context"
-	"log"
-	"os/signal"
-	"syscall"
+	"fmt"
+	"os"
 	"time"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 
 	"github.com/neondatabase/autoscaling/pkg/plugin"
+	"github.com/neondatabase/autoscaling/pkg/task"
 )
 
 // all of the juicy bits are defined in pkg/plugin/
 
 func main() {
-	if err := runProgram(); err != nil {
-		log.Fatal(err)
+	tm := task.NewRootTaskManager("autoscale-scheduler")
+	tm.ShutdownOnSigterm()
+	tm = tm.WithContext(context.WithValue(context.Background(), task.ManagerKey, tm))
+
+	command := app.NewSchedulerCommand(app.WithPlugin(plugin.Name, plugin.NewAutoscaleEnforcerPlugin(tm.Context())))
+	err := command.ExecuteContext(tm.Context())
+	if err != nil {
+		klog.Errorf("%s", err)
+	}
+	if shutdownErr := tm.Shutdown(shutdownContext()); shutdownErr != nil {
+		shutdownErr = fmt.Errorf("Error shutting down: %w", shutdownErr)
+		klog.Errorf("%s", shutdownErr)
+		if err != nil {
+			err = shutdownErr
+		}
+	}
+
+	if err != nil {
+		os.Exit(1)
 	}
 }
 
-// runProgram is the "real" main, but returning an error means that
-// the shutdown handling code doesn't have to call os.Exit, even indirectly.
-func runProgram() error {
-	// this: listens for sigterm, when we catch that signal, the
-	// context gets canceled, a go routine waits for half a second, and
-	// then closes the signal channel, which we block on in a
-	// defer. because defers execute in LIFO errors, this just
-	// pauses for a *very* short period of time before exiting.
-	//
-	// eventually, the constructed application will track it's
-	// services and be able to more coherently wait for shutdown
-	// without needing a sleep.
-	sig := make(chan struct{})
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
-	go func() { defer close(sig); <-ctx.Done(); time.Sleep(500 * time.Millisecond) }()
-	defer func() { <-sig }()
-	defer cancel()
-
-	command := app.NewSchedulerCommand(app.WithPlugin(plugin.Name, plugin.NewAutoscaleEnforcerPlugin(ctx)))
-	if err := command.ExecuteContext(ctx); err != nil {
-		return err
-	}
-	return nil
+func shutdownContext() context.Context {
+	// it's ok to leak here; this only gets called once
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second) //nolint:govet // see above
+	return ctx
 }

--- a/cmd/autoscale-scheduler/main.go
+++ b/cmd/autoscale-scheduler/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -17,29 +15,27 @@ import (
 
 func main() {
 	tm := task.NewRootTaskManager("autoscale-scheduler")
-	tm.ShutdownOnSigterm()
+	shutdownErrorHandler := task.LogFatalError("Error during shutdown: %w")
+
+	tm = tm.WithShutdownErrorHandler(shutdownErrorHandler)
 	tm = tm.WithContext(context.WithValue(context.Background(), task.ManagerKey, tm))
+	tm = tm.WithPanicHandler(task.LogPanicAndShutdown(tm, makeShutdownContext))
+	tm.ShutdownOnSigterm(makeShutdownContext)
+	defer func() {
+		ctx, cancel := makeShutdownContext()
+		defer cancel()
+		if err := tm.Shutdown(ctx); err != nil {
+			shutdownErrorHandler(err)
+		}
+	}()
 
 	command := app.NewSchedulerCommand(app.WithPlugin(plugin.Name, plugin.NewAutoscaleEnforcerPlugin(tm.Context())))
 	err := command.ExecuteContext(tm.Context())
 	if err != nil {
-		klog.Errorf("%s", err)
-	}
-	if shutdownErr := tm.Shutdown(shutdownContext()); shutdownErr != nil {
-		shutdownErr = fmt.Errorf("Error shutting down: %w", shutdownErr)
-		klog.Errorf("%s", shutdownErr)
-		if err != nil {
-			err = shutdownErr
-		}
-	}
-
-	if err != nil {
-		os.Exit(1)
+		klog.Fatalf("%s", err)
 	}
 }
 
-func shutdownContext() context.Context {
-	// it's ok to leak here; this only gets called once
-	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second) //nolint:govet // see above
-	return ctx
+func makeShutdownContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 2*time.Second)
 }

--- a/cmd/autoscale-scheduler/main.go
+++ b/cmd/autoscale-scheduler/main.go
@@ -14,7 +14,7 @@ import (
 // all of the juicy bits are defined in pkg/plugin/
 
 func main() {
-	tm := task.NewRootTaskManager("autoscale-scheduler")
+	tm := task.NewRootManager("autoscale-scheduler")
 	shutdownErrorHandler := task.LogFatalError("Error during shutdown: %w")
 
 	tm = tm.WithShutdownErrorHandler(shutdownErrorHandler)

--- a/cmd/autoscaler-agent/main.go
+++ b/cmd/autoscaler-agent/main.go
@@ -49,7 +49,7 @@ func main() {
 		VMClient:   vmClient,
 	}
 
-	tm := task.NewRootTaskManager("autoscaler-agent")
+	tm := task.NewRootManager("autoscaler-agent")
 	errHandler := task.LogFatalError("Error during shutdown: %w")
 
 	tm = tm.WithShutdownErrorHandler(errHandler)

--- a/cmd/autoscaler-agent/main.go
+++ b/cmd/autoscaler-agent/main.go
@@ -59,7 +59,7 @@ func main() {
 		ctx, cancel := agent.MakeShutdownContext()
 		defer cancel()
 		if err := tm.Shutdown(ctx); err != nil {
-			errHandler(err)
+			_ = errHandler(err)
 		}
 	}()
 

--- a/cmd/vm-informant/main.go
+++ b/cmd/vm-informant/main.go
@@ -75,7 +75,7 @@ func main() {
 		klog.Infof("No cgroup selected")
 	}
 
-	tm := task.NewRootTaskManager("vm-informant").WithPanicHandler(task.LogPanicAndExit)
+	tm := task.NewRootManager("vm-informant").WithPanicHandler(task.LogPanicAndExit)
 	tm.ShutdownOnSigterm(informant.MakeShutdownContext)
 	defer func() {
 		ctx, cancel := informant.MakeShutdownContext()

--- a/go.mod
+++ b/go.mod
@@ -37,8 +37,9 @@ require (
 	github.com/elastic/go-sysinfo v1.9.0
 	github.com/google/uuid v1.3.0
 	github.com/neondatabase/neonvm v0.4.6
+	github.com/sharnoff/chord v0.0.0-20230306180645-0b0987b7b7d2
 	github.com/tychoish/fun v0.7.1
-	golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9
+	golang.org/x/exp v0.0.0-20230304125523-9ff063c70017
 	k8s.io/api v0.23.15
 	k8s.io/apimachinery v0.23.15
 	k8s.io/client-go v0.23.15

--- a/go.mod
+++ b/go.mod
@@ -37,9 +37,9 @@ require (
 	github.com/elastic/go-sysinfo v1.9.0
 	github.com/google/uuid v1.3.0
 	github.com/neondatabase/neonvm v0.4.6
-	github.com/sharnoff/chord v0.0.0-20230306180645-0b0987b7b7d2
+	github.com/sharnoff/chord v0.1.0
 	github.com/tychoish/fun v0.7.1
-	golang.org/x/exp v0.0.0-20230304125523-9ff063c70017
+	golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0
 	k8s.io/api v0.23.15
 	k8s.io/apimachinery v0.23.15
 	k8s.io/client-go v0.23.15

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/sharnoff/chord v0.0.0-20230306180645-0b0987b7b7d2 h1:eSs0JrvH6haOqe2AP1mC1I4ohPbZEhWdkvPav+sMNCY=
-github.com/sharnoff/chord v0.0.0-20230306180645-0b0987b7b7d2/go.mod h1:dnhCdrtQIG12LKorRMT6IW76gWIVp8RxLTGmqwaADQ0=
+github.com/sharnoff/chord v0.1.0 h1:R91fiqP7Z4LTmSCWKSpCAKuurjp1DTqEfKc5feQTHGY=
+github.com/sharnoff/chord v0.1.0/go.mod h1:ubdoMl+hZu1rhZD0q4j5OEGv/MaWybc7Dfcc6L2L+tE=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -772,8 +772,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20210220032938-85be41e4509f/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
-golang.org/x/exp v0.0.0-20230304125523-9ff063c70017 h1:3Ea9SZLCB0aRIhSEjM+iaGIlzzeDJdpi579El/YIhEE=
-golang.org/x/exp v0.0.0-20230304125523-9ff063c70017/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0 h1:LGJsf5LRplCck6jUCH3dBL2dmycNruWNF5xugkSlfXw=
+golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/go.sum
+++ b/go.sum
@@ -595,6 +595,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/sharnoff/chord v0.0.0-20230306180645-0b0987b7b7d2 h1:eSs0JrvH6haOqe2AP1mC1I4ohPbZEhWdkvPav+sMNCY=
+github.com/sharnoff/chord v0.0.0-20230306180645-0b0987b7b7d2/go.mod h1:dnhCdrtQIG12LKorRMT6IW76gWIVp8RxLTGmqwaADQ0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -770,8 +772,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20210220032938-85be41e4509f/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
-golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9 h1:yZNXmy+j/JpX19vZkVktWqAo7Gny4PBWYYK3zskGpx4=
-golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230304125523-9ff063c70017 h1:3Ea9SZLCB0aRIhSEjM+iaGIlzzeDJdpi579El/YIhEE=
+golang.org/x/exp v0.0.0-20230304125523-9ff063c70017/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/pkg/agent/billing.go
+++ b/pkg/agent/billing.go
@@ -14,6 +14,7 @@ import (
 	vmapi "github.com/neondatabase/neonvm/apis/neonvm/v1"
 
 	"github.com/neondatabase/autoscaling/pkg/billing"
+	"github.com/neondatabase/autoscaling/pkg/task"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
@@ -65,7 +66,7 @@ const (
 )
 
 func RunBillingMetricsCollector(
-	backgroundCtx context.Context,
+	tm task.Manager,
 	conf *BillingConfig,
 	targetNode string,
 	store *util.WatchStore[vmapi.VirtualMachine],
@@ -104,7 +105,7 @@ func RunBillingMetricsCollector(
 			}
 			// Sending was successful; clear the batch.
 			batch = client.NewBatch()
-		case <-backgroundCtx.Done():
+		case <-tm.Context().Done():
 			// If we're being shut down, push the latests events we have before returning.
 			klog.Infof("Creating final billing batch")
 			state.drainAppendToBatch(conf, batch)

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -1,11 +1,9 @@
 package agent
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/tychoish/fun/pubsub"
 
@@ -16,6 +14,7 @@ import (
 	vmclient "github.com/neondatabase/neonvm/client/clientset/versioned"
 
 	"github.com/neondatabase/autoscaling/pkg/api"
+	"github.com/neondatabase/autoscaling/pkg/task"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
@@ -51,13 +50,24 @@ func podIsOurResponsibility(pod *corev1.Pod, config *Config, nodeName string) bo
 		util.PodReady(pod)
 }
 
-func (s *agentState) Stop() {
-	for _, pod := range s.pods {
-		pod.stop()
+func (s *agentState) Stop(tm task.Manager) {
+	handle := tm.SpawnAsSubgroup("shutdown-runners", func(tm task.Manager) {
+		for name, pod := range s.pods {
+			name, pod := name, pod
+			tm.Spawn(fmt.Sprintf("stop-%v", name), func(tm task.Manager) {
+				if err := pod.group.Shutdown(tm.Context()); err != nil {
+					klog.Errorf("Error while stopping Runner %v: %s", name, err)
+				}
+			})
+		}
+	})
+
+	if err := handle.TryWait(tm.Context()); err != nil {
+		klog.Warningf("Error while waiting for Runners to shut down: %s", err)
 	}
 }
 
-func (s *agentState) handleEvent(ctx context.Context, event podEvent) {
+func (s *agentState) handleEvent(tm task.Manager, event podEvent) {
 	klog.Infof("Handling pod event %+v", event)
 
 	state, hasPod := s.pods[event.podName]
@@ -69,15 +79,17 @@ func (s *agentState) handleEvent(ctx context.Context, event podEvent) {
 			return
 		}
 
-		state.stop()
+		tm.Spawn(fmt.Sprintf("stop-%v", event.podName), func(tm task.Manager) {
+			if err := state.group.Shutdown(makeShutdownContext()); err != nil {
+				klog.Errorf("Error while stopping Runner %v: %w", event.podName, err)
+			}
+		})
 		delete(s.pods, event.podName)
 	case podEventAdded:
 		if hasPod {
 			klog.Errorf("Received add event for pod %v while already present", event.podName)
 			return
 		}
-
-		runnerCtx, cancelRunnerContext := context.WithCancel(ctx)
 
 		status := &podStatus{
 			lock:     sync.Mutex{},
@@ -93,32 +105,31 @@ func (s *agentState) handleEvent(ctx context.Context, event podEvent) {
 				prefix: fmt.Sprintf("Runner %v: ", event.podName),
 			},
 			// note: vm is expected to be nil before (*Runner).Run
-			vm:                    nil,
-			podName:               event.podName,
-			podIP:                 event.podIP,
-			lock:                  util.NewChanMutex(),
-			vmStateLock:           util.NewChanMutex(),
-			requestedUpscale:      api.MoreResources{Cpu: false, Memory: false},
-			lastMetrics:           nil,
-			scheduler:             nil,
-			server:                nil,
-			informant:             nil,
-			computeUnit:           nil,
-			lastApproved:          nil,
-			lastSchedulerError:    nil,
-			lastInformantError:    nil,
-			backgroundWorkerCount: atomic.Int64{},
-			backgroundPanic:       make(chan error),
+			vm:                 nil,
+			podName:            event.podName,
+			podIP:              event.podIP,
+			lock:               util.NewChanMutex(),
+			vmStateLock:        util.NewChanMutex(),
+			requestedUpscale:   api.MoreResources{Cpu: false, Memory: false},
+			lastMetrics:        nil,
+			scheduler:          nil,
+			server:             nil,
+			informant:          nil,
+			computeUnit:        nil,
+			lastApproved:       nil,
+			lastSchedulerError: nil,
+			lastInformantError: nil,
 		}
+
+		runnerGroup := runner.Spawn(tm, event.vmName)
 
 		state = &podState{
 			podName: event.podName,
-			stop:    cancelRunnerContext,
+			group:   runnerGroup,
 			runner:  runner,
 			status:  status,
 		}
 		s.pods[event.podName] = state
-		runner.Spawn(runnerCtx, event.vmName)
 	default:
 		panic(errors.New("bad event: unexpected event kind"))
 	}
@@ -127,7 +138,7 @@ func (s *agentState) handleEvent(ctx context.Context, event podEvent) {
 type podState struct {
 	podName api.PodName
 
-	stop   context.CancelFunc
+	group  task.SubgroupHandle
 	runner *Runner
 	status *podStatus
 }

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -80,7 +80,9 @@ func (s *agentState) handleEvent(tm task.Manager, event podEvent) {
 		}
 
 		tm.Spawn(fmt.Sprintf("stop-%v", event.podName), func(tm task.Manager) {
-			if err := state.group.Shutdown(makeShutdownContext()); err != nil {
+			ctx, cancel := MakeShutdownContext()
+			defer cancel()
+			if err := state.group.Shutdown(ctx); err != nil {
 				klog.Errorf("Error while stopping Runner %v: %w", event.podName, err)
 			}
 		})

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -172,10 +172,10 @@ func NewInformantServer(
 	logPrefix := runner.logger.prefix
 
 	mux := http.NewServeMux()
-	util.AddHandler(logPrefix, mux, "/id", http.MethodGet, "struct{}", server.handleID)
-	util.AddHandler(logPrefix, mux, "/resume", http.MethodPost, "ResumeAgent", server.handleResume)
-	util.AddHandler(logPrefix, mux, "/suspend", http.MethodPost, "SuspendAgent", server.handleSuspend)
-	util.AddHandler(logPrefix, mux, "/try-upscale", http.MethodPost, "MoreResourcesRequest", server.handleTryUpscale)
+	util.AddHandler(tm, logPrefix, mux, "/id", http.MethodGet, "struct{}", server.handleID)
+	util.AddHandler(tm, logPrefix, mux, "/resume", http.MethodPost, "ResumeAgent", server.handleResume)
+	util.AddHandler(tm, logPrefix, mux, "/suspend", http.MethodPost, "SuspendAgent", server.handleSuspend)
+	util.AddHandler(tm, logPrefix, mux, "/try-upscale", http.MethodPost, "MoreResourcesRequest", server.handleTryUpscale)
 	httpServer := &http.Server{Handler: mux}
 
 	sendFinished, recvFinished := util.NewSingleSignalPair()
@@ -623,7 +623,7 @@ func (s *InformantServer) informantURL(path string) string {
 // of that context.
 //
 // Returns: response body (if successful), status code, error (if unsuccessful)
-func (s *InformantServer) handleID(ctx context.Context, body *struct{}) (*api.AgentIdentificationMessage, int, error) {
+func (s *InformantServer) handleID(tm task.Manager, body *struct{}) (*api.AgentIdentificationMessage, int, error) {
 	s.runner.lock.Lock()
 	defer s.runner.lock.Unlock()
 
@@ -643,7 +643,7 @@ func (s *InformantServer) handleID(ctx context.Context, body *struct{}) (*api.Ag
 // outside of that context.
 //
 // Returns: response body (if successful), status code, error (if unsuccessful)
-func (s *InformantServer) handleResume(ctx context.Context, body *api.ResumeAgent) (*api.AgentIdentificationMessage, int, error) {
+func (s *InformantServer) handleResume(tm task.Manager, body *api.ResumeAgent) (*api.AgentIdentificationMessage, int, error) {
 	if body.ExpectedID != s.desc.AgentID {
 		s.runner.logger.Warningf("AgentID %q not found, server has %q", body.ExpectedID, s.desc.AgentID)
 		return nil, 404, fmt.Errorf("AgentID %q not found", body.ExpectedID)
@@ -702,7 +702,7 @@ func (s *InformantServer) handleResume(ctx context.Context, body *api.ResumeAgen
 // called outside of that context.
 //
 // Returns: response body (if successful), status code, error (if unsuccessful)
-func (s *InformantServer) handleSuspend(ctx context.Context, body *api.SuspendAgent) (*api.AgentIdentificationMessage, int, error) {
+func (s *InformantServer) handleSuspend(tm task.Manager, body *api.SuspendAgent) (*api.AgentIdentificationMessage, int, error) {
 	if body.ExpectedID != s.desc.AgentID {
 		s.runner.logger.Warningf("AgentID %q not found, server has %q", body.ExpectedID, s.desc.AgentID)
 		return nil, 404, fmt.Errorf("AgentID %q not found", body.ExpectedID)
@@ -756,7 +756,7 @@ func (s *InformantServer) handleSuspend(ctx context.Context, body *api.SuspendAg
 //
 // Returns: response body (if successful), status code, error (if unsuccessful)
 func (s *InformantServer) handleTryUpscale(
-	ctx context.Context,
+	tm task.Manager,
 	body *api.MoreResourcesRequest,
 ) (*api.AgentIdentificationMessage, int, error) {
 	if body.ExpectedID != s.desc.AgentID {

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -321,13 +321,13 @@ func MakeShutdownContext() (context.Context, context.CancelFunc) {
 
 func (r *Runner) Spawn(tm task.Manager, vmName string) task.SubgroupHandle {
 	// Handle panics by marking ourselves as such and shutting down everything else
-	tm = tm.WithPanicHandler(func(taskName string, stackTrace chord.StackTrace) {
+	tm = tm.WithPanicHandler(func(taskName string, err any, stackTrace chord.StackTrace) {
 		r.setStatus(func(stat *podStatus) {
 			stat.panicked = true
 			stat.done = true
 			stat.errored = fmt.Errorf("task %s panicked", taskName)
 		})
-		task.LogPanicAndShutdown(tm, MakeShutdownContext)
+		task.LogPanicAndShutdown(tm, MakeShutdownContext)(taskName, err, stackTrace)
 	})
 	// Don't use the top-level error handler
 	tm = tm.WithShutdownErrorHandler(nil)

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	vmclient "github.com/neondatabase/neonvm/client/clientset/versioned"
 
 	"github.com/neondatabase/autoscaling/pkg/api"
+	"github.com/neondatabase/autoscaling/pkg/task"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
@@ -31,14 +31,14 @@ const (
 )
 
 func startPodWatcher(
-	ctx context.Context,
+	tm task.Manager,
 	config *Config,
 	kubeClient *kubernetes.Clientset,
 	nodeName string,
 	podEvents chan<- podEvent,
 ) (*util.WatchStore[corev1.Pod], error) {
 	return util.Watch(
-		ctx,
+		tm,
 		kubeClient.CoreV1().Pods(corev1.NamespaceAll),
 		util.WatchConfig{
 			LogName: "pods",
@@ -111,12 +111,12 @@ func startPodWatcher(
 
 // note: unlike startPodWatcher, we aren't able to use a field selector on VM status.node (currently; NeonVM v0.4.6)
 func startVMWatcher(
-	ctx context.Context,
+	tm task.Manager,
 	vmClient *vmclient.Clientset,
 	nodeName string,
 ) (*util.WatchStore[vmapi.VirtualMachine], error) {
 	return util.Watch(
-		ctx,
+		tm,
 		vmClient.NeonvmV1().VirtualMachines(corev1.NamespaceAll),
 		util.WatchConfig{
 			LogName: "VMs",

--- a/pkg/informant/agent.go
+++ b/pkg/informant/agent.go
@@ -435,6 +435,7 @@ func (a *Agent) runHandler(tm task.Manager) {
 			// merge req.ctx and tm.Context():
 			reqCtx := tm.WithContext(req.ctx).Context()
 			req.doRequest(reqCtx, &client)
+			req.done.Send()
 		}
 	}
 }

--- a/pkg/informant/consts.go
+++ b/pkg/informant/consts.go
@@ -3,6 +3,7 @@ package informant
 // Assorted constants that aren't worth having a configuration file for
 
 import (
+	"context"
 	"time"
 )
 
@@ -18,6 +19,8 @@ const (
 	AgentResumeTimeout  time.Duration = 100 * time.Millisecond
 	AgentSuspendTimeout time.Duration = 200 * time.Millisecond
 	AgentUpscaleTimeout time.Duration = 400 * time.Millisecond // does not include waiting for /upscale response
+
+	ShutdownTimeout time.Duration = 2 * time.Second
 )
 
 var (
@@ -29,3 +32,7 @@ var (
 		MaxUpscaleWaitMillis:  20,              // 20ms
 	}
 )
+
+func MakeShutdownContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), ShutdownTimeout)
+}

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -3,7 +3,6 @@ package informant
 // This file contains the high-level handlers for various HTTP endpoints
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -11,6 +10,7 @@ import (
 	klog "k8s.io/klog/v2"
 
 	"github.com/neondatabase/autoscaling/pkg/api"
+	"github.com/neondatabase/autoscaling/pkg/task"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
@@ -96,7 +96,7 @@ func WithCgroup(cgm *CgroupManager, config CgroupConfig) NewStateOpts {
 // RegisterAgent registers a new or updated autoscaler-agent
 //
 // Returns: body (if successful), status code, error (if unsuccessful)
-func (s *State) RegisterAgent(ctx context.Context, info *api.AgentDesc) (*api.InformantDesc, int, error) {
+func (s *State) RegisterAgent(tm task.Manager, info *api.AgentDesc) (*api.InformantDesc, int, error) {
 	protoVersion, status, err := s.agents.RegisterNewAgent(info)
 	if err != nil {
 		return nil, status, err
@@ -116,7 +116,7 @@ func (s *State) RegisterAgent(ctx context.Context, info *api.AgentDesc) (*api.In
 // amount is ok
 //
 // Returns: body (if successful), status code and error (if unsuccessful)
-func (s *State) TryDownscale(ctx context.Context, target *api.RawResources) (*api.DownscaleResult, int, error) {
+func (s *State) TryDownscale(tm task.Manager, target *api.RawResources) (*api.DownscaleResult, int, error) {
 	// If we aren't interacting with a cgroup, then we don't need to do anything.
 	if s.cgroup == nil {
 		return &api.DownscaleResult{Ok: true, Status: "No action taken (no cgroup enabled)"}, 200, nil
@@ -174,7 +174,7 @@ func (s *State) TryDownscale(ctx context.Context, target *api.RawResources) (*ap
 // NotifyUpscale signals that the VM's resource usage has been increased to the new amount
 //
 // Returns: body (if successful), status code and error (if unsuccessful)
-func (s *State) NotifyUpscale(ctx context.Context, newResources *api.RawResources) (*struct{}, int, error) {
+func (s *State) NotifyUpscale(tm task.Manager, newResources *api.RawResources) (*struct{}, int, error) {
 	// FIXME: we shouldn't just trust what the agent says
 	//
 	// Because of race conditions like in <https://github.com/neondatabase/autoscaling/issues/23>,
@@ -217,7 +217,7 @@ func (s *State) NotifyUpscale(ctx context.Context, newResources *api.RawResource
 // If a different autoscaler-agent is currently registered, this method will do nothing.
 //
 // Returns: body (if successful), status code and error (if unsuccessful)
-func (s *State) UnregisterAgent(ctx context.Context, info *api.AgentDesc) (*api.UnregisterAgent, int, error) {
+func (s *State) UnregisterAgent(tm task.Manager, info *api.AgentDesc) (*api.UnregisterAgent, int, error) {
 	agent, ok := s.agents.Get(info.AgentID)
 	if !ok {
 		return nil, 404, fmt.Errorf("No agent with ID %q", info.AgentID)

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +15,7 @@ import (
 	klog "k8s.io/klog/v2"
 
 	"github.com/neondatabase/autoscaling/pkg/api"
+	"github.com/neondatabase/autoscaling/pkg/task"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
@@ -173,7 +173,7 @@ func (oldConf *config) validateChangeTo(newConf *config) (string, error) {
 
 // setConfigAndStartWatcher basically does what it says. It (indirectly) spawns goroutines that will
 // update the plugin's config (calling e.handleNewConfigMap).
-func (e *AutoscaleEnforcer) setConfigAndStartWatcher(ctx context.Context) error {
+func (e *AutoscaleEnforcer) setConfigAndStartWatcher(tm task.Manager) error {
 	e.state.lock.Lock()
 	defer e.state.lock.Unlock()
 
@@ -181,7 +181,7 @@ func (e *AutoscaleEnforcer) setConfigAndStartWatcher(ctx context.Context) error 
 	updateEvents := make(chan *corev1.ConfigMap)
 
 	watchStore, err := util.Watch(
-		ctx,
+		tm,
 		e.handle.ClientSet().CoreV1().ConfigMaps(ConfigMapNamespace),
 		util.WatchConfig{
 			LogName: fmt.Sprintf("ConfigMap %s:%s", ConfigMapNamespace, ConfigMapName),

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -50,8 +50,6 @@ func NewAutoscaleEnforcerPlugin(ctx context.Context) func(runtime.Object, framew
 // NewAutoscaleEnforcerPlugin produces the initial AutoscaleEnforcer plugin to be used by the
 // scheduler
 func makeAutoscaleEnforcerPlugin(ctx context.Context, obj runtime.Object, h framework.Handle) (framework.Plugin, error) {
-	tm := ctx.Value(task.ManagerKey).(task.Manager)
-
 	// ^ obj can be used for taking in configuration. it's a bit tricky to figure out, and we don't
 	// quite need it yet.
 	klog.Info("[autoscale-enforcer] Initializing plugin")
@@ -59,6 +57,8 @@ func makeAutoscaleEnforcerPlugin(ctx context.Context, obj runtime.Object, h fram
 	klog.Infof("[autoscale-enforcer] buildInfo.GitInfo:   %s", buildInfo.GitInfo)
 	klog.Infof("[autoscale-enforcer] buildInfo.NeonVM:    %s", buildInfo.NeonVM)
 	klog.Infof("[autoscale-enforcer] buildInfo.GoVersion: %s", buildInfo.GoVersion)
+
+	tm := ctx.Value(task.ManagerKey).(task.Manager)
 
 	// create the NeonVM client
 	if err := vmapi.AddToScheme(scheme.Scheme); err != nil {

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -12,6 +12,7 @@ import (
 	klog "k8s.io/klog/v2"
 
 	"github.com/neondatabase/autoscaling/pkg/api"
+	"github.com/neondatabase/autoscaling/pkg/task"
 )
 
 var MaxHTTPBodySize int64 = 1 << 10 // 1 KiB
@@ -27,7 +28,7 @@ const (
 )
 
 // runPermitHandler runs the server for handling each resourceRequest from a pod
-func (e *AutoscaleEnforcer) runPermitHandler(ctx context.Context) {
+func (e *AutoscaleEnforcer) runPermitHandler(tm task.Manager) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -80,29 +81,13 @@ func (e *AutoscaleEnforcer) runPermitHandler(ctx context.Context) {
 	server := http.Server{Addr: "0.0.0.0:10299", Handler: mux}
 	klog.Info("[autoscale-enforcer] Starting resource request server")
 
-	// in general this isn't the right way to do this: we should
-	// have a group of functions which return service objects that
-	// have blocking close routines, and then start them at a
-	// higher level in the process, and then when we catch a
-	// shutdown signal, you call the shutdown methods (preferably
-	// in parallel) and wait for them to shut down.
-	go func() {
-		// wait till the program is going to exit
-		<-ctx.Done()
-		// create a new context with a timeout because the
-		// context we have is canceled. In practice, there's
-		// nothing at the top level to prevent us from exiting
-		// directly, so this is somewhat pro forma.
-		sctx, scancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer scancel()
+	immediateCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
-		// this just stops accepting new requests, and lets
-		// the existing handlers return, and blocks until they
-		// do. That gives us a "clean shutdown."
-		if err := server.Shutdown(sctx); err != nil {
-			klog.Errorf("[autoscale-enforcer] Service shutdown failed: %s", err)
-		}
-	}()
+	err := tm.OnShutdown(immediateCtx, task.WrapOnError("Resource request server shutdown failed: %w", server.Shutdown))
+	if err != nil {
+		klog.Errorf("Error from immediate shutdown of resource request server: %s", err)
+	}
 
 	// this runs until something cancels or the context in
 	// the goroutine causes shutdown to run.
@@ -110,7 +95,6 @@ func (e *AutoscaleEnforcer) runPermitHandler(ctx context.Context) {
 		// this fatal will take down the entire process,
 		klog.Fatalf("[autoscale-enforcer] Resource request server failed: %s", err)
 	}
-
 }
 
 // Returns body (if successful), status code, error (if unsuccessful)

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -4,7 +4,6 @@ package plugin
 // associated resources
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	klog "k8s.io/klog/v2"
 
 	"github.com/neondatabase/autoscaling/pkg/api"
+	"github.com/neondatabase/autoscaling/pkg/task"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
@@ -25,12 +25,12 @@ import (
 //
 // Events occurring before this method is called will not be sent.
 func (e *AutoscaleEnforcer) watchPodDeletions(
-	ctx context.Context,
+	tm task.Manager,
 	vmDeletions chan<- api.PodName,
 	podDeletions chan<- api.PodName,
 ) error {
 	_, err := util.Watch(
-		ctx,
+		tm,
 		e.handle.ClientSet().CoreV1().Pods(corev1.NamespaceAll),
 		util.WatchConfig{
 			LogName: "pods",

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -231,7 +231,7 @@ func (m Manager) SpawnAsSubgroup(name string, f func(Manager)) SubgroupHandle {
 }
 
 func (m Manager) Shutdown(ctx context.Context) error {
-	return m.signals.sm.Trigger(sigShutdown{}, ctx)
+	return m.signals.sm.TriggerAndWait(sigShutdown{}, ctx)
 }
 
 func (m Manager) OnShutdown(ctx context.Context, callbacks ...func(context.Context) error) error {

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -1,0 +1,263 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/sharnoff/chord"
+
+	"k8s.io/klog/v2"
+)
+
+var ManagerKey managerKey
+
+type managerKey struct{}
+
+// Manager provides a per-goroutine task management interface
+//
+// It's expected that each goroutine will have its own Manager.
+type Manager struct {
+	ctx     context.Context
+	signals *signalManager
+	group   *chord.TaskGroup
+	caller  *chord.StackTrace
+
+	onPanic PanicHandler
+
+	pathInGroup string
+	groupPath   string
+
+	cleanupToken *struct{} // cleanup magic :P
+}
+
+// signalManager wraps a chord.SignalManager with a refcount, so we can call SignalManager.Stop()
+// only when all goroutines spawned by the task are done
+type signalManager struct {
+	sm       *chord.SignalManager
+	parent   *signalManager
+	refcount atomic.Int64
+}
+
+func (s signalManager) incr() {
+	s.refcount.Add(1)
+}
+
+func (s signalManager) decr() {
+	if s.refcount.Add(-1) == 0 {
+		s.sm.Stop()
+		if s.parent != nil {
+			s.parent.decr()
+		}
+	}
+}
+
+type TaskTree = chord.TaskTree
+
+type sigShutdown struct{}
+
+type PanicHandler func(fullTaskName string, stackTrace chord.StackTrace)
+
+func LogPanic(taskName string, stackTrace chord.StackTrace) {
+	klog.Errorf("task %s panicked:\n%s", taskName, stackTrace.String())
+}
+
+func LogPanicAndExit(taskName string, stackTrace chord.StackTrace) {
+	LogPanic(taskName, stackTrace)
+	os.Exit(2)
+}
+
+func LogPanicAndShutdown(m Manager, makeCtx func() context.Context) PanicHandler {
+	return func(taskName string, stackTrace chord.StackTrace) {
+		LogPanic(taskName, stackTrace)
+		klog.Warningf("Shutting down %v due to previous panic", m.FullName())
+		if err := m.Shutdown(makeCtx()); err != nil {
+			klog.Errorf("Shutdown returned error: %w", err)
+		}
+	}
+}
+
+func WrapOnError(format string, f func(context.Context) error) func(context.Context) error {
+	return func(c context.Context) error {
+		if err := f(c); err != nil {
+			return fmt.Errorf(format, err)
+		}
+		return nil
+	}
+}
+
+func Infallible(f func()) func(context.Context) error {
+	return func(context.Context) error {
+		f()
+		return nil
+	}
+}
+
+// NewRootTaskManager creates a new base TaskManager, typically done at program startup or
+func NewRootTaskManager(name string) Manager {
+	signals := &signalManager{
+		sm:       chord.NewSignalManager(),
+		parent:   nil,
+		refcount: atomic.Int64{},
+	}
+	signals.refcount.Add(1)
+
+	cleanupToken := &struct{}{}
+	runtime.SetFinalizer(cleanupToken, func(obj any) {
+		signals.decr()
+	})
+
+	return Manager{
+		ctx:          nil,
+		signals:      signals,
+		group:        chord.NewTaskGroup(name),
+		caller:       nil,
+		onPanic:      nil,
+		pathInGroup:  "main",
+		groupPath:    name,
+		cleanupToken: cleanupToken,
+	}
+}
+
+func (m Manager) FullName() string {
+	return fmt.Sprintf("group{%s}-task{%s}", m.groupPath, m.pathInGroup)
+}
+
+func (m Manager) ShutdownOnSigterm() {
+	err := m.signals.sm.On(syscall.SIGTERM, context.Background(), m.Shutdown)
+	if err != nil {
+		panic(fmt.Errorf("unexpected error while setting SIGTERM hook: %w", err))
+	}
+}
+
+func (m Manager) Context() context.Context {
+	if m.ctx != nil {
+		return m.ctx
+	} else {
+		return m.signals.sm.Context(sigShutdown{})
+	}
+}
+
+func (m Manager) WithContext(ctx context.Context) Manager {
+	m.ctx = ctx
+	return m
+}
+
+func (m Manager) WithPanicHandler(onPanic PanicHandler) Manager {
+	m.onPanic = onPanic
+	return m
+}
+
+func (m Manager) Spawn(name string, f func(Manager)) {
+	caller := chord.GetStackTrace(m.caller, 1) // ignore this function in stack trace
+
+	m.group.Add(name)
+	m.signals.incr()
+	go func() {
+		defer m.group.Done(name)
+		defer m.signals.decr()
+		f(Manager{
+			ctx:          m.ctx,
+			signals:      m.signals,
+			group:        m.group,
+			caller:       &caller,
+			onPanic:      m.onPanic,
+			pathInGroup:  fmt.Sprintf("%s/%s", m.pathInGroup, name),
+			groupPath:    m.groupPath,
+			cleanupToken: m.cleanupToken,
+		})
+	}()
+}
+
+func (m Manager) SpawnAsSubgroup(name string, f func(Manager)) SubgroupHandle {
+	caller := chord.GetStackTrace(m.caller, 1) // ignore this function in stack trace
+
+	signals := &signalManager{
+		sm:       m.signals.sm.NewChild(),
+		parent:   m.signals,
+		refcount: atomic.Int64{},
+	}
+	signals.refcount.Add(1)
+	signals.parent.incr()
+
+	sub := Manager{
+		ctx:          nil, // maybe set below
+		group:        m.group.NewSubgroup(name),
+		signals:      signals,
+		caller:       &caller,
+		onPanic:      m.onPanic,
+		pathInGroup:  "main",
+		groupPath:    fmt.Sprintf("%s/%s", m.groupPath, name),
+		cleanupToken: m.cleanupToken,
+	}
+
+	// make sure that that this subgroup's shutdown is propagated into the contexty by registering a
+	// shutdown hook to cancel the context
+	if m.ctx != nil {
+		var cancel context.CancelFunc
+		sub.ctx, cancel = context.WithCancel(m.ctx)
+		definitelyNotErr := sub.signals.sm.On(sigShutdown{}, context.Background(), Infallible(cancel))
+		if definitelyNotErr != nil {
+			panic(fmt.Errorf("unexpected error: %w", definitelyNotErr))
+		}
+	}
+
+	sub.group.Add("main")
+
+	go func() {
+		defer sub.group.Done("main")
+		defer sub.signals.decr()
+		defer func() {
+			if err := recover(); err != nil {
+				if m.onPanic != nil {
+					// panicking should skip 2 -- one for the deferred function, and one for the call to
+					// runtime.panic itself
+					trace := chord.GetStackTrace(sub.caller, 2)
+					m.onPanic(m.FullName(), trace)
+				} else {
+					// If there's no panic handler, propagate the error
+					panic(err)
+				}
+			}
+		}()
+
+		f(sub)
+	}()
+
+	return SubgroupHandle{m: sub}
+}
+
+func (m Manager) Shutdown(ctx context.Context) error {
+	return m.signals.sm.Trigger(sigShutdown{}, ctx)
+}
+
+func (m Manager) OnShutdown(ctx context.Context, callbacks ...func(context.Context) error) error {
+	return m.signals.sm.On(sigShutdown{}, ctx, callbacks...)
+}
+
+func (m Manager) IgnoreParentShutdown() {
+	m.signals.sm.Ignore(sigShutdown{})
+}
+
+type SubgroupHandle struct {
+	m Manager
+}
+
+func (h SubgroupHandle) Shutdown(ctx context.Context) error {
+	return h.m.Shutdown(ctx)
+}
+
+func (h SubgroupHandle) Wait() <-chan struct{} {
+	return h.m.group.Wait()
+}
+
+func (h SubgroupHandle) TryWait(ctx context.Context) error {
+	return h.m.group.TryWait(ctx)
+}
+
+func (h SubgroupHandle) TaskTree() TaskTree {
+	return h.m.group.TaskTree()
+}

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -1,5 +1,7 @@
 package task
 
+// Definition of task.Manager, alongside a handful of helper types.
+
 import (
 	"context"
 	"fmt"
@@ -13,13 +15,28 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// ManagerKey is a unique value that can be used as a key for context.Value to set/get a Manager.
 var ManagerKey managerKey
 
 type managerKey struct{}
 
-// Manager provides a per-goroutine task management interface
+// Manager provides a per-goroutine task management interface.
 //
-// It's expected that each goroutine will have its own Manager.
+// It's expected that each goroutine will have its own Manager, which should then be *exclusively*
+// used to spawn new goroutines. In other words: there should be no bare calls to 'go f()' outside
+// this package; you should use Manager.Spawn or Manager.SpawnAsSubgroup instead.
+//
+// Broadly, the primary task-running methods are Manager.Spawn (run a single function) and
+// Manager.SpawnAsSubgroup (run a function as the start of a "subgroup" - see below).
+// There's also a handful of methods for modifying the Manager in various ways - usually starting
+// with "With", which return a modified Manager.
+//
+// Shutdown hooks are registered with Manager.OnShutdown and called in reverse order by
+// Manager.Shutdown (refer to OnShutdown for more information). See also Manager.ShutdownOnSigterm
+// and Manager.IgnoreParentShutdown
+//
+// And finally, a handful of methods are provided to retrieve bits of per-task or per-group
+// information - see Manager.Context and Manager.Caller.
 type Manager struct {
 	ctx     context.Context
 	signals *signalManager
@@ -63,22 +80,35 @@ type sigShutdown struct{}
 type ErrorHandler func(error) error
 type PanicHandler func(fullTaskName string, err any, stackTrace chord.StackTrace)
 
-func LogFatalError(format string) func(error) error {
+// LogFatalError is an ErrorHandler that, on any error, calls klog.Fatalf(format, err). Typical
+// usage might look like:
+//
+//	tm.WithErrorHandler(LogFatalError("Server shutdown failed: %w")).
+//	 	OnShutdown(context.TODO(), httpServer.Shutdown)
+func LogFatalError(format string) ErrorHandler {
 	return func(err error) error {
 		klog.Fatalf(format, err)
 		return nil
 	}
 }
 
+// LogPanic is a PanicHandler that emits an error log describing the panic, with a format roughly
+// equivalent to the default display representation for unhandled panics.
 func LogPanic(taskName string, err any, stackTrace chord.StackTrace) {
 	klog.Errorf("task %s panicked with %v:\n%s", taskName, err, stackTrace.String())
 }
 
+// LogPanicAndExit is a PanicHandler that logs the panic (via LogPanic) and calls os.Exit.
+//
+// FIXME: This might run us into issues? Depending on the implementation of klog, we might end up
+// exiting without actually flushing to stdout/stderr.
 func LogPanicAndExit(taskName string, err any, stackTrace chord.StackTrace) {
 	LogPanic(taskName, err, stackTrace)
 	os.Exit(2)
 }
 
+// LogPanicAndShutdown is a PanicHandler that logs the panic (via LogPanic) and calls m.Shutdown
+// with a context provided by makeCtx.
 func LogPanicAndShutdown(m Manager, makeCtx func() (context.Context, context.CancelFunc)) PanicHandler {
 	return func(taskName string, err any, stackTrace chord.StackTrace) {
 		LogPanic(taskName, err, stackTrace)
@@ -91,6 +121,8 @@ func LogPanicAndShutdown(m Manager, makeCtx func() (context.Context, context.Can
 	}
 }
 
+// WrapOnError returns a function wrapping f that will return fmt.Errorf(format, err) if f returns a
+// non-nil error, and nil otherwise.
 func WrapOnError(format string, f func(context.Context) error) func(context.Context) error {
 	return func(c context.Context) error {
 		if err := f(c); err != nil {
@@ -100,6 +132,14 @@ func WrapOnError(format string, f func(context.Context) error) func(context.Cont
 	}
 }
 
+// Infallible converts a function that does not return error into one that returns nil (and takes an
+// unused Context).
+//
+// This is typically used when registering hooks with Manager.OnShutdown. For example:
+//
+//	func CloseSignalChannelOnShutdown(m Manager, sig chan struct{}) {
+//	 	_ = m.OnShutdown(context.TODO(), Infallible(func() { close(sig) }))
+//	}
 func Infallible(f func()) func(context.Context) error {
 	return func(context.Context) error {
 		f()
@@ -107,8 +147,9 @@ func Infallible(f func()) func(context.Context) error {
 	}
 }
 
-// NewRootTaskManager creates a new base TaskManager, typically done at program startup or
-func NewRootTaskManager(name string) Manager {
+// NewRootManager creates a new base Manager, typically done at program startup. Even for tests,
+// it's preferable to have a single root Manager, using subgroups for each test.
+func NewRootManager(name string) Manager {
 	signals := &signalManager{
 		sm:       chord.NewSignalManager(),
 		parent:   nil,
@@ -134,10 +175,13 @@ func NewRootTaskManager(name string) Manager {
 	}
 }
 
+// FullName returns the full name of the task. For specifics, refer to the function implementation
+// (it's quite short).
 func (m Manager) FullName() string {
 	return fmt.Sprintf("group{%s}-task{%s}", m.groupPath, m.pathInGroup)
 }
 
+// ShutdownOnSigterm sets the Manager to call Manager.Shutdown when SIGTERM occurs.
 func (m Manager) ShutdownOnSigterm(makeContext func() (context.Context, context.CancelFunc)) {
 	onErr := m.onError
 	handler := func(_ context.Context, err error) error {
@@ -156,6 +200,9 @@ func (m Manager) ShutdownOnSigterm(makeContext func() (context.Context, context.
 	}
 }
 
+// Context returns a Context that is canceled once Shutdown has been triggered. If
+// Manager.WithContext was previously called, the returned Context will be derived from that Context
+// (but it still has the guarantees about shutdown).
 func (m Manager) Context() context.Context {
 	if m.ctx != nil {
 		return m.ctx
@@ -164,10 +211,14 @@ func (m Manager) Context() context.Context {
 	}
 }
 
+// Caller returns the stack trace at the point this Manager's goroutine was spawned, if there was
+// one. The returned chord.StackTrace may be nil.
 func (m Manager) Caller() *chord.StackTrace {
 	return m.caller
 }
 
+// WithCaller returns a Manager with the calling goroutine overriden, typically used for managing
+// stack traces.
 func (m Manager) WithCaller(trace *chord.StackTrace) Manager {
 	m.caller = trace
 	return m
@@ -178,6 +229,12 @@ func (m Manager) WithContext(ctx context.Context) Manager {
 	return m
 }
 
+// WithShutdownErrorHandler sets an ErrorHandler for shutdown hooks (see Manager.OnShutdown for
+// more). If onError is nil, then all error handlers will be removed. If there is already an error
+// handler, then it will be called after onError if onError returns a non-nil error.
+//
+// In general, if all ErrorHandlers, when called in sequence, all return a non-nil error, then that
+// will be returned by Shutdown.
 func (m Manager) WithShutdownErrorHandler(onError ErrorHandler) Manager {
 	if m.onError != nil && onError != nil {
 		parent := m.onError
@@ -200,6 +257,16 @@ func (m Manager) WithPanicHandler(onPanic PanicHandler) Manager {
 	return m
 }
 
+// MaybeRecover implements the "defer, run panic handler" logic used internally. This method is only
+// really made public so that it can be used alongside Manager.NewForTask - for example:
+//
+//	func run(tm Manager, f func()) {
+//		tm, done := tm.NewForTask("run")
+//		defer done()
+//		defer tm.MaybeRecover()
+//
+//		f()
+//	}
 func (m Manager) MaybeRecover() {
 	if err := recover(); err != nil {
 		if m.onPanic != nil {
@@ -214,6 +281,12 @@ func (m Manager) MaybeRecover() {
 	}
 }
 
+// NewForTask creates a new Manager with a given task name, returning a cleanup function alongside
+// it.
+//
+// done *must* be called when the task is finished.
+//
+// The returned Manager will not have its caller set. See also: Manager.WithCaller.
 func (m Manager) NewForTask(name string) (_ Manager, done func()) {
 	m.group.Add(name)
 	m.signals.incr()
@@ -232,6 +305,8 @@ func (m Manager) NewForTask(name string) (_ Manager, done func()) {
 	}
 }
 
+// Spawn runs the function in a new goroutine, with the name provided. The Manager passed to f will
+// be derived from m, and specific to its goroutine.
 func (m Manager) Spawn(name string, f func(Manager)) {
 	caller := chord.GetStackTrace(m.caller, 1) // ignore this function in stack trace
 
@@ -243,6 +318,9 @@ func (m Manager) Spawn(name string, f func(Manager)) {
 	}()
 }
 
+// SpawnAsSubgroup runs the function in a new goroutine, creating a new task "subgroup" to hold it.
+// The returned SubgroupHandle provides a handful of methods for interacting with the tasks spawned
+// in that group - refer to its documentation for more information.
 func (m Manager) SpawnAsSubgroup(name string, f func(Manager)) SubgroupHandle {
 	caller := chord.GetStackTrace(m.caller, 1) // ignore this function in stack trace
 
@@ -292,10 +370,29 @@ func (m Manager) SpawnAsSubgroup(name string, f func(Manager)) SubgroupHandle {
 	return SubgroupHandle{m: sub}
 }
 
+// Shutdown runs all hooks registered with Manger.OnShutdown, for this task group and all subgroups.
+//
+// The context will be passed to all hooks. For more information, see Manager.OnShutdown.
+//
+// If Shutdown is called while currently in progress, it will block until shutting down is complete.
+// The new context will be completely ignored. Only the original caller will receive any error.
 func (m Manager) Shutdown(ctx context.Context) error {
 	return m.signals.sm.TriggerAndWait(sigShutdown{}, ctx)
 }
 
+// OnShutdown registers a hook to be run on shutdown - whether that's triggered by Manager.Shutdown,
+// SubgroupHandle.Shutdown, or via some signal.
+//
+// The callbacks are run in reverse order (including across calls to OnShutdown), and any unhandled
+// error (i.e. all ErrorHandlers still return a non-nil error) will be returned, aborting the
+// shutdown sequence.
+//
+// If the Manager's shutdown has already been triggered, then each callback will be immediately
+// called with the provided Context, with any error returned. No error will be returned, and the
+// context will be unused, if shutdown has not yet been triggered.
+//
+// For subgroups, the ordering of calling hooks is determined by when the subgroup was created. All
+// hooks in a subgroup run together.
 func (m Manager) OnShutdown(ctx context.Context, callbacks ...func(context.Context) error) error {
 	onErr := m.onError
 	handler := func(_ context.Context, err error) error {
@@ -307,26 +404,45 @@ func (m Manager) OnShutdown(ctx context.Context, callbacks ...func(context.Conte
 	return m.signals.sm.WithErrorHandler(handler).On(sigShutdown{}, ctx, callbacks...)
 }
 
+// IgnoreParentShutdown modifies this Manager so that any call to Shutdown on a parent task group
+// (via SpawnAsSubgroup)
+//
+// Broadly, IgnoreParentShutdown will do "the right thing" when the parent's shutdown has already
+// been triggered: it will be un-triggered if this Manager's shutdown has not yet been observed, but
+// it'll remain as-is if it has been.
 func (m Manager) IgnoreParentShutdown() {
 	m.signals.sm.Ignore(sigShutdown{})
 }
 
+// SubgroupHandle provides some ways to interact with a task subgroup, created by
+// Manager.SpawnAsSubgroup.
+//
+// Refer to the provided methods for more.
 type SubgroupHandle struct {
 	m Manager
 }
 
+// Shutdown runs all shutdown hooks in the subgroup, passing the context and returning any error.
+//
+// If Shutdown is called while currently in progress, it will block until shutting down is complete.
+// The new context will be completely ignored. Only the original caller will receive any error.
 func (h SubgroupHandle) Shutdown(ctx context.Context) error {
 	return h.m.Shutdown(ctx)
 }
 
+// Wait returns a channel that will be closed once all tasks in the subgroup have ended.
 func (h SubgroupHandle) Wait() <-chan struct{} {
 	return h.m.group.Wait()
 }
 
+// TryWait waits for all tasks in the subgroup to finish, or the context to be canceled. Once the
+// context is canceled, its error will be returned.
 func (h SubgroupHandle) TryWait(ctx context.Context) error {
 	return h.m.group.TryWait(ctx)
 }
 
+// TaskTree returns a representation of the structure of currently running tasks in this subgroup.
+// This is primarily intended for debugging only, used in various "dump state" endpoints.
 func (h SubgroupHandle) TaskTree() TaskTree {
 	return h.m.group.TaskTree()
 }

--- a/pkg/util/watch.go
+++ b/pkg/util/watch.go
@@ -180,7 +180,7 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 	}
 
 	// With the successful Watch call underway, we hand off responsibility to a new goroutine.
-	tm.Spawn("watch-%s", func(tm task.Manager) {
+	tm.Spawn(fmt.Sprintf("watch-%s", config.LogName), func(tm task.Manager) {
 		// note: instead of deferring watcher.Stop() directly, wrapping it in an outer function
 		// means that we'll always Stop the most recent watcher.
 		defer func() {


### PR DESCRIPTION
## Motivation

Briefly:

1. Move task management away from business logic
2. Better stack traces on panic
3. Allow introspection of which tasks are running
4. Allow mock tests to check we aren't leaking goroutines

Currently `pkg/agent/runner.go` has the `spawnBackgroundWorker` method, which is _ok_, but is very specific to the `Runner` type, and is still somewhat limited in scope — for example, it appropriately triggers `Runner` shutdown on panic, but only captures the stack trace for the single goroutine.

On top of that, I'd like to eventually have some "e2e-ish" mock tests that connect the components outside of kubernetes — e.g. by feeding in fake k8s data + metrics and connecting the components' HTTP servers/clients to each other. Points (3) and (4) above would allow these tests to test more, in addition to providing better debugging capabilities when things go wrong.

## Implementation

The general idea is that we add a new package (`pkg/task`) that primarily exports a `Manager` type, which gets passed around everywhere. Every instance of `go f(...)` is instead replaced by `Manager.Spawn(...)` or `Manager.SpawnAsSubgroup(...)`.

`task.Manager` also does (approximately) the right thing w.r.t. signal handling and shutdown.

The implementation of `pkg/task` is backed by https://github.com/sharnoff/chord, which was designed with this project in mind. We may want to move that into this repo, or under `neondatabase`.

## Remaining items

- [x] Documentation in `pkg/task`
- [ ] Rebasing on `main`
- [x] Testing locally
- [ ] Self review