### PR TITLE
agent: Add "unhealthy vm-informants" metric

### DIFF
--- a/deploy/autoscaler-agent.yaml
+++ b/deploy/autoscaler-agent.yaml
@@ -58,7 +58,7 @@ data:
       "registerTimeoutSeconds": 2,
       "downscaleTimeoutSeconds": 2,
       "unhealthyAfterSilenceDurationSeconds": 20,
-      "unhealthyStartupGracePeriodSeconds": 20,
+      "unhealthyStartupGracePeriodSeconds": 20
     },
     "metrics": {
       "loadMetricPrefix": "host_",

--- a/deploy/autoscaler-agent.yaml
+++ b/deploy/autoscaler-agent.yaml
@@ -56,7 +56,9 @@ data:
       "registerRetrySeconds": 5,
       "requestTimeoutSeconds": 1,
       "registerTimeoutSeconds": 2,
-      "downscaleTimeoutSeconds": 2
+      "downscaleTimeoutSeconds": 2,
+      "unhealthyAfterSilenceDurationSeconds": 20,
+      "unhealthyStartupGracePeriodSeconds": 20,
     },
     "metrics": {
       "loadMetricPrefix": "host_",

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -13,6 +13,9 @@ type Config struct {
 	Scheduler SchedulerConfig  `json:"scheduler"`
 	Billing   *BillingConfig   `json:"billing,omitempty"`
 	DumpState *DumpStateConfig `json:"dumpState"`
+
+	InformantUnhealthyAfterSilenceDurationSeconds uint `json:"informantUnhealthyAfterSilenceDurationSeconds"`
+	InformantUnhealthyStartupGracePeriodSeconds   uint `json:"informantUnhealthyStartupGracePeriodSeconds"`
 }
 
 // DumpStateConfig configures the endpoint to dump all internal state
@@ -157,6 +160,10 @@ func (c *Config) validate() error {
 		return cannotBeZero(".dumpState.port")
 	} else if c.DumpState != nil && c.DumpState.TimeoutSeconds == 0 {
 		return cannotBeZero(".dumpState.timeoutSeconds")
+	} else if c.InformantUnhealthyAfterSilenceDurationSeconds == 0 {
+		return cannotBeZero(".informantUnhealthyAfterSilenceDurationSeconds")
+	} else if c.InformantUnhealthyStartupGracePeriodSeconds == 0 {
+		return cannotBeZero(".informantUnhealthyStartupGracePeriodSeconds")
 	}
 
 	return nil

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -13,9 +13,6 @@ type Config struct {
 	Scheduler SchedulerConfig  `json:"scheduler"`
 	Billing   *BillingConfig   `json:"billing,omitempty"`
 	DumpState *DumpStateConfig `json:"dumpState"`
-
-	InformantUnhealthyAfterSilenceDurationSeconds uint `json:"informantUnhealthyAfterSilenceDurationSeconds"`
-	InformantUnhealthyStartupGracePeriodSeconds   uint `json:"informantUnhealthyStartupGracePeriodSeconds"`
 }
 
 // DumpStateConfig configures the endpoint to dump all internal state
@@ -62,6 +59,14 @@ type InformantConfig struct {
 	// This is a separate field from RequestTimeoutSeconds it's possible that downscaling may
 	// require some non-trivial work that we want to allow to complete.
 	DownscaleTimeoutSeconds uint `json:"downscaleTimeoutSeconds"`
+
+	// UnhealthyAfterSilenceDurationSeconds gives the duration, in seconds, after which failing to
+	// receive a successful request from the informant indicates that it is probably unhealthy.
+	UnhealthyAfterSilenceDurationSeconds uint `json:"unhealthyAfterSilenceDurationSeconds"`
+	// UnhealthyStartupGracePeriodSeconds gives the duration, in seconds, after which we will no
+	// longer excuse total VM informant failures - i.e. when unhealthyAfterSilenceDurationSeconds
+	// kicks in.
+	UnhealthyStartupGracePeriodSeconds uint `json:"unhealthyStartupGracePeriodSeconds"`
 }
 
 // MetricsConfig defines a few parameters for metrics requests to the VM
@@ -134,6 +139,10 @@ func (c *Config) validate() error {
 		return cannotBeZero(".informant.registerTimeoutSeconds")
 	} else if c.Informant.DownscaleTimeoutSeconds == 0 {
 		return cannotBeZero(".informant.downscaleTimeoutSeconds")
+	} else if c.Informant.UnhealthyAfterSilenceDurationSeconds == 0 {
+		return cannotBeZero(".informant.unhealthyAfterSilenceDurationSeconds")
+	} else if c.Informant.UnhealthyStartupGracePeriodSeconds == 0 {
+		return cannotBeZero(".informant.unhealthyStartupGracePeriodSeconds")
 	} else if c.Metrics.SecondsBetweenRequests == 0 {
 		return cannotBeZero(".metrics.secondsBetweenRequests")
 	} else if c.Metrics.LoadMetricPrefix == "" {
@@ -160,10 +169,6 @@ func (c *Config) validate() error {
 		return cannotBeZero(".dumpState.port")
 	} else if c.DumpState != nil && c.DumpState.TimeoutSeconds == 0 {
 		return cannotBeZero(".dumpState.timeoutSeconds")
-	} else if c.InformantUnhealthyAfterSilenceDurationSeconds == 0 {
-		return cannotBeZero(".informantUnhealthyAfterSilenceDurationSeconds")
-	} else if c.InformantUnhealthyStartupGracePeriodSeconds == 0 {
-		return cannotBeZero(".informantUnhealthyStartupGracePeriodSeconds")
 	}
 
 	return nil

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -237,8 +237,8 @@ func (s *podStatus) informantIsUnhealthy(config *Config) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	startupGracePeriod := time.Second * time.Duration(config.InformantUnhealthyStartupGracePeriodSeconds)
-	unhealthySilencePeriod := time.Second * time.Duration(config.InformantUnhealthyAfterSilenceDurationSeconds)
+	startupGracePeriod := time.Second * time.Duration(config.Informant.UnhealthyStartupGracePeriodSeconds)
+	unhealthySilencePeriod := time.Second * time.Duration(config.Informant.UnhealthyAfterSilenceDurationSeconds)
 
 	if s.lastSuccessfulInformantComm == nil {
 		return time.Since(s.startTime) >= startupGracePeriod

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -47,7 +47,7 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 	)
 	totalVMsWithUnhealthyInformants := prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
-			Name: "vms_unsuccessful_communication_with_informant_current",
+			Name: "autoscaling_vms_unsuccessful_communication_with_informant_current",
 			Help: "Number of VMs whose vm-informants aren't successfully communicating with the autoscaler-agent",
 		},
 		func() float64 {


### PR DESCRIPTION
Builds on #92. Should allow things like this to be detected via metrics: https://neondb.slack.com/archives/C03H1K0PGKH/p1681461362196019?thread_ts=1681459030.472469&cid=C03H1K0PGKH