### PR TITLE
agent/billing: panic if VM store unexpectedly stopped

### DIFF
--- a/pkg/agent/billing.go
+++ b/pkg/agent/billing.go
@@ -97,7 +97,7 @@ func RunBillingMetricsCollector(
 		select {
 		case <-collectTicker.C:
 			klog.Infof("Collecting billing state")
-			if store.Stopped() && backgroundCtx.Err() != nil {
+			if store.Stopped() && backgroundCtx.Err() == nil {
 				panic(errors.New("VM store stopped but background context is still live"))
 			}
 			state.collect(conf, targetNode, store)

--- a/pkg/agent/billing.go
+++ b/pkg/agent/billing.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"math"
 	"net/http"
 	"time"
@@ -96,6 +97,9 @@ func RunBillingMetricsCollector(
 		select {
 		case <-collectTicker.C:
 			klog.Infof("Collecting billing state")
+			if store.Stopped() && backgroundCtx.Err() != nil {
+				panic(errors.New("VM store stopped but background context is still live"))
+			}
 			state.collect(conf, targetNode, store)
 		case <-pushTicker.C:
 			klog.Infof("Creating billing batch")


### PR DESCRIPTION
This should act as a reasonable-ish fail-safe against the VM store ending early, which would otherwise cause us to continually send the same consumption metrics (and would be incorrect!)

This is an added concern because of #111, which actually does something in the VM store's handlers.