### PR TITLE
agent: Fix dump-state panic

### DIFF
--- a/pkg/agent/dumpstate.go
+++ b/pkg/agent/dumpstate.go
@@ -88,7 +88,7 @@ func (s *agentState) DumpState(ctx context.Context, stopped bool) (*StateDump, e
 	state := StateDump{
 		Stopped:   stopped,
 		BuildInfo: util.GetBuildInfo(),
-		Pods:      make([]podStateDump, 0, len(podList)),
+		Pods:      make([]podStateDump, len(podList)),
 	}
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
Panicked on staging (v0.5.0) with:

```
I0329 08:06:44.830862       1 handle.go:46] dump-state: Received request on / (client = 10.6.30.246:34950) {}
panic: runtime error: index out of range [0] with length 0

goroutine 521 [running]:
github.com/neondatabase/autoscaling/pkg/agent.(*agentState).DumpState.func2()
	/workspace/pkg/agent/dumpstate.go:108 +0x190
created by github.com/neondatabase/autoscaling/pkg/agent.(*agentState).DumpState
	/workspace/pkg/agent/dumpstate.go:102 +0x1e8
```