### PR TITLE
neonvm: go template fix for ENTRYPOINT and CMD strings

### DIFF
--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -112,15 +112,13 @@ fi
 if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
     /neonvm/bin/cat /neonvm/runtime/command.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo -n '{{- range .Entrypoint}}{{.}} {{- end }}' >>/neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo -n '{{$first := true}}{{range .Entrypoint}}{{if $first}}{{$first = false}}{{else}} {{end}}{{.}}{{end}}' >>/neonvm/bin/vmstarter.sh
 fi
-
-echo -n ' ' >>/neonvm/bin/vmstarter.sh
-
+{{if and .Entrypoint .Cmd}}echo -n ' ' >>/neonvm/bin/vmstarter.sh{{end}}
 if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
     /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo '{{- range .Cmd }}{{.}} {{- end }}' >>/neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo '{{$first := true}}{{range .Cmd}}{{if $first}}{{$first = false}}{{else}} {{end}}{{.}}{{end}}' >>/neonvm/bin/vmstarter.sh
 fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -204,15 +204,13 @@ fi
 if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
     /neonvm/bin/cat /neonvm/runtime/command.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo -n '{{- range .Entrypoint}}{{.}} {{- end }}' >>/neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo -n '{{$first := true}}{{range .Entrypoint}}{{if $first}}{{$first = false}}{{else}} {{end}}{{.}}{{end}}' >>/neonvm/bin/vmstarter.sh
 fi
-
-echo -n ' ' >>/neonvm/bin/vmstarter.sh
-
+{{if and .Entrypoint .Cmd}}echo -n ' ' >>/neonvm/bin/vmstarter.sh{{end}}
 if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
     /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo '{{- range .Cmd }}{{.}} {{- end }}' >>/neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo '{{$first := true}}{{range .Cmd}}{{if $first}}{{$first = false}}{{else}} {{end}}{{.}}{{end}}' >>/neonvm/bin/vmstarter.sh
 fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh


### PR DESCRIPTION
This PR fixes #156

tested with different combinations:

## case 1
```
ENTRYPOINT ["entry1", "entry2", "entry3"]
CMD ["cmd1", "cmd2", "cmd3"]
```
part of generated `vmstart` script:
```bash
if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
    /neonvm/bin/cat /neonvm/runtime/command.sh >>/neonvm/bin/vmstarter.sh
else
    /neonvm/bin/echo -n 'entry1 entry2 entry3' >>/neonvm/bin/vmstarter.sh
fi
echo -n ' ' >>/neonvm/bin/vmstarter.sh
if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
    /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
else
    /neonvm/bin/echo 'cmd1 cmd2 cmd3' >>/neonvm/bin/vmstarter.sh
fi
```

## case 2
```
ENTRYPOINT ["entry1", "entry2", "entry3"]
CMD []
```
part of generated `vmstart` script:
```bash
if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
    /neonvm/bin/cat /neonvm/runtime/command.sh >>/neonvm/bin/vmstarter.sh
else
    /neonvm/bin/echo -n 'entry1 entry2 entry3' >>/neonvm/bin/vmstarter.sh
fi

if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
    /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
else
    /neonvm/bin/echo '' >>/neonvm/bin/vmstarter.sh
fi
```

## case 3
```
ENTRYPOINT []
CMD ["cmd1", "cmd2", "cmd3"]
```
part of generated `vmstart` script:
```bash
if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
    /neonvm/bin/cat /neonvm/runtime/command.sh >>/neonvm/bin/vmstarter.sh
else
    /neonvm/bin/echo -n '' >>/neonvm/bin/vmstarter.sh
fi

if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
    /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
else
    /neonvm/bin/echo 'cmd1 cmd2 cmd3' >>/neonvm/bin/vmstarter.sh
fi
```

## case 4
```
ENTRYPOINT []
CMD []
```
part of generated `vmstart` script:
```bash
if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
    /neonvm/bin/cat /neonvm/runtime/command.sh >>/neonvm/bin/vmstarter.sh
else
    /neonvm/bin/echo -n '' >>/neonvm/bin/vmstarter.sh
fi

if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
    /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
else
    /neonvm/bin/echo '/neonvm/bin/sleep 3650d' >>/neonvm/bin/vmstarter.sh
fi
```