### PR TITLE
agent, informant: Add agent -> informant health checks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,22 +226,25 @@ The protocol is as follows:
 4. Begin "normal operation". During this, there are a few types of requests made between the agent
    and informant. Each party can make **only one request at a time**. The agent starts in the
    "suspended" state.
-    1. The informant's `/downscale` endpoint (via PUT), with `RawResources`. This serves as the
+    1. The informant's `/health-check` endpoint (via PUT), with `AgentIdentification`. This allows
+       the autoscaler-agent to check that the informant is up and running, and that it still
+       recognizes the agent.
+    2. The informant's `/downscale` endpoint (via PUT), with `RawResources`. This serves as the
        agent _politely asking_ the informant to decrease resource usage to the specified amount.
        The informant returns a `DownscaleResult` indicating whether it was able to downscale (it may
        not, if e.g. memory usage is too high).
-    2. The informant's `/upscale` endpoint (via PUT), with `RawResources`. This serves as the agent
+    3. The informant's `/upscale` endpoint (via PUT), with `RawResources`. This serves as the agent
        _notifying_ the informant that its resources have increased to the provided amount.
-    3. The agent's `/suspend` endpoint (via POST), with `SuspendAgent`. This allows the informant to
+    4. The agent's `/suspend` endpoint (via POST), with `SuspendAgent`. This allows the informant to
        inform the agent that it is no longer in use for the VM. While suspended, the agent **must
        not** make any `downscale` or `upscale` requests. The informant **must not** double-suspend
        an agent.
-    4. The agent's `/resume` endpoint (via POST), with `ResumeAgent`. This allows the informant to
+    5. The agent's `/resume` endpoint (via POST), with `ResumeAgent`. This allows the informant to
        pick up communication with an agent that was previously suspended. The informant **must not**
        double-resume an agent.
-    5. The agent's `/id` endpoint (via GET) is also available during normal operation, and is used
+    6. The agent's `/id` endpoint (via GET) is also available during normal operation, and is used
        as a health check by the informant.
-    6. The agent's `/try-upscale` endpoint (via POST), with `MoreResources`. This allows the
+    7. The agent's `/try-upscale` endpoint (via POST), with `MoreResources`. This allows the
        informant to request more of a particular resource (e.g. memory). The agent MUST respond
        immediately with an `AgentIdentification`. It MAY later send an `/upscale` request to the
        informant once the requested increase in resources has been achieved.

--- a/cmd/vm-informant/main.go
+++ b/cmd/vm-informant/main.go
@@ -119,6 +119,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	util.AddHandler("", mux, "/register", http.MethodPost, "AgentDesc", state.RegisterAgent)
+	util.AddHandler("", mux, "/health-check", http.MethodPut, "AgentIdentification", state.HealthCheck)
 	// FIXME: /downscale and /upscale should have the AgentID in the request body
 	util.AddHandler("", mux, "/downscale", http.MethodPut, "RawResources", state.TryDownscale)
 	util.AddHandler("", mux, "/upscale", http.MethodPut, "RawResources", state.NotifyUpscale)

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -258,6 +258,7 @@ func NewInformantServer(
 	runner.spawnBackgroundWorker(backgroundCtx, healthCheckerName, func(c context.Context) {
 		// FIXME: make this duration configurable
 		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-c.Done():

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -280,7 +280,7 @@ func NewInformantServer(
 				}
 
 				if _, err := server.HealthCheck(c); err != nil {
-					runner.logger.Warningf("Informant health check failed: %w", err)
+					runner.logger.Warningf("Informant health check failed: %s", err)
 				}
 			}()
 			if done {

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -913,9 +913,6 @@ func (s *InformantServer) handleTryUpscale(
 //
 // This method MUST be called while holding i.server.requestLock AND NOT i.server.runner.lock.
 func (s *InformantServer) HealthCheck(ctx context.Context) (*api.InformantHealthCheckResp, error) {
-	s.requestLock.Lock()
-	defer s.requestLock.Unlock()
-
 	err := func() error {
 		s.runner.lock.Lock()
 		defer s.runner.lock.Unlock()

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -928,7 +928,7 @@ func (s *InformantServer) HealthCheck(ctx context.Context) (*api.InformantHealth
 	timeout := time.Second * time.Duration(s.runner.global.config.Informant.RequestTimeoutSeconds)
 	id := api.AgentIdentification{AgentID: s.desc.AgentID}
 
-	s.runner.logger.Infof("Sending health-check %+v")
+	s.runner.logger.Infof("Sending health-check %+v", id)
 	resp, statusCode, err := doInformantRequest[api.AgentIdentification, api.InformantHealthCheckResp](
 		ctx, s, timeout, http.MethodPut, "/health-check", &id,
 	)

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -266,13 +266,13 @@ func NewInformantServer(
 			case <-ticker.C:
 			}
 
-			// If we've already registered with the informant, and it doesn't support health checks,
-			// exit.
 			var done bool
 			func() {
 				server.requestLock.Lock()
 				defer server.requestLock.Unlock()
 
+				// If we've already registered with the informant, and it doesn't support health
+				// checks, exit.
 				if server.protoVersion != nil && !server.protoVersion.AllowsHealthCheck() {
 					runner.logger.Infof("Aborting future informant health checks because it does not support them")
 					done = true

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -25,7 +25,7 @@ import (
 // If you update either of these values, make sure to also update VERSIONING.md.
 const (
 	MinInformantProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_0
-	MaxInformantProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_1
+	MaxInformantProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_2
 )
 
 type InformantServer struct {
@@ -250,6 +250,40 @@ func NewInformantServer(
 			server.exitStatus = &InformantServerExitStatus{
 				Err:            fmt.Errorf("Unexpected exit: %w", err),
 				RetryShouldFix: false,
+			}
+		}
+	})
+
+	healthCheckerName := fmt.Sprintf("InformantServer health-checker (%s)", server.desc.AgentID)
+	runner.spawnBackgroundWorker(backgroundCtx, healthCheckerName, func(c context.Context) {
+		// FIXME: make this duration configurable
+		ticker := time.NewTicker(5 * time.Second)
+		for {
+			select {
+			case <-c.Done():
+				return
+			case <-ticker.C:
+			}
+
+			// If we've already registered with the informant, and it doesn't support health checks,
+			// exit.
+			var done bool
+			func() {
+				server.requestLock.Lock()
+				defer server.requestLock.Unlock()
+
+				if server.protoVersion != nil && !server.protoVersion.AllowsHealthCheck() {
+					runner.logger.Infof("Aborting future informant health checks because it does not support them")
+					done = true
+					return
+				}
+
+				if _, err := server.HealthCheck(c); err != nil {
+					runner.logger.Warningf("Informant health check failed: %w", err)
+				}
+			}()
+			if done {
+				return
 			}
 		}
 	})
@@ -872,6 +906,50 @@ func (s *InformantServer) handleTryUpscale(
 	default:
 		panic(fmt.Errorf("unexpected server mode: %q", s.mode))
 	}
+}
+
+// HealthCheck makes a request to the informant's /health-check endpoint, using the server's ID.
+//
+// This method MUST be called while holding i.server.requestLock AND NOT i.server.runner.lock.
+func (s *InformantServer) HealthCheck(ctx context.Context) (*api.InformantHealthCheckResp, error) {
+	s.requestLock.Lock()
+	defer s.requestLock.Unlock()
+
+	err := func() error {
+		s.runner.lock.Lock()
+		defer s.runner.lock.Unlock()
+		return s.Valid()
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := time.Second * time.Duration(s.runner.global.config.Informant.RequestTimeoutSeconds)
+	id := api.AgentIdentification{AgentID: s.desc.AgentID}
+
+	s.runner.logger.Infof("Sending health-check %+v")
+	resp, statusCode, err := doInformantRequest[api.AgentIdentification, api.InformantHealthCheckResp](
+		ctx, s, timeout, http.MethodPut, "/health-check", &id,
+	)
+	if err != nil {
+		func() {
+			s.runner.lock.Lock()
+			defer s.runner.lock.Unlock()
+
+			s.setLastInformantError(fmt.Errorf("Health-check request failed: %w", err), true)
+
+			if 400 <= statusCode && statusCode <= 599 {
+				s.exit(InformantServerExitStatus{
+					Err:            err,
+					RetryShouldFix: statusCode == 404,
+				})
+			}
+		}()
+		return nil, err
+	}
+
+	s.runner.logger.Infof("Received health-check result %+v", *resp)
+	return resp, nil
 }
 
 // Downscale makes a request to the informant's /downscale endpoit with the api.Resources

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -13,7 +13,7 @@ commit in this repository, possibly unreleased.
 
 | Release | autoscaler-agent | VM informant |
 |---------|------------------|--------------|
-| _Current_ | v1.0 - v1.1 | v1.1 only |
+| _Current_ | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.6.0 | v1.0 - v1.1 | v1.1 only |
 | v0.5.2 | v1.0 - v1.1 | v1.1 only |
 | v0.5.1 | v1.0 - v1.1 | v1.1 only |

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -253,8 +253,17 @@ const (
 	//
 	// * Adds /try-upscale endpoint to the autoscaler-agent.
 	//
-	// Currently the latest version.
+	// Last used in release version v0.6.0.
 	InformantProtoV1_1
+
+	// InformantProtoV1_2 represents v1.2 of the agent<->informant protocol.
+	//
+	// Changes from v1.1:
+	//
+	// * Adds /health-check endpoint to the vm-informant.
+	//
+	// Currently the latest version.
+	InformantProtoV1_2
 
 	// latestInformantProtoVersion represents the latest version of the agent<->informant protocol
 	//
@@ -290,6 +299,14 @@ func (v InformantProtoVersion) IsValid() bool {
 // This is true for version v1.1 and greater.
 func (v InformantProtoVersion) HasTryUpscale() bool {
 	return v >= InformantProtoV1_1
+}
+
+// AllowsHealthCheck returns whether this version of the protocol has the informant's /health-check
+// endpoint
+//
+// This is true for version v1.2 and greater.
+func (v InformantProtoVersion) AllowsHealthCheck() bool {
+	return v >= InformantProtoV1_2
 }
 
 // AgentMessage is used for (almost) every message sent from the autoscaler-agent to the VM
@@ -395,6 +412,10 @@ type InformantMetricsMethod struct {
 type MetricsMethodPrometheus struct {
 	Port uint16 `json:"port"`
 }
+
+// InformantHealthCheckResp is the result of a successful request to a VM informant's /health-check
+// endpoint.
+type InformantHealthCheckResp struct{}
 
 // UnregisterAgent is the result of a successful request to a VM informant's /unregister endpoint
 type UnregisterAgent struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -283,6 +283,8 @@ func (v InformantProtoVersion) String() string {
 		return "v1.0"
 	case InformantProtoV1_1:
 		return "v1.1"
+	case InformantProtoV1_2:
+		return "v1.2"
 	default:
 		diff := v - latestInformantProtoVersion
 		return fmt.Sprintf("<unknown = %v + %d>", latestInformantProtoVersion, diff)

--- a/pkg/informant/agent.go
+++ b/pkg/informant/agent.go
@@ -22,10 +22,13 @@ import (
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
-// ProtocolVersion is the current version of the agent<->informant protocol in use by this informant
+// The VM informant currently supports v1.1 and v1.2 of the agent<->informant protocol.
 //
-// Currently, each VM informant supports only one version at a time. In the future, this may change.
-const ProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_1
+// If you update either of these values, make sure to also update VERSIONING.md.
+const (
+	MinProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_1
+	MaxProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_2
+)
 
 // AgentSet is the global state handling various autoscaler-agents that we could connect to
 type AgentSet struct {
@@ -264,8 +267,8 @@ func (s *AgentSet) tryNewAgents(signal <-chan struct{}) {
 // Returns: protocol version, status code, error (if unsuccessful)
 func (s *AgentSet) RegisterNewAgent(info *api.AgentDesc) (api.InformantProtoVersion, int, error) {
 	expectedRange := api.VersionRange[api.InformantProtoVersion]{
-		Min: ProtocolVersion,
-		Max: ProtocolVersion,
+		Min: MinProtocolVersion,
+		Max: MaxProtocolVersion,
 	}
 
 	descProtoRange := info.ProtocolRange()

--- a/pkg/informant/agent.go
+++ b/pkg/informant/agent.go
@@ -75,6 +75,8 @@ type Agent struct {
 	id         uuid.UUID
 	serverAddr string
 
+	protoVersion api.InformantProtoVersion
+
 	// all sends on requestQueue are made through the doRequest method; all receives are made from
 	// the runHandler background task.
 	requestQueue  chan agentRequest
@@ -293,6 +295,8 @@ func (s *AgentSet) RegisterNewAgent(info *api.AgentDesc) (api.InformantProtoVers
 
 		id:         info.AgentID,
 		serverAddr: info.ServerAddr,
+
+		protoVersion: protoVersion,
 
 		lastSeqNumber: 0,
 		requestQueue:  make(chan agentRequest),

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -224,8 +224,15 @@ func (s *State) RegisterAgent(ctx context.Context, info *api.AgentDesc) (*api.In
 // is up and running, and (b) the agent is still registered.
 //
 // Returns: body (if successful), status code, error (if unsuccessful)
-func (s *State) HealthCheck(ctx context.Context, info *api.AgentDesc) (*api.InformantHealthCheckResp, int, error) {
-	panic("todo")
+func (s *State) HealthCheck(ctx context.Context, info *api.AgentIdentification) (*api.InformantHealthCheckResp, int, error) {
+	agent, ok := s.agents.Get(info.AgentID)
+	if !ok {
+		return nil, 404, fmt.Errorf("No Agent with ID %s registered", agent.id)
+	} else if !agent.protoVersion.AllowsHealthCheck() {
+		return nil, 400, fmt.Errorf("health checks are not supported in protocol version %v", agent.protoVersion)
+	}
+
+	return &api.InformantHealthCheckResp{}, 200, nil
 }
 
 // TryDownscale tries to downscale the VM's current resource usage, returning whether the proposed

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -220,6 +220,14 @@ func (s *State) RegisterAgent(ctx context.Context, info *api.AgentDesc) (*api.In
 	return &desc, 200, nil
 }
 
+// HealthCheck is a dummy endpoint that allows the autoscaler-agent to check that (a) the informant
+// is up and running, and (b) the agent is still registered.
+//
+// Returns: body (if successful), status code, error (if unsuccessful)
+func (s *State) HealthCheck(ctx context.Context, info *api.AgentDesc) (*api.InformantHealthCheckResp, int, error) {
+	panic("todo")
+}
+
 // TryDownscale tries to downscale the VM's current resource usage, returning whether the proposed
 // amount is ok
 //


### PR DESCRIPTION
This should give a somewhat hacky way of getting around the "informant doesn't retry" issues we've had a couple of in production, by offloading the retry logic into making the autoscaler-agent reconnect when the informant no longer recognizes it.

Resolves #163, #200.