### PR TITLE
e2e tests: do not skip cleanup

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -70,22 +70,12 @@ jobs:
       - run: make docker-build
       - run: make docker-build-examples
 
-      - name: make local-cluster
-        run: make local-cluster
-        id: make_local_cluster
+      - run: make local-cluster
 
       - run: make deploy
       - run: make example-vms
 
-      - name: Run make e2e
-        run: |
-          # Increase inotify limits for dnsmasq to fix
-          #   "dnsmasq: failed to create inotify: No file descriptors available"
-          sudo sysctl fs.inotify.max_user_instances=8192
-          sudo sysctl fs.inotify.max_user_watches=524288
-          sudo sysctl -p
-
-          kubectl kuttl test --config tests/e2e/kuttl-test.yaml --skip-delete
+      - run: make e2e
 
       - name: Get k8s logs and events
         if: ${{ failure() || cancelled() }}


### PR DESCRIPTION
I suspect `--skip-delete` flag could be the cause of `vm-migration` test flakiness (https://github.com/neondatabase/autoscaling/issues/120).
`--skip-delete` prevents namespaces (with pods) from being deleted after the test, so it means for the second test (`vm-migration`) we have a pod from the first test (`autoscaling`).
