### PR TITLE
agent, plugin: Re-enable migration under load

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,11 +49,14 @@ linters-settings:
     exclude:
       - '^net/http\.(Client|Server)'
       - '^net\.TCPAddr$'
-      # metav1.{GetOptions,ListOptions,WatchOptions,PatchOptions}
-      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.(Get|List|Watch|Patch)Options$'
+      # metav1.{CreateOptions,GetOptions,ListOptions,WatchOptions,PatchOptions}
+      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.(Create|Get|List|Watch|Patch)Options$'
+      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.ObjectMeta$'
       - '^k8s\.io/apimachinery/pkg/api/resource\.Quantity$'
       - '^github\.com/containerd/cgroups/v3/cgroup2\.(Resources|Memory)'
       - '^github\.com/tychoish/fun/pubsub\.BrokerOptions$'
+      # vmapi.{VirtualMachine,VirtualMachineSpec,VirtualMachineMigration,VirtualMachineMigrationSpec}
+      - '^github\.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1\.VirtualMachine(Migration)?(Spec)?$'
 
   # see: <https://golangci-lint.run/usage/linters/#gci>
   gci:

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -107,6 +107,9 @@ func (s *agentState) handleEvent(ctx context.Context, event vmEvent) {
 			logger: RunnerLogger{
 				prefix: fmt.Sprintf("Runner %v: ", event.podName),
 			},
+			schedulerRespondedWithMigration: false,
+
+			shutdown:              cancelRunnerContext,
 			vm:                    event.vmInfo,
 			podName:               podName,
 			podIP:                 event.podIP,

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -109,7 +109,7 @@ func (s *agentState) handleEvent(ctx context.Context, event vmEvent) {
 			},
 			schedulerRespondedWithMigration: false,
 
-			shutdown:              cancelRunnerContext,
+			shutdown:              nil, // set by (*Runner).Run
 			vm:                    event.vmInfo,
 			podName:               podName,
 			podIP:                 event.podIP,

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -84,7 +84,8 @@ type Runner struct {
 	// logger is the shared logger for this Runner, giving all log lines a unique, relevant prefix
 	logger RunnerLogger
 
-	// shutdown provides a clean way to trigger all background Runner threads to shut down
+	// shutdown provides a clean way to trigger all background Runner threads to shut down. shutdown
+	// is set exactly once, by (*Runner).Run
 	shutdown context.CancelFunc
 
 	// vm stores some common information about the VM.
@@ -371,6 +372,7 @@ func (r *Runner) setStatus(with func(*podStatus)) {
 
 // Run is the main entrypoint to the long-running per-VM pod tasks
 func (r *Runner) Run(ctx context.Context) error {
+	ctx, r.shutdown = context.WithCancel(ctx)
 	defer r.shutdown()
 
 	schedulerWatch, scheduler, err := watchSchedulerUpdates(

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -130,11 +130,12 @@ func (e *AutoscaleEnforcer) handleAgentRequest(req api.AgentRequest) (*api.Plugi
 
 	node := pod.node
 
-	// Check whether the pod *will* migrate, then update its resources, and THEN start its
-	// migration, using the possibly-changed resources.
-	mustMigrate := e.updateMetricsAndCheckMustMigrate(pod, node, req.Metrics)
-	// Don't migrate if it's disabled
-	mustMigrate = mustMigrate && e.state.conf.migrationEnabled()
+	mustMigrate := pod.migrationState == nil &&
+		// Check whether the pod *will* migrate, then update its resources, and THEN start its
+		// migration, using the possibly-changed resources.
+		e.updateMetricsAndCheckMustMigrate(pod, node, req.Metrics) &&
+		// Don't migrate if it's disabled
+		e.state.conf.migrationEnabled()
 
 	permit, status, err := e.handleResources(pod, node, req.Resources, mustMigrate)
 	if err != nil {


### PR DESCRIPTION
In order to properly handle migration, agent.Runner now has a way to shut itself down to prevent future requests.