### PR TITLE
agent: fix runner log prefix

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -113,7 +113,7 @@ func (s *agentState) handleEvent(ctx context.Context, event vmEvent) {
 			global: s,
 			status: status,
 			logger: RunnerLogger{
-				prefix: fmt.Sprintf("Runner %v: ", event.podName),
+				prefix: fmt.Sprintf("Runner %v: ", podName),
 			},
 			schedulerRespondedWithMigration: false,
 


### PR DESCRIPTION
Follow-up from #111 that I missed there, noticed from @tychoish pointing it out in #154.