### PR TITLE
informant: Fix panic on HealthCheck for missing agent

### DIFF
--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -227,7 +227,7 @@ func (s *State) RegisterAgent(ctx context.Context, info *api.AgentDesc) (*api.In
 func (s *State) HealthCheck(ctx context.Context, info *api.AgentIdentification) (*api.InformantHealthCheckResp, int, error) {
 	agent, ok := s.agents.Get(info.AgentID)
 	if !ok {
-		return nil, 404, fmt.Errorf("No Agent with ID %s registered", agent.id)
+		return nil, 404, fmt.Errorf("No Agent with ID %s registered", info.AgentID)
 	} else if !agent.protoVersion.AllowsHealthCheck() {
 		return nil, 400, fmt.Errorf("health checks are not supported in protocol version %v", agent.protoVersion)
 	}


### PR DESCRIPTION
Without this, got the following in the logs, while doing other cgroup-related testing.

```
I0423 21:58:10.558353     142 main.go:165] Running vm-informant with args [-cgroup neon-test]
I0423 21:58:10.669739    4505 main.go:41] buildInfo.GitInfo:   v0.6.0-30-g3e7297f
I0423 21:58:10.670666    4505 main.go:42] buildInfo.GoVersion: go1.20.3
I0423 21:58:10.671451    4505 main.go:95] Selected cgroup "neon-test", starting handler with config {OOMBufferBytes:209715200 MemoryHighBufferBytes:104857600 MaxUpscaleWaitMillis:20}
I0423 21:58:10.673234    4505 cgroupmanager.go:124] Initial memory.events: {Low:0 High:15140 Max:0 OOM:0 OOMKill:0}
I0423 21:58:10.674406    4505 main.go:111] No postgres file cache selected
I0423 21:58:10.676361    4505 cgroup.go:74] Total memory available for cgroup is 968151040 bytes (923.30078125 MiB). Setting cgroup memory.high to 758435840 bytes (723.30078125 MiB)
I0423 21:58:10.678046    4505 cgroupmanager.go:247] Updating cgroup memory.high to 723.30078125 MiB (758435840 bytes)
I0423 21:58:10.679988    4505 cgroup.go:85] Successfully set cgroup memory.high
I0423 21:58:10.680859    4505 main.go:129] Starting server at 0.0.0.0:10301
I0423 21:58:11.154242    4505 cgroupmanager.go:100] New memory.events: {Low:0 High:15157 Max:0 OOM:0 OOMKill:0}
W0423 21:58:11.155349    4505 cgroupmanager.go:81] Respecting minimum wait of 1s before restarting memory.events listener
I0423 21:58:11.156609    4505 cgroup.go:147] Received memory high event. Freezing cgroup
I0423 21:58:11.157575    4505 cgroup.go:160] Sending request for immediate upscaling, waiting for at most 20ms
W0423 21:58:11.177870    4505 cgroup.go:170] Timed out after 20.301145ms waiting for upscale. Thawing cgroup
I0423 21:58:11.679928    4505 cgroupmanager.go:87] Restarting memory.events listener
I0423 21:58:11.800184    4505 cgroupmanager.go:100] New memory.events: {Low:0 High:15193 Max:0 OOM:0 OOMKill:0}
W0423 21:58:11.801183    4505 cgroupmanager.go:81] Respecting minimum wait of 1s before restarting memory.events listener
I0423 21:58:11.802446    4505 cgroup.go:147] Received memory high event. Freezing cgroup
I0423 21:58:11.803461    4505 cgroup.go:160] Sending request for immediate upscaling, waiting for at most 20ms
W0423 21:58:11.823512    4505 cgroup.go:170] Timed out after 20.055166ms waiting for upscale. Thawing cgroup
I0423 21:58:12.681616    4505 cgroupmanager.go:87] Restarting memory.events listener
I0423 21:58:13.075906    4505 cgroupmanager.go:100] New memory.events: {Low:0 High:15248 Max:0 OOM:0 OOMKill:0}
W0423 21:58:13.077121    4505 cgroupmanager.go:81] Respecting minimum wait of 1s before restarting memory.events listener
I0423 21:58:13.078664    4505 cgroup.go:147] Received memory high event. Freezing cgroup
I0423 21:58:13.079847    4505 cgroup.go:160] Sending request for immediate upscaling, waiting for at most 20ms
W0423 21:58:13.100203    4505 cgroup.go:170] Timed out after 20.378035ms waiting for upscale. Thawing cgroup
I0423 21:58:13.216120    4505 handle.go:46] Received request on /health-check (client = 10.244.162.132:57170) {AgentID:8de14343-cc1e-4187-b450-56d4bf655cc4}
2023/04/23 21:58:13 http: panic serving 10.244.162.132:57170: runtime error: invalid memory address or nil pointer dereference
goroutine 64 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1854 +0xbf
panic({0x1519580, 0x237b870})
	/usr/local/go/src/runtime/panic.go:890 +0x263
github.com/neondatabase/autoscaling/pkg/informant.(*State).HealthCheck(0x1?, {0x1bf3b29?, 0xc0000d90a0?}, 0xc00047bbf0?)
	/workspace/pkg/informant/endpoints.go:230 +0xb1
github.com/neondatabase/autoscaling/pkg/util.AddHandler[...].func1(0xc000417100)
	/workspace/pkg/util/handle.go:48 +0x5d2
net/http.HandlerFunc.ServeHTTP(0xc000113ce0?, {0x19018f0?, 0xc000113ce0?}, 0x16d1ed8?)
	/usr/local/go/src/net/http/server.go:2122 +0x2f
net/http.(*ServeMux).ServeHTTP(0x0?, {0x19018f0, 0xc000113ce0}, 0xc000417100)
	/usr/local/go/src/net/http/server.go:2500 +0x149
net/http.serverHandler.ServeHTTP({0x18f5538?}, {0x19018f0, 0xc000113ce0}, 0xc000417100)
	/usr/local/go/src/net/http/server.go:2936 +0x316
net/http.(*conn).serve(0xc000108630, {0x1902520, 0xc0004a4840})
	/usr/local/go/src/net/http/server.go:1995 +0x612
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:3089 +0x5ed
```