### PR TITLE
deploy/sched: Remove out-of-date comment

### DIFF
--- a/deploy/autoscale-scheduler.yaml
+++ b/deploy/autoscale-scheduler.yaml
@@ -116,8 +116,6 @@ data:
             enabled:
               - name: AutoscaleEnforcer
 ---
-# note: this ConfigMap is not meant to be mounted. For better responsiveness, the scheduler listens
-# for updates on the ConfigMap object directly.
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Removes this comment:

> note: this ConfigMap is not meant to be mounted. For better responsiveness, the scheduler listens for updates on the ConfigMap object directly.

The ConfigMap watcher was removed in #87; currently the plugin *does* actually mount the ConfigMap.