### PR TITLE
fix GIT_INFO in CI

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: [ self-hosted, gen3, small ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # fetch all, so that we also include tags
 
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -64,6 +64,8 @@ jobs:
           VM_KERNEL_IMAGE: "neondatabase/vm-kernel"
           VM_KERNEL_VERSION: "5.15.80"
 
+      - run: git describe --long --dirty
+
       # Explicitly build all the images beforehand. Building images while the cluster is up can
       # sometimes affect the cluster. For more information:
       # https://github.com/neondatabase/autoscaling/issues/120#issuecomment-1493405844

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -66,6 +66,7 @@ jobs:
           VM_KERNEL_IMAGE: "neondatabase/vm-kernel"
           VM_KERNEL_VERSION: "5.15.80"
 
+      # our docker builds use the output of 'git describe' for embedding git information
       - run: git describe --long --dirty
 
       # Explicitly build all the images beforehand. Building images while the cluster is up can


### PR DESCRIPTION
Currently because our git checkout is shallow, running `git describe` fails because there's no tags. It'd be good to have "proper" git info in our e2e builds - this does require a non-shallow clone though, AFAICT.