### PR TITLE
plugin/watch: Remove unnecessary error wrap

### DIFF
--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -57,9 +57,5 @@ func (e *AutoscaleEnforcer) watchPodDeletions(
 			},
 		},
 	)
-	if err != nil {
-		return fmt.Errorf("Error watching pod deletions: %w", err)
-	}
-
-	return nil
+	return err
 }

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -5,7 +5,6 @@ package plugin
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
The context for this error is already provided at the call-site. We don't need to duplicate that in the return itself as well.