### PR TITLE
neonvm/vm-builder: Add --quiet, default off (now shows build output)

### DIFF
--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -196,6 +196,7 @@ var (
 	dstImage   = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
 	size       = flag.String("size", "1G", `Size for disk image: --size=1G`)
 	outFile    = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
+	quiet      = flag.Bool("quiet", false, `Show less output from the docker build process`)
 	useInittab = flag.Bool("use-inittab", false, `Use guest container's inittab, appending it to the default one`)
 	forcePull  = flag.Bool("pull", false, `Pull src image even if already present locally`)
 )
@@ -362,7 +363,7 @@ func main() {
 			dstIm,
 		},
 		BuildArgs:      buildArgs,
-		SuppressOutput: true,
+		SuppressOutput: *quiet,
 		NoCache:        false,
 		Context:        tarBuffer,
 		Dockerfile:     "Dockerfile",

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -351,6 +351,7 @@ var (
 	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
 	size      = flag.String("size", "1G", `Size for disk image: --size=1G`)
 	outFile   = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
+	quiet     = flag.Bool("quiet", false, `Show less output from the docker build process`)
 	forcePull = flag.Bool("pull", false, `Pull src image even if already present locally`)
 	informant = flag.String("informant", VMInformant, `vm-informant docker image`)
 	version   = flag.Bool("version", false, `Print vm-builder version`)
@@ -521,7 +522,7 @@ func main() {
 			dstIm,
 		},
 		BuildArgs:      buildArgs,
-		SuppressOutput: true,
+		SuppressOutput: *quiet,
 		NoCache:        false,
 		Context:        tarBuffer,
 		Dockerfile:     "Dockerfile",


### PR DESCRIPTION
Initially running vm-builder can take a while, and it's often not clear that it's actually doing anything. Showing output by default should provide more observability there.