### PR TITLE
build: Use `git describe` instead of custom git_info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-GIT_INFO := $(shell source ./scripts-common.sh && git_info)
+GIT_INFO := $(git describe --long --dirty)
 
 .PHONY: all
 all: build

--- a/pkg/util/buildinfo.go
+++ b/pkg/util/buildinfo.go
@@ -7,8 +7,9 @@ import (
 )
 
 // BuildGitInfo stores some pretty-formatted information about the repository and working tree at
-// build time. It's set by the GIT_INFO argument in the Dockerfiles and generated with the git_info
-// function in 'scripts-common.sh'.
+// build time. It's set by the GIT_INFO argument in the Dockerfiles and set to the output of:
+//
+//	git describe --long --dirty
 //
 // While public, this value is not expected to be used externally. You should use GetBuildInfo
 // instead.

--- a/scripts-common.sh
+++ b/scripts-common.sh
@@ -17,30 +17,6 @@ require_root () {
     fi
 }
 
-# Usage: GIT_INFO="$(git_info)"
-#
-# Generates and outputs some information about the current git status. Normally we'd use Go's
-# built-in "version" buildinfo, but with git worktress + docker, the git information isn't available
-# without some extra help.
-git_info () {
-    diff="git diff --exit-code --name-only"
-
-    if $diff >/dev/null && $diff --staged >/dev/null; then
-        dirty=''
-    else
-        dirty='+dirty'
-    fi
-
-    # notes on formatting: the combination of TZ=UTC0 and --date=iso-local means that we'll output
-    # ISO 8601 (-ish) format, interpreting the timestamp as relative to UTC+0.
-    #
-    # Looks like: 7b66271+dirty (2022-12-23 17:20:49 +0000) - agent: Handle metrics more gracefully
-    TZ=UTC0 git show -s --format=format:"%h$dirty (%cd) - %s" --date=iso-local | \
-        # Passing through layers of quotes means that git commits including a quote won't be
-        # handled correctly 🤦. We're better off just removing them.
-        sed -e "s:'\|\"::g"
-}
-
 # Usage: VAR_NAME="$(get_var VAR_NAME DEFAULT_VALUE)"
 #
 # Helper function that


### PR DESCRIPTION
The number of issues we ran into with the previous approach made it not worthwhile. We may eventually provide more git information at build time, but it's best to keep it simple for the time being.

Resolves #16.