### PR TITLE
plugin: Don't reject request if VM is constrained

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -569,11 +569,23 @@ func (e *AutoscaleEnforcer) Reserve(
 		node.vCPU.Reserved = newNodeReservedCPU
 		node.memSlots.Reserved = newNodeReservedMemSlots
 		ps := &podState{
-			name:                     pName,
-			vmName:                   vmInfo.Name,
-			node:                     node,
-			vCPU:                     podResourceState[uint16]{Reserved: vmInfo.Cpu.Use, CapacityPressure: 0},
-			memSlots:                 podResourceState[uint16]{Reserved: vmInfo.Mem.Use, CapacityPressure: 0},
+			name:   pName,
+			vmName: vmInfo.Name,
+			node:   node,
+			vCPU: podResourceState[uint16]{
+				Reserved:         vmInfo.Cpu.Use,
+				Buffer:           0,
+				CapacityPressure: 0,
+				Min:              vmInfo.Cpu.Min,
+				Max:              vmInfo.Cpu.Max,
+			},
+			memSlots: podResourceState[uint16]{
+				Reserved:         vmInfo.Mem.Use,
+				Buffer:           0,
+				CapacityPressure: 0,
+				Min:              vmInfo.Mem.Min,
+				Max:              vmInfo.Mem.Max,
+			},
 			testingOnlyAlwaysMigrate: vmInfo.AlwaysMigrate,
 			mostRecentComputeUnit:    nil,
 			metrics:                  nil,

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -197,6 +197,10 @@ type podResourceState[T any] struct {
 	// CapacityPressure is this pod's contribution to this pod's node's CapacityPressure for this
 	// resource
 	CapacityPressure T
+
+	// Min and Max give the minimum and maxmium values of this resource that the VM may use.
+	Min T `json:"min"`
+	Max T `json:"max"`
 }
 
 // otherPodState tracks a little bit of information for the non-VM pods we're handling
@@ -838,11 +842,15 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context) error {
 				Reserved:         vmInfo.Cpu.Max,
 				Buffer:           vmInfo.Cpu.Max - vmInfo.Cpu.Use,
 				CapacityPressure: 0,
+				Min:              vmInfo.Cpu.Min,
+				Max:              vmInfo.Cpu.Max,
 			},
 			memSlots: podResourceState[uint16]{
 				Reserved:         vmInfo.Mem.Max,
 				Buffer:           vmInfo.Mem.Max - vmInfo.Mem.Use,
 				CapacityPressure: 0,
+				Min:              vmInfo.Mem.Min,
+				Max:              vmInfo.Mem.Max,
 			},
 
 			mqIndex:               -1,


### PR DESCRIPTION
Per the commit message:

> Ran into this with free tier VMs in production, which are bounded to exactly 1 CPU and 1 GB memory. The autoscaler-agent (validly) sends a resource request to the scheduler plugin which wasn't a multiple of the compute unit (because it can only be 1 CPU + 1 GB).
> 
> This commit allows the plugin to recognize that some requests that aren't a multiple of the compute unit are still valid if it's not possible for the VM's allocation to be a multiple of the compute unit.
> 
> Adds Min and Max fields to podResourceState, to track the information we need to make the determination.

see also: https://neondb.slack.com/archives/C03H1K0PGKH/p1680082384420809?thread_ts=1680080372.280049&cid=C03H1K0PGKH