### PR TITLE
agent: watch VMs for events, not pods

### DIFF
--- a/pkg/agent/entrypoint.go
+++ b/pkg/agent/entrypoint.go
@@ -23,14 +23,14 @@ type MainRunner struct {
 }
 
 func (r MainRunner) Run(ctx context.Context) error {
-	podEvents := make(chan vmEvent)
+	vmEvents := make(chan vmEvent)
 
 	buildInfo := util.GetBuildInfo()
 	klog.Infof("buildInfo.GitInfo:   %s", buildInfo.GitInfo)
 	klog.Infof("buildInfo.GoVersion: %s", buildInfo.GoVersion)
 
 	klog.Info("Starting VM watcher")
-	vmWatchStore, err := startVMWatcher(ctx, r.Config, r.VMClient, r.EnvArgs.K8sNodeName, podEvents)
+	vmWatchStore, err := startVMWatcher(ctx, r.Config, r.VMClient, r.EnvArgs.K8sNodeName, vmEvents)
 	if err != nil {
 		return fmt.Errorf("Error starting VM watcher: %w", err)
 	}
@@ -72,7 +72,7 @@ func (r MainRunner) Run(ctx context.Context) error {
 		loop:
 			for {
 				select {
-				case <-podEvents:
+				case <-vmEvents:
 				default:
 					break loop
 				}
@@ -80,7 +80,7 @@ func (r MainRunner) Run(ctx context.Context) error {
 
 			globalState.Stop()
 			return nil
-		case event := <-podEvents:
+		case event := <-vmEvents:
 			globalState.handleEvent(ctx, event)
 		}
 	}

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -36,7 +36,7 @@ func startVMWatcher(
 	config *Config,
 	vmClient *vmclient.Clientset,
 	nodeName string,
-	podEvents chan<- vmEvent,
+	vmEvents chan<- vmEvent,
 ) (*util.WatchStore[vmapi.VirtualMachine], error) {
 	return util.Watch(
 		ctx,
@@ -60,7 +60,7 @@ func startVMWatcher(
 						klog.Errorf("Erorr handling VM added: %s", err)
 						return
 					}
-					podEvents <- event
+					vmEvents <- event
 				}
 			},
 			UpdateFunc: func(oldVM, newVM *vmapi.VirtualMachine) {
@@ -86,7 +86,7 @@ func startVMWatcher(
 					return
 				}
 
-				podEvents <- event
+				vmEvents <- event
 			},
 			DeleteFunc: func(vm *vmapi.VirtualMachine, maybeStale bool) {
 				if vmIsOurResponsibility(vm, config, nodeName) {
@@ -95,7 +95,7 @@ func startVMWatcher(
 						klog.Errorf("Error handling VM deletion: %s", err)
 						return
 					}
-					podEvents <- event
+					vmEvents <- event
 				}
 			},
 		},


### PR DESCRIPTION
This change mostly does nothing, but it has a few important impliciations that are worth listing:

1. vmIsOurResponsibility checks vm.Status.Phase == VmRunning, which means that we won't scale VMs that are currently migrating.
2. NeonVM can't do a FieldSelector on Status.NodeName, so we have to do the filtering ourselves. That was already the case with the billing-related code though, so :shrug:
3. A handful of functions deleted, because they aren't necessary if we're watching VMs directly :D

Required by #112.