### PR TITLE
e2e: run k8s logs/events step if cluster exists

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -70,7 +70,9 @@ jobs:
       - run: make docker-build
       - run: make docker-build-examples
 
-      - run: make local-cluster
+      - name: make local-cluster
+        run: make local-cluster
+        id: make_local_cluster
 
       - run: make deploy
       - run: make example-vms
@@ -86,7 +88,7 @@ jobs:
           kubectl kuttl test --config tests/e2e/kuttl-test.yaml --skip-delete
 
       - name: Get k8s logs and events
-        if: failure()
+        if: steps.make_local_cluster.conclusion != skipped
         run: |
           namespaces=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
           for namespace in $namespaces; do

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -88,7 +88,7 @@ jobs:
           kubectl kuttl test --config tests/e2e/kuttl-test.yaml --skip-delete
 
       - name: Get k8s logs and events
-        if: steps.make_local_cluster.conclusion != 'skipped'
+        if: ${{ (failure() || cancelled()) && steps.make_local_cluster.conclusion != 'skipped' }}
         run: |
           namespaces=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
           for namespace in $namespaces; do

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -88,8 +88,12 @@ jobs:
           kubectl kuttl test --config tests/e2e/kuttl-test.yaml --skip-delete
 
       - name: Get k8s logs and events
-        if: ${{ (failure() || cancelled()) && steps.make_local_cluster.conclusion != 'skipped' }}
+        if: ${{ failure() || cancelled() }}
         run: |
+          if ! kubectl config current-context; then
+            echo "skipping cluster logs because no cluster found in kubectl context"
+            exit 0
+          fi
           namespaces=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
           for namespace in $namespaces; do
             pods=$(kubectl get pods -n $namespace -o jsonpath='{.items[*].metadata.name}')

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -88,7 +88,7 @@ jobs:
           kubectl kuttl test --config tests/e2e/kuttl-test.yaml --skip-delete
 
       - name: Get k8s logs and events
-        if: steps.make_local_cluster.conclusion != skipped
+        if: steps.make_local_cluster.conclusion != 'skipped'
         run: |
           namespaces=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
           for namespace in $namespaces; do


### PR DESCRIPTION
From the commit message:

> This makes some of the handling around the "Get k8s logs and events" step a little more precise. We want to run it on failure-ish so long as the cluster was created.
>
> To do so, this commit makes fetching the logs conditional on cluster creation *not being skipped* (in case cluster creation failed, or was cancelled).

I'm not _actually_ sure that this does what I'm expecting; my knowledge of github workflows is limited :sweat_smile: