### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# "intermediate commit: de-indent some blocks (#113)" - factored out of #113 to make blame clear.
+480e9cc9534b49204d7e5bbd06fbc454c96e6c9e

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
+# "style: function formatting (#46)" - changes formatting of function params, exculsively from
+# single-line to multi-line
+f8fb06a1565599c3d44a1951c7a50b6c065cdb96
 # "intermediate commit: de-indent some blocks (#113)" - factored out of #113 to make blame clear.
 480e9cc9534b49204d7e5bbd06fbc454c96e6c9e


### PR DESCRIPTION
This allows us to filter out commits from `git blame`, which should make it clearer after refactorings that are sufficiently broken up :)

To enable locally, run

    git config --add blame.ignoreRevsFile .git-blame-ignore-revs

For info on Github's handling, see:
https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

(this is a follow-up to #113)

**Edit:** The blame is a bit [funky in some places](https://github.com/neondatabase/autoscaling/blame/41cc47ff45dde4afba135db790be1c0ce4143c14/pkg/agent/runner.go#L1005-L1016), but I still think this is _probably_ a net win.