### PR TITLE
Add util.NamespacedName to replace api.PodName

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -26,7 +26,7 @@ import (
 type agentState struct {
 	// lock guards access to pods
 	lock util.ChanMutex
-	pods map[api.PodName]*podState
+	pods map[util.NamespacedName]*podState
 
 	podIP                string
 	config               *Config
@@ -39,7 +39,7 @@ type agentState struct {
 func (r MainRunner) newAgentState(podIP string, broker *pubsub.Broker[watchEvent], schedulerStore *util.WatchStore[corev1.Pod]) agentState {
 	return agentState{
 		lock:                 util.NewChanMutex(),
-		pods:                 make(map[api.PodName]*podState),
+		pods:                 make(map[util.NamespacedName]*podState),
 		config:               r.Config,
 		kubeClient:           r.KubeClient,
 		vmClient:             r.VMClient,
@@ -74,7 +74,7 @@ func (s *agentState) handleEvent(ctx context.Context, event vmEvent) {
 	}
 	defer s.lock.Unlock()
 
-	podName := api.PodName{Namespace: event.vmInfo.Namespace, Name: event.podName}
+	podName := util.NamespacedName{Namespace: event.vmInfo.Namespace, Name: event.podName}
 	state, hasPod := s.pods[podName]
 
 	switch event.kind {
@@ -142,7 +142,7 @@ func (s *agentState) handleEvent(ctx context.Context, event vmEvent) {
 }
 
 type podState struct {
-	podName api.PodName
+	podName util.NamespacedName
 
 	stop   context.CancelFunc
 	runner *Runner
@@ -150,10 +150,10 @@ type podState struct {
 }
 
 type podStateDump struct {
-	PodName         api.PodName   `json:"podName"`
-	Status          podStatusDump `json:"status"`
-	Runner          *RunnerState  `json:"runner,omitempty"`
-	CollectionError error         `json:"collectionError,omitempty"`
+	PodName         util.NamespacedName `json:"podName"`
+	Status          podStatusDump       `json:"status"`
+	Runner          *RunnerState        `json:"runner,omitempty"`
+	CollectionError error               `json:"collectionError,omitempty"`
 }
 
 func (p *podState) dump(ctx context.Context) podStateDump {

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -92,7 +92,7 @@ type Runner struct {
 	//
 	// This field MUST NOT be read or updated without holding lock.
 	vm      api.VmInfo
-	podName api.PodName
+	podName util.NamespacedName
 	podIP   string
 
 	// schedulerRespondedWithMigration is true iff the scheduler has returned an api.PluginResponse

--- a/pkg/agent/sched.go
+++ b/pkg/agent/sched.go
@@ -14,19 +14,18 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
 type schedulerInfo struct {
-	PodName api.PodName
+	PodName util.NamespacedName
 	UID     types.UID
 	IP      string
 }
 
 func newSchedulerInfo(pod *corev1.Pod) schedulerInfo {
 	return schedulerInfo{
-		PodName: api.PodName{Name: pod.Name, Namespace: pod.Namespace},
+		PodName: util.NamespacedName{Name: pod.Name, Namespace: pod.Namespace},
 		UID:     pod.UID,
 		IP:      pod.Status.PodIP,
 	}
@@ -111,7 +110,7 @@ func startSchedulerWatcher(
 		metav1.ListOptions{LabelSelector: schedulerLabelSelector(schedulerName)},
 		util.WatchHandlerFuncs[*corev1.Pod]{
 			AddFunc: func(pod *corev1.Pod, preexisting bool) {
-				podName := api.PodName{Name: pod.Name, Namespace: pod.Namespace}
+				podName := util.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 				if util.PodReady(pod) {
 					if pod.Status.PodIP == "" {
 						logger.Errorf("Pod %v is ready but has no IP", podName)
@@ -122,8 +121,8 @@ func startSchedulerWatcher(
 				}
 			},
 			UpdateFunc: func(oldPod, newPod *corev1.Pod) {
-				oldPodName := api.PodName{Name: oldPod.Name, Namespace: oldPod.Namespace}
-				newPodName := api.PodName{Name: newPod.Name, Namespace: newPod.Namespace}
+				oldPodName := util.NamespacedName{Name: oldPod.Name, Namespace: oldPod.Namespace}
+				newPodName := util.NamespacedName{Name: newPod.Name, Namespace: newPod.Namespace}
 
 				if oldPod.Name != newPod.Name || oldPod.Namespace != newPod.Namespace {
 					logger.Errorf(

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -11,18 +11,7 @@ import (
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
-// PodName represents the namespaced name of a pod
-//
-// Some analogous types already exist elsewhere (e.g., in the kubernetes API packages), but they
-// don't provide satisfactory JSON marshal/unmarshalling.
-type PodName struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-}
-
-func (n PodName) String() string {
-	return fmt.Sprintf("%s:%s", n.Namespace, n.Name)
-}
+type PodName = util.NamespacedName
 
 /////////////////////////////////
 // (Autoscaler) Agent Messages //

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -11,8 +11,6 @@ import (
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
-type PodName = util.NamespacedName
-
 /////////////////////////////////
 // (Autoscaler) Agent Messages //
 /////////////////////////////////
@@ -90,7 +88,7 @@ type AgentRequest struct {
 	// If the scheduler does not support this version, then it will respond with a 400 status.
 	ProtoVersion PluginProtoVersion `json:"protoVersion"`
 	// Pod is the namespaced name of the pod making the request
-	Pod PodName `json:"pod"`
+	Pod util.NamespacedName `json:"pod"`
 	// Resources gives a requested or notified change in resources allocated to the VM.
 	//
 	// The requested amount MAY be equal to the current amount, in which case it serves as a

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -110,25 +110,25 @@ type pluginStateDump struct {
 }
 
 type podNameAndPointer struct {
-	Obj     pointerString `json:"obj"`
-	PodName api.PodName   `json:"podName"`
+	Obj     pointerString       `json:"obj"`
+	PodName util.NamespacedName `json:"podName"`
 }
 
 type pointerString string
 
 type nodeStateDump struct {
-	Obj       pointerString                           `json:"obj"`
-	Name      string                                  `json:"name"`
-	VCPU      nodeResourceState[uint16]               `json:"vCPU"`
-	MemSlots  nodeResourceState[uint16]               `json:"memSlots"`
-	Pods      []keyed[api.PodName, podStateDump]      `json:"pods"`
-	OtherPods []keyed[api.PodName, otherPodStateDump] `json:"otherPods"`
-	Mq        []*podNameAndPointer                    `json:"mq"`
+	Obj       pointerString                                   `json:"obj"`
+	Name      string                                          `json:"name"`
+	VCPU      nodeResourceState[uint16]                       `json:"vCPU"`
+	MemSlots  nodeResourceState[uint16]                       `json:"memSlots"`
+	Pods      []keyed[util.NamespacedName, podStateDump]      `json:"pods"`
+	OtherPods []keyed[util.NamespacedName, otherPodStateDump] `json:"otherPods"`
+	Mq        []*podNameAndPointer                            `json:"mq"`
 }
 
 type podStateDump struct {
 	Obj                      pointerString            `json:"obj"`
-	Name                     api.PodName              `json:"name"`
+	Name                     util.NamespacedName      `json:"name"`
 	VMName                   string                   `json:"vmName"`
 	Node                     pointerString            `json:"node"`
 	TestingOnlyAlwaysMigrate bool                     `json:"testingOnlyAlwaysMigrate"`
@@ -152,7 +152,7 @@ func makePointerString[T any](t *T) pointerString {
 	return pointerString(fmt.Sprintf("%p", t))
 }
 
-func sortSliceByPodName[T any](slice []T, name func(T) api.PodName) {
+func sortSliceByPodName[T any](slice []T, name func(T) util.NamespacedName) {
 	slices.SortFunc(slice, func(a, b T) (less bool) {
 		aName := name(a)
 		bName := name(b)
@@ -170,13 +170,13 @@ func (s *pluginState) dump(ctx context.Context) (*pluginStateDump, error) {
 	for _, p := range s.podMap {
 		vmPods = append(vmPods, podNameAndPointer{Obj: makePointerString(p), PodName: p.name})
 	}
-	sortSliceByPodName(vmPods, func(p podNameAndPointer) api.PodName { return p.PodName })
+	sortSliceByPodName(vmPods, func(p podNameAndPointer) util.NamespacedName { return p.PodName })
 
 	otherPods := make([]podNameAndPointer, 0, len(s.otherPods))
 	for _, p := range s.otherPods {
 		otherPods = append(otherPods, podNameAndPointer{Obj: makePointerString(p), PodName: p.name})
 	}
-	sortSliceByPodName(otherPods, func(p podNameAndPointer) api.PodName { return p.PodName })
+	sortSliceByPodName(otherPods, func(p podNameAndPointer) util.NamespacedName { return p.PodName })
 
 	nodes := make([]keyed[string, nodeStateDump], 0, len(s.nodeMap))
 	for k, n := range s.nodeMap {
@@ -197,17 +197,17 @@ func (s *pluginState) dump(ctx context.Context) (*pluginStateDump, error) {
 }
 
 func (s *nodeState) dump() nodeStateDump {
-	pods := make([]keyed[api.PodName, podStateDump], 0, len(s.pods))
+	pods := make([]keyed[util.NamespacedName, podStateDump], 0, len(s.pods))
 	for k, p := range s.pods {
-		pods = append(pods, keyed[api.PodName, podStateDump]{Key: k, Value: p.dump()})
+		pods = append(pods, keyed[util.NamespacedName, podStateDump]{Key: k, Value: p.dump()})
 	}
-	sortSliceByPodName(pods, func(kv keyed[api.PodName, podStateDump]) api.PodName { return kv.Key })
+	sortSliceByPodName(pods, func(kv keyed[util.NamespacedName, podStateDump]) util.NamespacedName { return kv.Key })
 
-	otherPods := make([]keyed[api.PodName, otherPodStateDump], 0, len(s.otherPods))
+	otherPods := make([]keyed[util.NamespacedName, otherPodStateDump], 0, len(s.otherPods))
 	for k, p := range s.otherPods {
-		otherPods = append(otherPods, keyed[api.PodName, otherPodStateDump]{Key: k, Value: p.dump()})
+		otherPods = append(otherPods, keyed[util.NamespacedName, otherPodStateDump]{Key: k, Value: p.dump()})
 	}
-	sortSliceByPodName(otherPods, func(kv keyed[api.PodName, otherPodStateDump]) api.PodName { return kv.Key })
+	sortSliceByPodName(otherPods, func(kv keyed[util.NamespacedName, otherPodStateDump]) util.NamespacedName { return kv.Key })
 
 	mq := make([]*podNameAndPointer, 0, len(s.mq))
 	for _, p := range s.mq {

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -28,11 +28,11 @@ import (
 type pluginState struct {
 	lock util.ChanMutex
 
-	podMap  map[api.PodName]*podState
+	podMap  map[util.NamespacedName]*podState
 	nodeMap map[string]*nodeState
 
 	// otherPods stores information about non-VM pods
-	otherPods map[api.PodName]*otherPodState
+	otherPods map[util.NamespacedName]*otherPodState
 
 	// maxTotalReservableCPU stores the maximum value of any node's totalReservableCPU(), so that we
 	// can appropriately scale our scoring
@@ -62,10 +62,10 @@ type nodeState struct {
 	//
 	// This includes both bound pods (i.e., pods fully committed to the node) and reserved pods
 	// (still may be unreserved)
-	pods map[api.PodName]*podState
+	pods map[util.NamespacedName]*podState
 
 	// otherPods are the non-VM pods that we're also tracking in this node
-	otherPods map[api.PodName]*otherPodState
+	otherPods map[util.NamespacedName]*otherPodState
 	// otherResources is the sum resource usage associated with the non-VM pods
 	otherResources nodeOtherResourceState
 
@@ -146,7 +146,7 @@ type podState struct {
 	// name is the namespace'd name of the pod
 	//
 	// name will not change after initialization, so it can be accessed without holding a lock.
-	name api.PodName
+	name util.NamespacedName
 
 	// vmName is the name of the VM, as given by the 'vm.neon.tech/name' label.
 	vmName string
@@ -206,7 +206,7 @@ type podResourceState[T any] struct {
 
 // otherPodState tracks a little bit of information for the non-VM pods we're handling
 type otherPodState struct {
-	name      api.PodName
+	name      util.NamespacedName
 	node      *nodeState
 	resources podOtherResourceState
 }
@@ -521,8 +521,8 @@ func buildInitialNodeState(node *corev1.Node, conf *Config) (*nodeState, error) 
 		name:      node.Name,
 		vCPU:      vCPU,
 		memSlots:  memSlots,
-		pods:      make(map[api.PodName]*podState),
-		otherPods: make(map[api.PodName]*otherPodState),
+		pods:      make(map[util.NamespacedName]*podState),
+		otherPods: make(map[util.NamespacedName]*otherPodState),
 		otherResources: nodeOtherResourceState{
 			RawCPU:           resource.Quantity{},
 			RawMemory:        resource.Quantity{},
@@ -585,7 +585,7 @@ func extractPodOtherPodResourceState(pod *corev1.Pod) (podOtherResourceState, er
 
 // This method is /basically/ the same as e.Unreserve, but the API is different and it has different
 // logs, so IMO it's worthwhile to have this separate.
-func (e *AutoscaleEnforcer) handleVMDeletion(podName api.PodName) {
+func (e *AutoscaleEnforcer) handleVMDeletion(podName util.NamespacedName) {
 	klog.Infof("[autoscale-enforcer] Handling deletion of VM pod %v", podName)
 
 	e.state.lock.Lock()
@@ -621,7 +621,7 @@ func (e *AutoscaleEnforcer) handleVMDeletion(podName api.PodName) {
 	klog.Infof(fmtString, migrating, pod.name, pod.node.name, vCPUVerdict, memVerdict)
 }
 
-func (e *AutoscaleEnforcer) handlePodDeletion(podName api.PodName) {
+func (e *AutoscaleEnforcer) handlePodDeletion(podName util.NamespacedName) {
 	klog.Infof("[autoscale-enforcer] Handling deletion of non-VM pod %v", podName)
 
 	e.state.lock.Lock()
@@ -752,8 +752,8 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context) error {
 	}
 
 	p.state.nodeMap = make(map[string]*nodeState)
-	p.state.podMap = make(map[api.PodName]*podState)
-	p.state.otherPods = make(map[api.PodName]*otherPodState)
+	p.state.podMap = make(map[util.NamespacedName]*podState)
+	p.state.otherPods = make(map[util.NamespacedName]*otherPodState)
 
 	// Build the node map
 	klog.Infof("[autoscale-enforcer] load state: Building node map")
@@ -778,10 +778,10 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context) error {
 
 	// Store the PodSpecs by name, so we can access them as we're going through VMs
 	klog.Infof("[autoscale-enforcer] load state: Building initial PodSpecs map")
-	podSpecs := make(map[api.PodName]*corev1.Pod)
+	podSpecs := make(map[util.NamespacedName]*corev1.Pod)
 	for i := range pods.Items {
 		p := &pods.Items[i]
-		name := api.PodName{Name: p.Name, Namespace: p.Namespace}
+		name := util.NamespacedName{Name: p.Name, Namespace: p.Namespace}
 		podSpecs[name] = p
 	}
 
@@ -790,7 +790,7 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context) error {
 	skippedVms := 0
 	for i := range vms.Items {
 		vm := &vms.Items[i]
-		vmName := api.PodName{Name: vm.Name, Namespace: vm.Namespace}
+		vmName := util.NamespacedName{Name: vm.Name, Namespace: vm.Namespace}
 		if vm.Spec.SchedulerName != p.state.conf.SchedulerName {
 			klog.Infof(
 				"[autoscale-enforcer] load state: Skipping VM %v, Spec.SchedulerName %q != our config.SchedulerName %q",
@@ -807,7 +807,7 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context) error {
 			continue
 		}
 
-		podName := api.PodName{Name: vm.Status.PodName, Namespace: vm.Namespace}
+		podName := util.NamespacedName{Name: vm.Status.PodName, Namespace: vm.Namespace}
 		pod, ok := podSpecs[podName]
 		if !ok {
 			klog.Warningf(
@@ -909,7 +909,7 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context) error {
 	skippedOtherPods := 0
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		podName := api.PodName{Name: pod.Name, Namespace: pod.Namespace}
+		podName := util.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 		if pod.Spec.SchedulerName != p.state.conf.SchedulerName {
 			klog.Infof(
 				"[autoscale-enforcer] load state: Skipping non-VM pod %v, Spec.SchedulerName %q != our config.SchedulerName %q",

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klog "k8s.io/klog/v2"
 
-	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
@@ -25,8 +24,8 @@ import (
 // Events occurring before this method is called will not be sent.
 func (e *AutoscaleEnforcer) watchPodDeletions(
 	ctx context.Context,
-	vmDeletions chan<- api.PodName,
-	podDeletions chan<- api.PodName,
+	vmDeletions chan<- util.NamespacedName,
+	podDeletions chan<- util.NamespacedName,
 ) error {
 	_, err := util.Watch(
 		ctx,
@@ -46,7 +45,7 @@ func (e *AutoscaleEnforcer) watchPodDeletions(
 		metav1.ListOptions{},
 		util.WatchHandlerFuncs[*corev1.Pod]{
 			DeleteFunc: func(pod *corev1.Pod, mayBeStale bool) {
-				name := api.PodName{Name: pod.Name, Namespace: pod.Namespace}
+				name := util.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 				klog.Infof("[autoscale-enforcer] watch: Received delete event for pod %v", name)
 				if _, ok := pod.Labels[LabelVM]; ok {
 					vmDeletions <- name

--- a/pkg/util/namespacedname.go
+++ b/pkg/util/namespacedname.go
@@ -1,0 +1,41 @@
+package util
+
+// same as k8s.io/apimachinery/pkg/types/namespacedname.go, but with JSON (de)serialization
+
+import (
+	"fmt"
+)
+
+// FIXME: K8s uses '/' as its separator. We currently use this for backwards-compatibility, but we
+// should change to '/'. That change will involve fixing the many places where we create strings
+// with %s:%s instead of %s/%s as well; those should just use NamespacedName directly.
+const Separator = ':'
+
+// NamespacedName represents a resource name with the namespace it's in.
+//
+// When printed with '%s' or '%v', NamespacedName is rendered as "<namespace>:<name>". Printing with
+// '%+v' or '%#v' renders as it would normally.
+type NamespacedName struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+func (n NamespacedName) Format(state fmt.State, verb rune) {
+	switch {
+	case verb == 'v' && state.Flag('+'):
+		// Show fields, e.g. `{Namespace:foo Name:bar}`
+		_, _ = state.Write([]byte(string("{Namespace:")))
+		_, _ = state.Write([]byte(n.Namespace))
+		_, _ = state.Write([]byte(string(" Name:")))
+		_, _ = state.Write([]byte(n.Name))
+		_, _ = state.Write([]byte{'}'})
+	case verb == 'v' && state.Flag('#'):
+		// Go syntax representation, e.g. `util.NamespacedName{Namespace:"foo", Name:"bar"}`
+		_, _ = state.Write([]byte(fmt.Sprintf("util.NamespacedName{Namespace:%q, Name:%q}", n.Namespace, n.Name)))
+	default:
+		// Pretty-printed representation, e.g. `foo:bar`
+		_, _ = state.Write([]byte(n.Namespace))
+		_, _ = state.Write([]byte(string(Separator)))
+		_, _ = state.Write([]byte(n.Name))
+	}
+}

--- a/pkg/util/namespacedname_test.go
+++ b/pkg/util/namespacedname_test.go
@@ -1,0 +1,29 @@
+package util_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/neondatabase/autoscaling/pkg/util"
+)
+
+func TestFormatting(t *testing.T) {
+	base := util.NamespacedName{Namespace: "foo", Name: "bar"}
+	cases := []struct {
+		name     string
+		expected string
+		got      string
+	}{
+		{"sprint", "foo:bar", fmt.Sprint(base)},
+		{"sprintf-%s", "foo:bar", fmt.Sprintf("%s", base)},
+		{"sprintf-%v", "foo:bar", fmt.Sprintf("%v", base)},
+		{"sprintf-%+v", `{Namespace:foo Name:bar}`, fmt.Sprintf("%+v", base)},
+		{"sprintf-%#v", `util.NamespacedName{Namespace:"foo", Name:"bar"}`, fmt.Sprintf("%#v", base)},
+	}
+
+	for _, c := range cases {
+		if c.got != c.expected {
+			t.Errorf("%s: expected %q but got %q", c.name, c.expected, c.got)
+		}
+	}
+}


### PR DESCRIPTION
Having an `api.PodName`-equivalent available in util is required for #135. This PR bundles that with some cleanup of the name itself, which I'd been wanting to do for a while.

More justification from the 1st commit message:

> Defining this functionality in pkg/api means it can't be used in pkg/util, because api depends on util. https://github.com/neondatabase/autoscaling/pull/135 requires it in util.
>
> It's also worth making the name more generic, because it's not just pods that we want to handle namespaced names for.

Plan is to add the second commit to .git-blame-ignore-revs after merging.

---

**Suggestion for reviewing**: I'd probably just look at the first commit. The second _does_ have a couple changes that aren't just search-and-replace, but those are the actual deletion of `api.PodName` plus getting rid of unused imports.