### PR TITLE
util/watch: Delete old objects before adding new ones

### DIFF
--- a/pkg/util/watch.go
+++ b/pkg/util/watch.go
@@ -374,19 +374,40 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 				relistItems := accessors.Items(relistList)
 
 				func() {
-					// First, copy the contents of objects into oldObjects. We do this so that we can
-					// uphold some guarantees about the contents of the store.
-					oldObjects := make(map[types.UID]*T)
-					for uid, obj := range store.objects {
-						oldObjects[uid] = obj
-					}
-
 					store.mutex.Lock()
 					defer store.mutex.Unlock()
+
+					// Copy the current contents of objects, and start tracking which ones have
+					// since been deleted.
+					oldObjects := make(map[types.UID]*T)
+					deleted := make(map[types.UID]bool)
+					for uid, obj := range store.objects {
+						oldObjects[uid] = obj
+						deleted[uid] = true // initially mark everything as deleted, until we find it isn't
+					}
+
+					// Mark all items we still have as not deleted
+					for i := range relistItems {
+						uid := P(&relistItems[i]).GetObjectMeta().GetUID()
+						delete(deleted, uid)
+					}
+
+					// Generate deletion events for all objects that are no longer present. We do
+					// this first so that when there's externally-enforced uniqueness that isn't
+					// unique *across time* (e.g. object names), users can still rely on uniqueness
+					// at any time that handlers are called.
+					for uid, obj := range oldObjects {
+						delete(store.objects, uid)
+						handlers.DeleteFunc(obj, true)
+					}
 
 					for i := range relistItems {
 						obj := &relistItems[i]
 						uid := P(obj).GetObjectMeta().GetUID()
+
+						if deleted[uid] {
+							continue // already processed above
+						}
 
 						store.objects[uid] = obj
 						oldObj, hasObj := oldObjects[uid]
@@ -397,13 +418,6 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 						} else {
 							handlers.AddFunc(obj, false)
 						}
-					}
-
-					// For everything that's still in oldObjects (i.e. wasn't covered by relistItems),
-					// generate deletion events:
-					for uid, obj := range oldObjects {
-						delete(store.objects, uid)
-						handlers.DeleteFunc(obj, true)
 					}
 				}()
 

--- a/pkg/util/watch.go
+++ b/pkg/util/watch.go
@@ -380,10 +380,10 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 					// Copy the current contents of objects, and start tracking which ones have
 					// since been deleted.
 					oldObjects := make(map[types.UID]*T)
-					deleted := make(map[types.UID]bool)
+					deleted := make(map[types.UID]struct{}) // set of UIDs that have been deleted
 					for uid, obj := range store.objects {
 						oldObjects[uid] = obj
-						deleted[uid] = true // initially mark everything as deleted, until we find it isn't
+						deleted[uid] = struct{}{} // initially mark everything as deleted, until we find it isn't
 					}
 
 					// Mark all items we still have as not deleted
@@ -405,7 +405,7 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 						obj := &relistItems[i]
 						uid := P(obj).GetObjectMeta().GetUID()
 
-						if deleted[uid] {
+						if _, deleted := deleted[uid]; deleted {
 							continue // already processed above
 						}
 

--- a/pkg/util/watch.go
+++ b/pkg/util/watch.go
@@ -396,7 +396,8 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 					// this first so that when there's externally-enforced uniqueness that isn't
 					// unique *across time* (e.g. object names), users can still rely on uniqueness
 					// at any time that handlers are called.
-					for uid, obj := range oldObjects {
+					for uid := range deleted {
+						obj := store.objects[uid]
 						delete(store.objects, uid)
 						handlers.DeleteFunc(obj, true)
 					}
@@ -404,10 +405,6 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 					for i := range relistItems {
 						obj := &relistItems[i]
 						uid := P(obj).GetObjectMeta().GetUID()
-
-						if _, deleted := deleted[uid]; deleted {
-							continue // already processed above
-						}
 
 						store.objects[uid] = obj
 						oldObj, hasObj := oldObjects[uid]

--- a/pkg/util/watch.go
+++ b/pkg/util/watch.go
@@ -411,7 +411,6 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 
 						if hasObj {
 							handlers.UpdateFunc(oldObj, obj)
-							delete(oldObjects, uid)
 						} else {
 							handlers.AddFunc(obj, false)
 						}


### PR DESCRIPTION
This commit fixes a problem with the relisting code, namely: Because we delete old objects *after* adding new ones, properties that are normally considered unique (e.g. a Pod's name) may be temporarily violated because they are not unique *across time*.

Required for the correctness of the API added in #135.