### PR TITLE
agent/informant: Make (*InformantServer).Valid() private

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -273,14 +273,14 @@ func IsNormalInformantError(err error) bool {
 		errors.Is(err, InformantServerNotCurrentError)
 }
 
-// Valid checks if the InformantServer is good to use for communication, returning an error if not
+// valid checks if the InformantServer is good to use for communication, returning an error if not
 //
 // This method can return errors for a number of unavoidably-racy protocol states - errors from this
 // method should be handled as unusual, but not unexpected. Any error returned will be one of
 // InformantServer{AlreadyExited,Suspended,Confirmed}Error.
 //
 // This method MUST be called while holding s.runner.lock.
-func (s *InformantServer) Valid() error {
+func (s *InformantServer) valid() error {
 	if s.exitStatus != nil {
 		return InformantServerAlreadyExitedError
 	}
@@ -884,7 +884,7 @@ func (s *InformantServer) Downscale(ctx context.Context, to api.Resources) (*api
 	err := func() error {
 		s.runner.lock.Lock()
 		defer s.runner.lock.Unlock()
-		return s.Valid()
+		return s.valid()
 	}()
 	if err != nil {
 		return nil, err
@@ -926,7 +926,7 @@ func (s *InformantServer) Upscale(ctx context.Context, to api.Resources) error {
 	err := func() error {
 		s.runner.lock.Lock()
 		defer s.runner.lock.Unlock()
-		return s.Valid()
+		return s.valid()
 	}()
 	if err != nil {
 		return err

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -916,7 +916,7 @@ func (s *InformantServer) HealthCheck(ctx context.Context) (*api.InformantHealth
 	err := func() error {
 		s.runner.lock.Lock()
 		defer s.runner.lock.Unlock()
-		return s.Valid()
+		return s.valid()
 	}()
 	if err != nil {
 		return nil, err

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1539,7 +1539,7 @@ func (r *Runner) validateInformant() error {
 	if r.server == nil {
 		return errors.New("no informant server set")
 	}
-	return r.server.Valid()
+	return r.server.valid()
 }
 
 // doInformantDownscale is a convenience wrapper around (*InformantServer).Downscale that locks r,


### PR DESCRIPTION
Correct usage requires accessing a private field, so the method shouldn't be public.

ref https://github.com/neondatabase/autoscaling/pull/203#discussion_r1174293331

Will merge this after #203 to avoid complicating that PR.