### PR TITLE
lint: Always run golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,12 +17,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - uses: technote-space/get-diff-action@v6
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
       - uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,6 @@ jobs:
           version: v1.52.2
           args: --timeout 5m --fix
           github-token: ${{ secrets.github_token }}
-        if: env.GIT_DIFF
 
       - name: go mod tidy
         run: |


### PR DESCRIPTION
There are sometimes non-Go files that affect linting (e.g., changes to the linting workflow itself, as in #201) and realistically the longest CI job is the e2e tests, so being efficient about linting isn't as significant.