### PR TITLE
lint: Check that `make manifests` has no changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,14 @@ jobs:
             echo "ERROR: 'go mod tidy' modified the source tree."
             exit 1
           fi
+
+      - name: make manifests
+        run: |
+          make manifests
+          if ! (test -z "$(git ls-files --exclude-standard --others .)$(git diff .)"); then
+            git ls-files --exclude-standard --others .
+            git diff .
+            echo "ERROR: 'make manifests' modified the source tree."
+            exit 1
+          fi
+


### PR DESCRIPTION
ref https://github.com/neondatabase/autoscaling/pull/188#issuecomment-1510896020

Expecting this to fail for now, until #188 is merged.