### PR TITLE
rename e2e job: tests -> e2e-tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -11,7 +11,7 @@ on:
       - main
 
 jobs:
-  tests:
+  e2e-tests:
     runs-on: [ self-hosted, gen3, small ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Currently it conflicts (ish) with the go tests, so it's hard to tell at a glance in the github UI whether you're looking at e2e tests or unit tests.