### PR TITLE
Fix logs with %w

### DIFF
--- a/pkg/agent/dumpstate.go
+++ b/pkg/agent/dumpstate.go
@@ -60,7 +60,7 @@ func (s *agentState) StartDumpStateServer(shutdownCtx context.Context, config *D
 		// internal state after shutdown has started.
 		server := &http.Server{Handler: mux}
 		if err := server.Serve(listener); err != nil {
-			klog.Errorf("dump-state server exited: %w", err)
+			klog.Errorf("dump-state server exited: %s", err)
 		}
 	}()
 

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1066,7 +1066,7 @@ func (r *Runner) updateVMResources(
 	// The reason we care about the informant server being "enabled" is that the VM informant uses
 	// it to ensure that there's at most one autoscaler-agent that's making requests on its behalf.
 	if err := r.validateInformant(); err != nil {
-		r.logger.Warningf("Unable to update VM resources because informant server is disabled: %w", err)
+		r.logger.Warningf("Unable to update VM resources because informant server is disabled: %s", err)
 		return nil
 	}
 
@@ -1415,7 +1415,7 @@ func (r *Runner) doVMUpdate(
 	}
 
 	if err := r.validateInformant(); err != nil {
-		r.logger.Warningf("Aborting VM update because informant server is not valid: %w", err)
+		r.logger.Warningf("Aborting VM update because informant server is not valid: %s", err)
 		resetVMTo(current)
 		return nil, nil
 	}

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -72,7 +72,7 @@ func (p *AutoscaleEnforcer) startDumpStateServer(shutdownCtx context.Context) er
 		// internal state after shutdown has started.
 		server := &http.Server{Handler: mux}
 		if err := server.Serve(listener); err != nil {
-			klog.Errorf("dump-state server exited: %w", err)
+			klog.Errorf("dump-state server exited: %s", err)
 		}
 	}()
 

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -116,12 +116,12 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 			UpdateFunc: func(oldVM, newVM *vmapi.VirtualMachine) {
 				oldInfo, err := api.ExtractVmInfo(oldVM)
 				if err != nil {
-					klog.Errorf("[autoscale-enforcer] Error extracting VM info for %v: %w", util.GetNamespacedName(oldVM), err)
+					klog.Errorf("[autoscale-enforcer] Error extracting VM info for %v: %s", util.GetNamespacedName(oldVM), err)
 					return
 				}
 				newInfo, err := api.ExtractVmInfo(newVM)
 				if err != nil {
-					klog.Errorf("[autoscale-enforcer] Error extracting VM info for %v: %w", util.GetNamespacedName(newVM), err)
+					klog.Errorf("[autoscale-enforcer] Error extracting VM info for %v: %s", util.GetNamespacedName(newVM), err)
 					return
 				}
 

--- a/pkg/util/promserver.go
+++ b/pkg/util/promserver.go
@@ -34,7 +34,7 @@ func StartPrometheusMetricsServer(ctx context.Context, port uint16, reg *prometh
 	go func() {
 		<-shutdownCtx.Done()
 		if err := srv.Shutdown(context.Background()); err != nil {
-			klog.Errorf("Error shutting down prometheus server: %w", err)
+			klog.Errorf("Error shutting down prometheus server: %s", err)
 		}
 	}()
 


### PR DESCRIPTION
Noticed an instance in the logs, used ripgrep to locate many occurrences:

    rg --multiline '(klog|logger)\.(Info|Warning|Error)f\("[^"]*%w'

Realistically this should also be in CI, but that can be a follow-up.