### PR TITLE
deploy/sched: Re-enable migration

### DIFF
--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -37,5 +37,5 @@ data:
         "port": 10298,
         "timeoutSeconds": 5
       },
-      "doMigration": false
+      "doMigration": true
     }


### PR DESCRIPTION
Follow-up to #112 that turns the feature on. Requires #104.