### PR TITLE
api: Update "testing-only-always-migrate" label

### DIFF
--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	LabelTestingOnlyAlwaysMigrate = "autoscaler/testing-only-always-migrate"
+	LabelTestingOnlyAlwaysMigrate = "autoscaling.neon.tech/testing-only-always-migrate"
 	LabelEnableAutoscaling        = "autoscaling.neon.tech/enabled"
 	AnnotationAutoscalingBounds   = "autoscaling.neon.tech/bounds"
 )
@@ -23,6 +23,12 @@ const (
 func HasAutoscalingEnabled(obj metav1.ObjectMetaAccessor) bool {
 	labels := obj.GetObjectMeta().GetLabels()
 	value, ok := labels[LabelEnableAutoscaling]
+	return ok && value == "true"
+}
+
+func HasAlwaysMigrateLabel(obj metav1.ObjectMetaAccessor) bool {
+	labels := obj.GetObjectMeta().GetLabels()
+	value, ok := labels[LabelTestingOnlyAlwaysMigrate]
 	return ok && value == "true"
 }
 
@@ -96,8 +102,8 @@ func ExtractVmInfo(vm *vmapi.VirtualMachine) (*VmInfo, error) {
 		}
 	}
 
-	_, alwaysMigrate := vm.Labels[LabelTestingOnlyAlwaysMigrate]
 	scalingEnabled := HasAutoscalingEnabled(vm)
+	alwaysMigrate := HasAlwaysMigrateLabel(vm)
 
 	slotSize := vm.Spec.Guest.MemorySlotSize // explicitly copy slot size so we aren't keeping the VM object around
 	info := VmInfo{

--- a/vm-deploy.yaml
+++ b/vm-deploy.yaml
@@ -8,8 +8,8 @@ metadata:
     autoscaling.neon.tech/bounds: '{ "min": { "cpu": 1, "mem": "1Gi" }, "max": { "cpu": 4, "mem": "4Gi" } }'
   labels:
     autoscaling.neon.tech/enabled: "true"
-    # Uncomment the line below to continuously migrate the VM (TESTING ONLY)
-    # autoscaler/testing-only-always-migrate: ""
+    # Set to "true" to continuously migrate the VM (TESTING ONLY)
+    autoscaling.neon.tech/testing-only-always-migrate: "false"
 spec:
   schedulerName: autoscale-scheduler
   guest:


### PR DESCRIPTION
This commit changes the "enabled" state from

    autoscaler/testing-only-always-migrate: "*"

(where '*' stands in for any string, possibly empty) to

    autoscaling.neon.tech/testing-only-always-migrate: "true"

This matches the semantics for the "enabled" label, added by https://github.com/neondatabase/autoscaling/pull/38.