### PR TITLE
agent: Use single request lock for plugin & NeonVM

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -114,7 +114,7 @@ func (s *agentState) handleEvent(ctx context.Context, event vmEvent) {
 			podName:               podName,
 			podIP:                 event.podIP,
 			lock:                  util.NewChanMutex(),
-			vmStateLock:           util.NewChanMutex(),
+			requestLock:           util.NewChanMutex(),
 			requestedUpscale:      api.MoreResources{Cpu: false, Memory: false},
 			lastMetrics:           nil,
 			scheduler:             nil,

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -80,8 +80,7 @@ type InformantServer struct {
 	// made at a time.
 	//
 	// If both requestLock and runner.lock are required, then requestLock MUST be acquired before
-	// runner.lock. Similarly, if both requestLock and runner.vmStateLock are required, then
-	// runner.vmStateLock MUST be acquired before requestLock.
+	// runner.lock.
 	requestLock util.ChanMutex
 
 	// exitStatus holds some information about why the server exited


### PR DESCRIPTION
This PR also does all the implied simplification from this, mainly:
    
- Remove vmStateLock
- Merge schedulerInternal into Scheduler (was only used for deadlock
  checker, which is no longer needed)
- Hold requestLock for all of updateVMResources
- Simplify internals of updateVMResources in cases where holding
  requestLock guarantees the state hasn't changed.
  - Remove retries from updateVMResources (no longer used)
- Don't pre-add to Runner's vm.{Cpu,Mem}.Use - no longer required,
  because scheduler requests can no longer co-occur with NeonVM requests

**Note:** For ease of review (and maybe future blame?), this PR is split into two commits. The first one _only touches whitespace._ Not yet sure if I should merge without squashing.