### PR TITLE
util/watch: Allow watch bookmarks

### DIFF
--- a/pkg/util/watch.go
+++ b/pkg/util/watch.go
@@ -134,6 +134,10 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 		handlers.DeleteFunc = func(obj P, mayBeStale bool) {}
 	}
 
+	// Handling bookmarks means that sometimes the API server will be kind, allowing us to continue
+	// the watch instead of resyncing.
+	opts.AllowWatchBookmarks = true
+
 	// Perform an initial listing
 	initialList, err := client.List(ctx, opts)
 	if err != nil {


### PR DESCRIPTION
This isn't explicitly required for anything, but it's good to have. In theory, it should provide some efficiency gains when the API server sends us bookmark events instead of saying that the watch is too far out of date.