### PR TITLE
neonvm: Remove VirtualMachineSpec.ServiceAccountName

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -44,12 +44,11 @@ type VirtualMachineSpec struct {
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds"`
 
-	NodeSelector       map[string]string           `json:"nodeSelector,omitempty"`
-	Affinity           *corev1.Affinity            `json:"affinity,omitempty"`
-	Tolerations        []corev1.Toleration         `json:"tolerations,omitempty"`
-	SchedulerName      string                      `json:"schedulerName,omitempty"`
-	ServiceAccountName string                      `json:"serviceAccountName,omitempty"`
-	PodResources       corev1.ResourceRequirements `json:"podResources,omitempty"`
+	NodeSelector  map[string]string           `json:"nodeSelector,omitempty"`
+	Affinity      *corev1.Affinity            `json:"affinity,omitempty"`
+	Tolerations   []corev1.Toleration         `json:"tolerations,omitempty"`
+	SchedulerName string                      `json:"schedulerName,omitempty"`
+	PodResources  corev1.ResourceRequirements `json:"podResources,omitempty"`
 
 	// +kubebuilder:default:=Never
 	// +optional

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -641,7 +641,6 @@ func podSpec(virtualmachine *vmv1.VirtualMachine) (*corev1.Pod, error) {
 			NodeSelector:                  virtualmachine.Spec.NodeSelector,
 			ImagePullSecrets:              virtualmachine.Spec.ImagePullSecrets,
 			Tolerations:                   virtualmachine.Spec.Tolerations,
-			ServiceAccountName:            virtualmachine.Spec.ServiceAccountName,
 			SchedulerName:                 virtualmachine.Spec.SchedulerName,
 			Affinity:                      affinity,
 			InitContainers: []corev1.Container{{


### PR DESCRIPTION
This was a holdover from when we needed to run each autoscaler-agent in a sidecar. Supporting sidecar containers only ever existed in a non-main branch, and so ServiceAccountName currently doesn't do anything visible within the VM.

Closes #103.

See also: https://github.com/neondatabase/neonvm/pull/15.