### PR TITLE
agent/informant: Don't return from /suspend until NeonVM requests finished

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -967,6 +967,16 @@ func (r *Runner) updateVMResources(
 
 	r.logger.Infof("Updating VM resources: reason = %q", reason)
 
+	// A /suspend request from a VM informant will wait until requestLock returns. So we're good to
+	// make whatever requests we need as long as the informant is here at the start.
+	//
+	// The reason we care about the informant server being "enabled" is that the VM informant uses
+	// it to ensure that there's at most one autoscaler-agent that's making requests on its behalf.
+	if err := r.validateInformant(); err != nil {
+		r.logger.Warningf("Unable to update VM resources because informant server is disabled: %w", err)
+		return nil
+	}
+
 	// state variables
 	var (
 		target api.Resources
@@ -1311,17 +1321,8 @@ func (r *Runner) doVMUpdate(
 		r.vm.SetUsing(amount)
 	}
 
-	invalidInformantErr := func() error {
-		r.lock.Lock()
-		defer r.lock.Unlock()
-
-		if r.server == nil {
-			return errors.New("no informant server set")
-		}
-		return r.server.Valid()
-	}()
-	if invalidInformantErr != nil {
-		r.logger.Warningf("Aborting VM update because informant server is not valid: %w", invalidInformantErr)
+	if err := r.validateInformant(); err != nil {
+		r.logger.Warningf("Aborting VM update because informant server is not valid: %w", err)
 		resetVMTo(current)
 		return nil, nil
 	}
@@ -1425,6 +1426,24 @@ func (r *Runner) doVMUpdate(
 
 	// Everything successful.
 	return &target, nil
+}
+
+// validateInformant checks that the Runner's informant server is present AND active (i.e. not
+// suspended).
+//
+// If either condition is false, this method returns error. This is typically used to check that the
+// Runner is enabled before making a request to NeonVM or the scheduler, in which case holding
+// r.requestLock is advised.
+//
+// This method MUST NOT be called while holding r.lock.
+func (r *Runner) validateInformant() error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.server == nil {
+		return errors.New("no informant server set")
+	}
+	return r.server.Valid()
 }
 
 // doInformantDownscale is a convenience wrapper around (*InformantServer).Downscale that locks r,

--- a/pkg/informant/consts.go
+++ b/pkg/informant/consts.go
@@ -16,7 +16,7 @@ const (
 	AgentBackgroundCheckTimeout time.Duration = 250 * time.Millisecond
 
 	AgentResumeTimeout  time.Duration = 100 * time.Millisecond
-	AgentSuspendTimeout time.Duration = 200 * time.Millisecond
+	AgentSuspendTimeout time.Duration = 5 * time.Second        // may take a while; it /suspend intentionally waits
 	AgentUpscaleTimeout time.Duration = 400 * time.Millisecond // does not include waiting for /upscale response
 )
 


### PR DESCRIPTION
Without this, it's possible for the informant to allow multiple active agents at the same time - something we generally want to avoid

Note: this builds on #113.