### PR TITLE
e2e workflow: Check kind exists before delete cluster

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -111,4 +111,6 @@ jobs:
         if: always()
         run: |
           # check that kind exists before trying to delete the cluster. Avoids spurious errors
-          which kind 2>/dev/null >/dev/null && kind delete cluster
+          if which kind 2>/dev/null >/dev/null; then
+            kind delete cluster
+          fi

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -110,4 +110,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          kind delete cluster
+          # check that kind exists before trying to delete the cluster. Avoids spurious errors
+          kind version 2>&1 >/dev/null && kind delete cluster

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -111,4 +111,4 @@ jobs:
         if: always()
         run: |
           # check that kind exists before trying to delete the cluster. Avoids spurious errors
-          kind version 2>&1 >/dev/null && kind delete cluster
+          which kind 2>/dev/null >/dev/null && kind delete cluster


### PR DESCRIPTION
The step fails here for example, because the workflow was cancelled before the cluster was created:
https://github.com/neondatabase/autoscaling/actions/runs/4631573330/jobs/8194589481

Edit: did some futzing around with cancelling, seems to be working as expected.