### PR TITLE
lint: Don't use golangci cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,9 @@ jobs:
           version: v1.52.2
           args: --timeout 5m --fix
           github-token: ${{ secrets.github_token }}
+          # caching issues, see: https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052190775
+          skip-pkg-cache: true
+          skip-build-cache: true
         if: env.GIT_DIFF
 
       - name: go mod tidy


### PR DESCRIPTION
Currently we have ~50k lines of tar extraction errors with "File exists" when the golangi-lint-action runs. There doesn't seem to be a clean way around this, other than disabling its cache.

See also: https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052190775

Example of an offending run: https://github.com/neondatabase/autoscaling/actions/runs/4740610494/jobs/8416629913