### PR TITLE
Switch to '/' for namespace/name separator, not ':'

### DIFF
--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -105,9 +105,11 @@ func startVMWatcher(
 }
 
 func makeVMEvent(vm *vmapi.VirtualMachine, kind vmEventKind) (vmEvent, error) {
+	vmName := util.NamespacedName{Namespace: vm.Namespace, Name: vm.Name}
+
 	info, err := api.ExtractVmInfo(vm)
 	if err != nil {
-		return vmEvent{}, fmt.Errorf("Error extracting VM info from %s:%s: %w", vm.Namespace, vm.Name, err)
+		return vmEvent{}, fmt.Errorf("Error extracting VM info from %v: %w", vmName, err)
 	}
 
 	return vmEvent{

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -11,6 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+
+	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
 const (
@@ -86,6 +88,10 @@ func (vm VmInfo) Max() Resources {
 		VCPU: vm.Cpu.Max,
 		Mem:  vm.Mem.Max,
 	}
+}
+
+func (vm VmInfo) NamespacedName() util.NamespacedName {
+	return util.NamespacedName{Namespace: vm.Namespace, Name: vm.Name}
 }
 
 func ExtractVmInfo(vm *vmapi.VirtualMachine) (*VmInfo, error) {

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -129,7 +129,7 @@ type nodeStateDump struct {
 type podStateDump struct {
 	Obj                      pointerString            `json:"obj"`
 	Name                     util.NamespacedName      `json:"name"`
-	VMName                   string                   `json:"vmName"`
+	VMName                   util.NamespacedName      `json:"vmName"`
 	Node                     pointerString            `json:"node"`
 	TestingOnlyAlwaysMigrate bool                     `json:"testingOnlyAlwaysMigrate"`
 	VCPU                     podResourceState[uint16] `json:"vCPU"`

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -148,8 +148,8 @@ type podState struct {
 	// name will not change after initialization, so it can be accessed without holding a lock.
 	name util.NamespacedName
 
-	// vmName is the name of the VM, as given by the 'vm.neon.tech/name' label.
-	vmName string
+	// vmName is the name of the VM, as given by the 'vm.neon.tech/name' label (and name.Namespace)
+	vmName util.NamespacedName
 
 	// testingOnlyAlwaysMigrate is a test-only debugging flag that, if present in the pod's labels,
 	// will always prompt it to mgirate, regardless of whether the VM actually *needs* to.
@@ -669,15 +669,17 @@ func (e *AutoscaleEnforcer) handlePodDeletion(podName util.NamespacedName) {
 	klog.Infof(fmtString, podName, pod.node.name, cpuVerdict, memVerdict)
 }
 
-func (e *AutoscaleEnforcer) handleUpdatedScalingBounds(vm *api.VmInfo, podName string) {
+func (e *AutoscaleEnforcer) handleUpdatedScalingBounds(vm *api.VmInfo, unqualifiedPodName string) {
 	e.state.lock.Lock()
 	defer e.state.lock.Unlock()
 
-	klog.Infof("Handling updated scaling bounds for VM pod %s:%s", vm.Namespace, podName)
+	podName := util.NamespacedName{Namespace: vm.Namespace, Name: unqualifiedPodName}
 
-	pod, ok := e.state.podMap[util.NamespacedName{Namespace: vm.Namespace, Name: podName}]
+	klog.Infof("Handling updated scaling bounds for VM pod %v", podName)
+
+	pod, ok := e.state.podMap[podName]
 	if !ok {
-		klog.Errorf("[autoscale-enforcer] cannot find VM pod %s:%s to update scaling bounds", vm.Namespace, podName)
+		klog.Errorf("[autoscale-enforcer] cannot find VM pod %v to update scaling bounds", podName)
 		return
 	}
 
@@ -687,10 +689,10 @@ func (e *AutoscaleEnforcer) handleUpdatedScalingBounds(vm *api.VmInfo, podName s
 	cpuVerdict := handleUpdatedLimits(&pod.node.vCPU, &pod.vCPU, receivedContact, vm.Cpu.Min, vm.Cpu.Max)
 	memVerdict := handleUpdatedLimits(&pod.node.memSlots, &pod.memSlots, receivedContact, vm.Mem.Min, vm.Mem.Max)
 
-	fmtString := "[autoscale-enforcer] Updated scaling bounds for VM pod %s:%s from node %s:\n" +
+	fmtString := "[autoscale-enforcer] Updated scaling bounds for VM pod %v from node %s:\n" +
 		"\tvCPU verdict: %s\n" +
 		"\t mem verdict: %s"
-	klog.Infof(fmtString, vm.Namespace, podName, pod.node.name, cpuVerdict, memVerdict)
+	klog.Infof(fmtString, podName, pod.node.name, cpuVerdict, memVerdict)
 }
 
 func (s *podState) isBetterMigrationTarget(other *podState) bool {
@@ -732,14 +734,14 @@ func (s *pluginState) startMigration(ctx context.Context, pod *podState, vmClien
 
 	vmm := &vmapi.VirtualMachineMigration{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-pluginvmm", pod.vmName),
+			GenerateName: fmt.Sprintf("%s-pluginvmm", pod.vmName.Name),
 			Namespace:    pod.name.Namespace,
 		},
 		Spec: vmapi.VirtualMachineMigrationSpec{
-			VmName: pod.vmName,
+			VmName: pod.vmName.Name,
 		},
 	}
-	klog.Infof("[autoscale-enforcer] VM Migration create request for VM %s:%s", pod.name.Namespace, pod.vmName)
+	klog.Infof("[autoscale-enforcer] VM Migration create request for VM %v", pod.vmName)
 	_, err := vmClient.NeonvmV1().
 		VirtualMachineMigrations(pod.name.Namespace).
 		Create(ctx, vmm, metav1.CreateOptions{})
@@ -904,7 +906,7 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context) error {
 		// Build the pod state, update the node
 		ps := &podState{
 			name:   podName,
-			vmName: vm.Name,
+			vmName: util.GetNamespacedName(vm),
 			node:   ns,
 			vCPU: podResourceState[uint16]{
 				Reserved:         vmInfo.Cpu.Max,

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -116,19 +116,19 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 			UpdateFunc: func(oldVM, newVM *vmapi.VirtualMachine) {
 				oldInfo, err := api.ExtractVmInfo(oldVM)
 				if err != nil {
-					klog.Errorf("[autoscale-enforcer] Error extracting VM info for %s:%s: %w", oldVM.Namespace, oldVM.Name, err)
+					klog.Errorf("[autoscale-enforcer] Error extracting VM info for %v: %w", util.GetNamespacedName(oldVM), err)
 					return
 				}
 				newInfo, err := api.ExtractVmInfo(newVM)
 				if err != nil {
-					klog.Errorf("[autoscale-enforcer] Error extracting VM info for %s:%s: %w", newVM.Namespace, newVM.Name, err)
+					klog.Errorf("[autoscale-enforcer] Error extracting VM info for %v: %w", util.GetNamespacedName(newVM), err)
 					return
 				}
 
 				if newVM.Status.PodName == "" {
 					klog.Infof(
-						"[autoscale-enforcer] Skipping update for VM %s:%s because .status.podName is empty",
-						newVM.Namespace, newVM.Name,
+						"[autoscale-enforcer] Skipping update for VM %v because .status.podName is empty",
+						util.GetNamespacedName(newVM),
 					)
 					return
 				}

--- a/pkg/util/namespacedname.go
+++ b/pkg/util/namespacedname.go
@@ -8,14 +8,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// FIXME: K8s uses '/' as its separator. We currently use this for backwards-compatibility, but we
-// should change to '/'. That change will involve fixing the many places where we create strings
-// with %s:%s instead of %s/%s as well; those should just use NamespacedName directly.
-const Separator = ':'
+const Separator = '/'
 
 // NamespacedName represents a resource name with the namespace it's in.
 //
-// When printed with '%s' or '%v', NamespacedName is rendered as "<namespace>:<name>". Printing with
+// When printed with '%v', NamespacedName is rendered as "<namespace>/<name>". Printing with
 // '%+v' or '%#v' renders as it would normally.
 type NamespacedName struct {
 	Namespace string `json:"namespace"`

--- a/pkg/util/namespacedname.go
+++ b/pkg/util/namespacedname.go
@@ -4,6 +4,8 @@ package util
 
 import (
 	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // FIXME: K8s uses '/' as its separator. We currently use this for backwards-compatibility, but we
@@ -18,6 +20,11 @@ const Separator = ':'
 type NamespacedName struct {
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
+}
+
+func GetNamespacedName(obj metav1.ObjectMetaAccessor) NamespacedName {
+	meta := obj.GetObjectMeta()
+	return NamespacedName{Namespace: meta.GetNamespace(), Name: meta.GetName()}
 }
 
 func (n NamespacedName) Format(state fmt.State, verb rune) {

--- a/pkg/util/namespacedname_test.go
+++ b/pkg/util/namespacedname_test.go
@@ -14,9 +14,9 @@ func TestFormatting(t *testing.T) {
 		expected string
 		got      string
 	}{
-		{"sprint", "foo:bar", fmt.Sprint(base)},
-		{"sprintf-%s", "foo:bar", fmt.Sprintf("%s", base)},
-		{"sprintf-%v", "foo:bar", fmt.Sprintf("%v", base)},
+		{"sprint", "foo/bar", fmt.Sprint(base)},
+		{"sprintf-%s", "foo/bar", fmt.Sprintf("%s", base)},
+		{"sprintf-%v", "foo/bar", fmt.Sprintf("%v", base)},
 		{"sprintf-%+v", `{Namespace:foo Name:bar}`, fmt.Sprintf("%+v", base)},
 		{"sprintf-%#v", `util.NamespacedName{Namespace:"foo", Name:"bar"}`, fmt.Sprintf("%#v", base)},
 	}

--- a/pkg/util/watch.go
+++ b/pkg/util/watch.go
@@ -266,9 +266,7 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 					// event, which we're currently processing.
 					opts.ResourceVersion = meta.GetResourceVersion()
 
-					name := func(m metav1.Object) string {
-						return fmt.Sprintf("%s:%s", m.GetNamespace(), m.GetName())
-					}
+					name := GetNamespacedName(obj)
 
 					// Wrap the remainder in a function, so we can have deferred unlocks.
 					err := func() error {
@@ -279,8 +277,8 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 
 							if _, ok := store.objects[uid]; ok {
 								return fmt.Errorf(
-									"watch %s: received add event for object %s that we already have",
-									config.LogName, name(meta),
+									"watch %s: received add event for object %v that we already have",
+									config.LogName, name,
 								)
 							}
 							store.objects[uid] = (*T)(obj)
@@ -299,8 +297,8 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 							old, ok := store.objects[uid]
 							if !ok {
 								return fmt.Errorf(
-									"watch %s: received delete event for object %s that's not present",
-									config.LogName, name(meta),
+									"watch %s: received delete event for object %v that's not present",
+									config.LogName, name,
 								)
 							}
 							// Update:
@@ -318,8 +316,8 @@ func Watch[C WatchClient[L], L metav1.ListMetaAccessor, T any, P WatchObject[T]]
 							old, ok := store.objects[uid]
 							if !ok {
 								return fmt.Errorf(
-									"watch %s: received update event for object %s that's not present",
-									config.LogName, name(meta),
+									"watch %s: received update event for object %v that's not present",
+									config.LogName, name,
 								)
 							}
 							store.objects[uid] = (*T)(obj)


### PR DESCRIPTION
Quoting the comment that marked this as a todo:

> K8s uses '/' as its separator. We currently use this for backwards-compatibility, but we should change to '/'. That change will involve fixing the many places where we create strings with %s:%s instead of %s/%s as well; those should just use NamespacedName directly.

So that should hopefully explain why this change is good, and what's actually going on here.

Planning to merge both commits separately, not squash.