### PR TITLE
e2e workflow: handle failure when fetching logs/events

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -89,9 +89,9 @@ jobs:
             for pod in $pods; do
               echo "*** Namespace=$namespace Pod=$pod ***"
               echo "Logs:"
-              kubectl logs -n $namespace $pod
+              kubectl logs -n $namespace $pod || echo 'Error getting logs'
               echo "Events:"
-              kubectl get events --namespace $namespace --field-selector involvedObject.name=$pod
+              kubectl get events --namespace $namespace --field-selector involvedObject.name=$pod || echo 'Error getting events'
               echo ""
             done
           done


### PR DESCRIPTION
Should stop the "Get k8s logs and events" step from failing like this, I think:

```
*** Namespace=kuttl-test-eternal-drake Pod=workload ***
Logs:
Defaulted container "pgbench" out of: pgbench, wait-for-pg (init), pgbench-initialize (init)
Error from server (BadRequest): container "pgbench" in pod "workload" is waiting to start: PodInitializing
Error: Process completed with exit code 1.
```

https://github.com/neondatabase/autoscaling/actions/runs/4589958144/jobs/8105191759#step:12:4945