### PR TITLE
plugin: Fix missing podResourceState JSON tags

### DIFF
--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -193,10 +193,10 @@ type podResourceState[T any] struct {
 	//
 	// After the first communication from the autoscaler-agent, we update Reserved to match its
 	// value, and set Buffer to zero.
-	Buffer T
+	Buffer T `json:"buffer"`
 	// CapacityPressure is this pod's contribution to this pod's node's CapacityPressure for this
 	// resource
-	CapacityPressure T
+	CapacityPressure T `json:"capacityPressure"`
 
 	// Min and Max give the minimum and maxmium values of this resource that the VM may use.
 	Min T `json:"min"`


### PR DESCRIPTION
This is technically a breaking change to the JSON format exposed by the dump state endpoint, but I'd rather consider this a bugfix and not bump the version from v0.5 -> v0.6 because of it.