### PR TITLE
make: fix manifests paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ generate: ## Generate boilerplate DeepCopy methods, manifests, and Go client
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="neonvm/..." \
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./neonvm/..." \
 		output:crd:artifacts:config=neonvm/config/common/crd/bases \
 		output:rbac:artifacts:config=neonvm/config/common/rbac \
 		output:webhook:artifacts:config=neonvm/config/common/webhook


### PR DESCRIPTION
ref https://github.com/neondatabase/autoscaling/pull/172#discussion_r1167967559

I couldn't replicate the issue with `make manifests` not working, so not too sure what's going on.

~~cc @nikitakalyanov would be good to include the error message this fixes into the final commit.~~ Nevermind, re-read the comment.