### PR TITLE
e2e: Build docker images before cluster init

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -64,11 +64,16 @@ jobs:
           VM_KERNEL_IMAGE: "neondatabase/vm-kernel"
           VM_KERNEL_VERSION: "5.15.80"
 
+      # Explicitly build all the images beforehand. Building images while the cluster is up can
+      # sometimes affect the cluster. For more information:
+      # https://github.com/neondatabase/autoscaling/issues/120#issuecomment-1493405844
+      - run: make docker-build
+      - run: make docker-build-examples
+
       - run: make local-cluster
 
       - run: make deploy
-
-      - run: make vm-example
+      - run: make example-vms
 
       - name: Run make e2e
         run: |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,17 @@ For more information, refer to [ARCHITECTURE.md](./ARCHITECTURE.md).
 
 ## Building and running
 
-Build everything:
+Build NeonVM Linux kernel (it takes time, can be run only once)
+
+```sh
+make kernel
+```
+
+Build docker images:
+
+```sh
+make docker-build
+```
 
 Start local [`kind`] cluster:
 
@@ -60,19 +70,13 @@ Start local [`kind`] cluster:
 make local-cluster
 ```
 
-Build NeonVM Linux kernel (it takes time, can be run only once)
-
-```sh
-make kernel
-```
-
-Build and deploy NeonVM and Autoscaling components
+Deploy NeonVM and Autoscaling components
 
 ```sh
 make deploy
 ```
 
-Build test VM:
+Build and load the test VM:
 
 ```sh
 make pg14-disk-test
@@ -122,7 +126,7 @@ You can either download them from their websites or install using Homebrew: `bre
 make local-cluster
 make kernel
 make deploy
-make vm-example
+make example-vms
 make e2e
 ```
 


### PR DESCRIPTION
AFAICT, some of the e2e flakiness might be partially resulting from system load after cluster start up, due to running vm-builder. I don't _actually_ know, though.

See also:
https://github.com/neondatabase/autoscaling/issues/120#issuecomment-1493405844

**Edit:** At first glance, it seems like this may allow the e2e tests to run faster. More investigation required, probably.