### PR TITLE
Always run e2e tests on push to the main

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -2,11 +2,6 @@ name: e2e-test
 on:
   pull_request:
   push:
-    paths:
-      - "neonvm/**"
-      - "tests/**"
-      - "**.go"
-      - "Makefile"
     branches:
       - main
 


### PR DESCRIPTION
Instead of supporting a list of paths that could affect autoscaling/neonvm, let's just always run e2e tests on push (merge) to the main