### PR TITLE
api: Use better formatting for VmInfo

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -859,7 +859,7 @@ func (s *InformantServer) Downscale(ctx context.Context, to api.Resources) (*api
 	s.runner.logger.Infof("Sending downscale %+v", to)
 
 	timeout := time.Second * time.Duration(s.runner.global.config.Informant.DownscaleTimeoutSeconds)
-	rawResources := to.ConvertToRaw(&s.runner.vm.Mem.SlotSize)
+	rawResources := to.ConvertToRaw(s.runner.vm.Mem.SlotSize)
 
 	resp, statusCode, err := doInformantRequest[api.RawResources, api.DownscaleResult](
 		ctx, s, timeout, http.MethodPut, "/downscale", &rawResources,
@@ -901,7 +901,7 @@ func (s *InformantServer) Upscale(ctx context.Context, to api.Resources) error {
 	s.runner.logger.Infof("Sending upscale %+v", to)
 
 	timeout := time.Second * time.Duration(s.runner.global.config.Informant.DownscaleTimeoutSeconds)
-	rawResources := to.ConvertToRaw(&s.runner.vm.Mem.SlotSize)
+	rawResources := to.ConvertToRaw(s.runner.vm.Mem.SlotSize)
 
 	_, statusCode, err := doInformantRequest[api.RawResources, struct{}](
 		ctx, s, timeout, http.MethodPut, "/upscale", &rawResources,

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -532,7 +532,7 @@ func (r *Runner) handleVMResources(
 				r.lock.Lock()
 				defer r.lock.Unlock()
 
-				if r.vm.Mem.SlotSize.Cmp(newVMInfo.Mem.SlotSize) != 0 {
+				if r.vm.Mem.SlotSize.Cmp(*newVMInfo.Mem.SlotSize) != 0 {
 					// VM memory slot sizes can't change at runtime, at time of writing (2023-04-12).
 					// It's worth checking it here though, because something must have gone horribly
 					// wrong elsewhere for the memory slots size to change that it's worth aborting

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -128,7 +128,7 @@ func ExtractVmInfo(vm *vmapi.VirtualMachine) (*VmInfo, error) {
 			return nil, fmt.Errorf("Error unmarshaling annotation %q: %w", AnnotationAutoscalingBounds, err)
 		}
 
-		if err := bounds.validate(&info.Mem.SlotSize); err != nil {
+		if err := bounds.validate(info.Mem.SlotSize); err != nil {
 			return nil, fmt.Errorf("Bad scaling bounds in annotation %q: %w", AnnotationAutoscalingBounds, err)
 		}
 		info.applyBounds(bounds)

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -220,11 +220,10 @@ func (b resourceBound) validate(memSlotSize *resource.Quantity) (field string, _
 func (vm VmInfo) Format(state fmt.State, verb rune) {
 	switch {
 	case verb == 'v' && state.Flag('#'):
-		state.Write([]byte(fmt.Sprintf("api.VmInfo{Name:%q, Namespace:%q, Cpu:", vm.Name, vm.Namespace)))
-		vm.Cpu.format(state, verb)
-		state.Write([]byte(", Mem:"))
-		vm.Mem.format(state, verb)
-		state.Write([]byte(fmt.Sprintf(", AlwaysMigrate:%t, ScalingEnabled:%t}", vm.AlwaysMigrate, vm.ScalingEnabled)))
+		state.Write([]byte(fmt.Sprintf(
+			"api.VmInfo{Name:%q, Namespace:%q, Cpu:%#v, Mem:%#v, AlwaysMigrate:%t, ScalingEnabled:%t}",
+			vm.Name, vm.Namespace, vm.Cpu, vm.Mem, vm.AlwaysMigrate, vm.ScalingEnabled,
+		)))
 	default:
 		if verb != 'v' {
 			state.Write([]byte("%!"))
@@ -232,11 +231,10 @@ func (vm VmInfo) Format(state fmt.State, verb rune) {
 			state.Write([]byte("(api.VmInfo="))
 		}
 
-		state.Write([]byte(fmt.Sprintf("{Name:%s Namespace:%s Cpu:", vm.Name, vm.Namespace)))
-		vm.Cpu.format(state, verb)
-		state.Write([]byte(" Mem:"))
-		vm.Mem.format(state, verb)
-		state.Write([]byte(fmt.Sprintf(" AlwaysMigrate:%t ScalingEnabled:%t}", vm.AlwaysMigrate, vm.ScalingEnabled)))
+		state.Write([]byte(fmt.Sprintf(
+			"{Name:%s Namespace:%s Cpu:%v Mem:%v AlwaysMigrate:%t ScalingEnabled:%t}",
+			vm.Name, vm.Namespace, vm.Cpu, vm.Mem, vm.AlwaysMigrate, vm.ScalingEnabled,
+		)))
 
 		if verb != 'v' {
 			state.Write([]byte{')'})
@@ -244,7 +242,7 @@ func (vm VmInfo) Format(state fmt.State, verb rune) {
 	}
 }
 
-func (cpu VmCpuInfo) format(state fmt.State, verb rune) {
+func (cpu VmCpuInfo) Format(state fmt.State, verb rune) {
 	// same-ish style as for VmInfo, differing slightly from default repr.
 	switch {
 	case verb == 'v' && state.Flag('#'):
@@ -254,7 +252,7 @@ func (cpu VmCpuInfo) format(state fmt.State, verb rune) {
 	}
 }
 
-func (mem VmMemInfo) format(state fmt.State, verb rune) {
+func (mem VmMemInfo) Format(state fmt.State, verb rune) {
 	// same-ish style as for VmInfo, differing slightly from default repr.
 	switch {
 	case verb == 'v' && state.Flag('#'):

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -214,7 +214,7 @@ func (b resourceBound) validate(memSlotSize *resource.Quantity) (field string, _
 }
 
 // the reason we have custom formatting for VmInfo is because without it, the formatting of memory
-// slot size (which is a resource.Quanitty) has all the fields, meaning (a) it's hard to read, and
+// slot size (which is a resource.Quantity) has all the fields, meaning (a) it's hard to read, and
 // (b) there's a lot of unnecessary information. But in order to enable "proper" formatting given a
 // VmInfo, we have to implement Format from the top down, so we do.
 func (vm VmInfo) Format(state fmt.State, verb rune) {

--- a/pkg/api/vminfo_test.go
+++ b/pkg/api/vminfo_test.go
@@ -1,0 +1,51 @@
+package api_test
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/neondatabase/autoscaling/pkg/api"
+)
+
+func TestFormatting(t *testing.T) {
+	slotSize := resource.MustParse("1Gi")
+	base := any(api.VmInfo{
+		Name:      "foo",
+		Namespace: "bar",
+		Cpu: api.VmCpuInfo{
+			Min: 1,
+			Max: 5,
+			Use: 3,
+		},
+		Mem: api.VmMemInfo{
+			Min:      2,
+			Max:      6,
+			Use:      4,
+			SlotSize: &slotSize,
+		},
+		AlwaysMigrate:  false,
+		ScalingEnabled: true,
+	})
+	defaultFormat := "{Name:foo Namespace:bar Cpu:{Min:1 Max:5 Use:3} Mem:{Min:2 Max:6 Use:4 SlotSize:1Gi} AlwaysMigrate:false ScalingEnabled:true}"
+	goSyntaxRepr := `api.VmInfo{Name:"foo", Namespace:"bar", Cpu:api.VmCpuInfo{Min:1, Max:5, Use:3}, Mem:api.VmMemInfo{Min:2, Max:6, Use:4, SlotSize:&resource.Quantity{i:resource.int64Amount{value:1073741824, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1Gi", Format:"BinarySI"}}, AlwaysMigrate:false, ScalingEnabled:true}`
+	cases := []struct {
+		name     string
+		expected string
+		got      string
+	}{
+		{"sprint", defaultFormat, fmt.Sprint(base)},
+		{"sprintf-%v", defaultFormat, fmt.Sprintf("%v", base)},
+		{"sprintf-%+v", defaultFormat, fmt.Sprintf("%+v", base)},
+		{"sprintf-%#v", goSyntaxRepr, fmt.Sprintf("%#v", base)},
+		{"sprintf-%q", fmt.Sprintf("%%!q(api.VmInfo=%s)", defaultFormat), fmt.Sprintf("%q", base)},
+		//                          ^^ actually '%!q(api.VmInfo=...)'
+	}
+
+	for _, c := range cases {
+		if c.got != c.expected {
+			t.Errorf("%s: expected %q but got %q", c.name, c.expected, c.got)
+		}
+	}
+}


### PR DESCRIPTION
The reason this is useful is because `VmInfo` contains a k8s `resource.Quantity`, and the default formatting shows all the fields (instead of the more useful pretty-printing that it _could_ do). Basically: it makes the logs cleaner.