### PR TITLE
make: Add targets to build individual docker images

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -74,6 +74,7 @@ jobs:
       # Explicitly build all the images beforehand. Building images while the cluster is up can
       # sometimes affect the cluster. For more information:
       # https://github.com/neondatabase/autoscaling/issues/120#issuecomment-1493405844
+      - run: make build
       - run: make docker-build
       - run: make docker-build-examples
 

--- a/Makefile
+++ b/Makefile
@@ -148,21 +148,36 @@ vm-informant: ## Build vm-informant image
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: build ## Build docker image with the controller.
+docker-build: docker-build-controller docker-build-runner docker-build-vxlan-controller docker-build-autoscaler-agent docker-build-scheduler ## Build docker images for NeonVM controllers, NeonVM runner, autoscaler-agent, and scheduler
+
+.PHONY: docker-build-neonvm-controller
+docker-build-controller: ## Build docker image for NeonVM controller
 	docker build --build-arg VM_RUNNER_IMAGE=$(IMG_RUNNER) -t $(IMG_CONTROLLER) -f neonvm/Dockerfile .
+
+.PHONY: docker-build-neonvm-runner
+docker-build-runner: ## Build docker image for NeonVM runner
 	docker build -t $(IMG_RUNNER) -f neonvm/runner/Dockerfile .
+
+.PHONY: docker-build-vxlan-controller
+docker-build-vxlan-controller: ## Build docker image for NeonVM vxlan controller
 	docker build -t $(IMG_VXLAN) -f neonvm/tools/vxlan/Dockerfile .
-	docker buildx build \
-		--tag $(AUTOSCALER_SCHEDULER_IMG) \
-		--load \
-		--build-arg "GIT_INFO=$(GIT_INFO)" \
-		--file build/autoscale-scheduler/Dockerfile \
-		.
+
+.PHONY: docker-build-autoscaler-agent
+docker-build-autoscaler-agent: ## Build docker image for autoscaler-agent
 	docker buildx build \
 		--tag $(AUTOSCALER_AGENT_IMG) \
 		--load \
 		--build-arg "GIT_INFO=$(GIT_INFO)" \
 		--file build/autoscaler-agent/Dockerfile \
+		.
+
+.PHONY: docker-build-scheduler
+docker-build-scheduler: ## Build docker image for (autoscaling) scheduler
+	docker buildx build \
+		--tag $(AUTOSCALER_SCHEDULER_IMG) \
+		--load \
+		--build-arg "GIT_INFO=$(GIT_INFO)" \
+		--file build/autoscale-scheduler/Dockerfile \
 		.
 
 .PHONY: docker-build-examples


### PR DESCRIPTION
Just a quality-of-life improvement. When developing locally, I often only want to rebuild a single image, but changing any file invalidates the docker caches for all images, so `make docker-build` does a lot of work that I don't actually care about.

This PR also changes the `docker-build` target so that it no longer has a dependency on `build`, which *seems* like it's ok, AFAICT.