### PR TITLE
metrics: unify failed http request label

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -579,7 +579,7 @@ func doInformantRequest[Q any, R any](
 
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
-		result = "<error>"
+		result = "[error doing request]"
 		return nil, statusCode, fmt.Errorf("Error doing request: %w", err)
 	}
 	defer response.Body.Close()

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1676,7 +1676,7 @@ func (s *Scheduler) DoRequest(ctx context.Context, reqData *api.AgentRequest) (*
 
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
-		s.runner.global.metrics.schedulerRequests.WithLabelValues("<request error>").Inc()
+		s.runner.global.metrics.schedulerRequests.WithLabelValues("[error doing request]").Inc()
 		return nil, s.handleRequestError(reqData, fmt.Errorf("Error doing request: %w", err))
 	}
 	defer response.Body.Close()


### PR DESCRIPTION
Currently failed requests to the scheduler plugin vs vm-informant have different labels when the (*http.Request).Do() call fails. This change unifies them to the same value: "[error doing request]"

Showcase of current metrics, for comparison:

![Screenshot of Grafana, showing \<error\> and \<request error\> being used for agent to informant and agent to plugin requests, respectively](https://user-images.githubusercontent.com/29154784/232857650-6f0a6a4d-cbd2-4609-8368-c1c707fa6a42.png)
