### PR TITLE
e2e: always get k8s logs + events

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -83,7 +83,7 @@ jobs:
       - run: make e2e
 
       - name: Get k8s logs and events
-        if: ${{ failure() || cancelled() }}
+        if: always()
         run: |
           if ! kubectl config current-context; then
             echo "skipping cluster logs because no cluster found in kubectl context"


### PR DESCRIPTION
Follow-up to a conversation with @nikitakalyanov yesterday. Currently we get logs/events on everything but success, which means that when you see errors in logs, there's no way to tell if those are "normal" or not.

cc @bayandin in case there's reasons not to do this.