### PR TITLE
informant: Try to avoid cgroup memory.high throttling

### DIFF
--- a/pkg/informant/cgroup.go
+++ b/pkg/informant/cgroup.go
@@ -18,8 +18,8 @@ import (
 // CgroupState provides the high-level cgroup handling logic, building upon the low-level plumbing
 // provided by CgroupManager.
 type CgroupState struct {
-	// updateMemHighLock guards access to setting the cgroup's memory.high
-	updateMemHighLock sync.Mutex
+	// updateMemLimitsLock guards access to setting the cgroup's memory.high and memory.max
+	updateMemLimitsLock sync.Mutex
 
 	mgr    *CgroupManager
 	config CgroupConfig
@@ -52,6 +52,27 @@ type CgroupConfig struct {
 	// MaxUpscaleWaitMillis gives the maximum duration, in milliseconds, that we're allowed to pause
 	// the cgroup for while waiting for the autoscaler-agent to upscale us
 	MaxUpscaleWaitMillis uint
+
+	// DoNotFreezeMoreOftenThanMillis gives a required minimum time, in milliseconds, that we must
+	// wait before re-freezing the cgroup while waiting for the autoscaler-agent to upscale us.
+	DoNotFreezeMoreOftenThanMillis uint
+
+	// MemoryHighIncreaseByBytes gives the amount of memory, in bytes, that we should periodically
+	// increase memory.high by while waiting for the autoscaler-agent to upscale us.
+	//
+	// This exists to avoid the excessive throttling that happens when a cgroup is above its
+	// memory.high for too long. See more here:
+	// https://github.com/neondatabase/autoscaling/issues/44#issuecomment-1522487217
+	MemoryHighIncreaseByBytes uint64
+
+	// MemoryHighIncreaseEveryMillis gives the period, in milliseconds, at which we should
+	// repeatedly increase the value of the cgroup's memory.high while we're waiting on upscaling
+	// and memory.high is still being hit.
+	//
+	// Technically speaking, this actually serves as a rate limit to moderate responding to
+	// memory.high events, but these are roughly equivalent if the process is still allocating
+	// memory.
+	MemoryHighIncreaseEveryMillis uint
 }
 
 // ReceivedUpscale notifies s.upscaleEventsRecvr
@@ -61,11 +82,11 @@ func (s *CgroupState) ReceivedUpscale() {
 	s.upscaleEventsSendr.Send()
 }
 
-// setMemoryHigh updates the cgroup's value of memory.high, according to the current total
-// system memory.
+// setMemoryLimits updates the cgroup's value of memory.high and memory.max, according to the memory
+// made available to the cgroup.
 //
-// This method MUST be called while holding s.updateMemHighLock.
-func (s *CgroupState) setMemoryHigh(availableMemory uint64) error {
+// This method MUST be called while holding s.updateMemLimitsLock.
+func (s *CgroupState) setMemoryLimits(availableMemory uint64) error {
 	var newMemHigh uint64
 	mib := float64(1 << 20) // Size of 1 MiB = 2^20 = 1 << 20
 
@@ -78,49 +99,31 @@ func (s *CgroupState) setMemoryHigh(availableMemory uint64) error {
 
 	s.mgr.MemoryHighEvent.Consume()
 
-	if err := s.mgr.SetHighMem(newMemHigh); err != nil {
-		return fmt.Errorf("Error setting cgroup memory.high: %w", err)
+	memLimits := memoryLimits{
+		highBytes: newMemHigh,
+		maxBytes:  availableMemory,
+	}
+	if err := s.mgr.SetMemLimits(memLimits); err != nil {
+		return fmt.Errorf("Error setting cgroup memory limits: %w", err)
 	}
 
-	klog.Infof("Successfully set cgroup memory.high")
+	klog.Infof("Successfully set cgroup memory limits")
 	return nil
 }
 
 // handleCgroupSignals is an internal function that handles "memory high" signals from the cgroup
 func (s *CgroupState) handleCgroupSignalsLoop(config CgroupConfig) {
-	// NOTE: the process might exit after freezing the cgroup but before thawing it. This isn't
-	// really feasible to fix here; the parent process should handle the "thaw if frozen" check on
-	// exit.
-	//
 	// FIXME: we should have "proper" error handling instead of just panicking. It's hard to
 	// determine what the correct behavior should be if a cgroup operation fails, though.
 
-	// FIXME: make minWaitDuration configurable.
-	minWaitDuration := time.Second
-	mustWait := false
+	waitingOnUpscale := false
 
+	waitToIncreaseMemoryHigh := time.NewTimer(0)
+	waitToFreeze := time.NewTimer(0)
+
+	// hey! Before reading this function, have a read through the fields of CgroupConfig - it'll be
+	// hard to understand the control flow that's going on here without that.
 	for {
-		if mustWait {
-			timer := time.After(minWaitDuration)
-			ignored := 0
-			for {
-				select {
-				case <-s.upscaleEventsRecvr.Recv():
-					ignored += 1
-					continue
-				case <-timer:
-				}
-				break
-			}
-			if ignored != 0 {
-				plural := ""
-				if ignored > 1 {
-					plural = "s"
-				}
-				klog.Warningf("Ignoring memory event%s that occurred while respecting minimum wait", plural)
-			}
-		}
-
 		// Wait for a new signal
 		select {
 		case err := <-s.mgr.ErrCh:
@@ -128,12 +131,87 @@ func (s *CgroupState) handleCgroupSignalsLoop(config CgroupConfig) {
 		case <-s.upscaleEventsRecvr.Recv():
 			klog.Infof("Received upscale event")
 			s.mgr.MemoryHighEvent.Consume()
+
+			// note: Don't reset the timers. We still want to be precise about our rate limit, if
+			// upscale events are happening very frequently.
+
 		case <-s.mgr.MemoryHighEvent.Recv():
-			if err := s.handleMemoryHighEvent(config); err != nil {
-				panic(fmt.Errorf("Error handling memory high event: %w", err))
+			select {
+			case <-waitToFreeze.C:
+				var err error
+
+				// Freeze the cgroup and request more memory (maybe duplicate - that'll be handled
+				// internally so we're not spamming the agent)
+				waitingOnUpscale, err = s.handleMemoryHighEvent(config)
+				if err != nil {
+					panic(fmt.Errorf("Error handling memory high event: %w", err))
+				}
+				waitToFreeze.Reset(time.Duration(config.DoNotFreezeMoreOftenThanMillis) * time.Millisecond)
+			default:
+				if !waitingOnUpscale {
+					klog.Infof("Received memory.high event, but too soon to re-freeze. Requesting upscaling")
+
+					// Too soon after the last freeze, but there's currently no unsatisfied
+					// upscaling requests. We should send a new one:
+					func() {
+						s.updateMemLimitsLock.Lock()
+						defer s.updateMemLimitsLock.Unlock()
+
+						// Double-check we haven't already been upscaled (can happen if the agent
+						// independently decides to upscale us again)
+						select {
+						case <-s.upscaleEventsRecvr.Recv():
+							klog.Infof("No need to request upscaling because we were already upscaled")
+							return
+						default:
+							s.requestUpscale()
+						}
+					}()
+				} else {
+					// Maybe increase memory.high to reduce throttling:
+					select {
+					case <-waitToIncreaseMemoryHigh.C:
+						klog.Infof("Received memory.high event, too soon to re-freeze, but increasing memory.high")
+
+						func() {
+							s.updateMemLimitsLock.Lock()
+							defer s.updateMemLimitsLock.Unlock()
+
+							// Double-check we haven't already been upscaled (can happen if the
+							// agent independently decides to upscale us again)
+							select {
+							case <-s.upscaleEventsRecvr.Recv():
+								klog.Infof("No need to update memory.high because we were already upscaled")
+								return
+							default:
+								s.requestUpscale()
+							}
+
+							memHigh, err := s.mgr.FetchMemoryHigh()
+							if err != nil {
+								panic(fmt.Errorf("Error fetching memory.high: %w", err))
+							} else if memHigh == nil {
+								panic(fmt.Errorf("memory.high is unset (equal to 'max') but should have been set to a value already"))
+							}
+
+							newMemHigh := *memHigh + config.MemoryHighIncreaseByBytes
+							klog.Infof(
+								"Updating memory.high from %g MiB -> %g MiB",
+								float64(*memHigh)/float64(1<<20), float64(newMemHigh)/float64(1<<20),
+							)
+
+							if err := s.mgr.SetMemHigh(newMemHigh); err != nil {
+								panic(fmt.Errorf("Error setting memory limits: %w", err))
+							}
+						}()
+
+						waitToIncreaseMemoryHigh.Reset(time.Duration(config.MemoryHighIncreaseEveryMillis) * time.Millisecond)
+					default:
+						// Can't do anything.
+					}
+				}
 			}
 		}
-
 	}
 }
 
@@ -143,12 +221,29 @@ func (s *CgroupState) handleCgroupSignalsLoop(config CgroupConfig) {
 // This method waits on s.agents.UpscaleEvents(), so incorrect behavior will occur if it's called at
 // the same time as anything else that waits on the upscale events. For that reason, both this
 // function and s.setMemoryHigh() are dispatched from within s.handleCgroupSignalsLoop().
-func (s *CgroupState) handleMemoryHighEvent(config CgroupConfig) error {
+func (s *CgroupState) handleMemoryHighEvent(config CgroupConfig) (waitingOnUpscale bool, _ error) {
+	locked := true
+	s.updateMemLimitsLock.Lock()
+	defer func() {
+		if locked {
+			s.updateMemLimitsLock.TryLock()
+		}
+	}()
+
+	// If we've actually already received an upscale event, then we should ignore this memory.high
+	// event for the time being:
+	select {
+	case <-s.upscaleEventsRecvr.Recv():
+		klog.Infof("Skipping memory.high event because there was an upscale event")
+		return false, nil
+	default:
+	}
+
 	klog.Infof("Received memory high event. Freezing cgroup")
 
 	// Immediately freeze the cgroup before doing anything else.
 	if err := s.mgr.Freeze(); err != nil {
-		return fmt.Errorf("Error freezing cgroup: %w", err)
+		return false, fmt.Errorf("Error freezing cgroup: %w", err)
 	}
 
 	startTime := time.Now()
@@ -161,22 +256,29 @@ func (s *CgroupState) handleMemoryHighEvent(config CgroupConfig) error {
 
 	s.requestUpscale()
 
+	// Unlock before waiting:
+	locked = false
+	s.updateMemLimitsLock.Unlock()
+
+	var upscaled bool
+
 	select {
 	case <-s.upscaleEventsRecvr.Recv():
 		totalWait := time.Since(startTime)
 		klog.Infof("Received notification that upscale occurred after %s. Thawing cgroup", totalWait)
+		upscaled = true
 	case <-mustThaw:
 		totalWait := time.Since(startTime)
 		klog.Warningf("Timed out after %s waiting for upscale. Thawing cgroup", totalWait)
 	}
 
 	if err := s.mgr.Thaw(); err != nil {
-		return fmt.Errorf("Error thawing cgroup: %w", err)
+		return false, fmt.Errorf("Error thawing cgroup: %w", err)
 	}
 
 	s.mgr.MemoryHighEvent.Consume()
 
-	return nil
+	return !upscaled, nil
 }
 
 // calculateMemoryHighValue calculates the new value for the cgroup's memory.high based on the total

--- a/pkg/informant/cgroup.go
+++ b/pkg/informant/cgroup.go
@@ -187,7 +187,7 @@ func (s *CgroupState) handleCgroupSignalsLoop(config CgroupConfig) {
 								s.requestUpscale()
 							}
 
-							memHigh, err := s.mgr.FetchMemoryHigh()
+							memHigh, err := s.mgr.FetchMemoryHighBytes()
 							if err != nil {
 								panic(fmt.Errorf("Error fetching memory.high: %w", err))
 							} else if memHigh == nil {
@@ -200,7 +200,7 @@ func (s *CgroupState) handleCgroupSignalsLoop(config CgroupConfig) {
 								float64(*memHigh)/float64(1<<20), float64(newMemHigh)/float64(1<<20),
 							)
 
-							if err := s.mgr.SetMemHigh(newMemHigh); err != nil {
+							if err := s.mgr.SetMemHighBytes(newMemHigh); err != nil {
 								panic(fmt.Errorf("Error setting memory limits: %w", err))
 							}
 						}()

--- a/pkg/informant/cgroup.go
+++ b/pkg/informant/cgroup.go
@@ -93,8 +93,8 @@ func (s *CgroupState) setMemoryLimits(availableMemory uint64) error {
 	newMemHigh = s.config.calculateMemoryHighValue(availableMemory)
 
 	klog.Infof(
-		"Total memory available for cgroup is %d bytes (%g MiB). Setting cgroup memory.high to %d bytes (%g MiB)",
-		availableMemory, float64(availableMemory)/mib, newMemHigh, float64(newMemHigh)/mib,
+		"Total memory available for cgroup %q is %d bytes (%g MiB). Setting cgroup memory.high to %d bytes (%g MiB)",
+		s.mgr.name, availableMemory, float64(availableMemory)/mib, newMemHigh, float64(newMemHigh)/mib,
 	)
 
 	s.mgr.MemoryHighEvent.Consume()
@@ -104,10 +104,10 @@ func (s *CgroupState) setMemoryLimits(availableMemory uint64) error {
 		maxBytes:  availableMemory,
 	}
 	if err := s.mgr.SetMemLimits(memLimits); err != nil {
-		return fmt.Errorf("Error setting cgroup memory limits: %w", err)
+		return fmt.Errorf("Error setting cgroup %q memory limits: %w", s.mgr.name, err)
 	}
 
-	klog.Infof("Successfully set cgroup memory limits")
+	klog.Infof("Successfully set cgroup %q memory limits", s.mgr.name)
 	return nil
 }
 

--- a/pkg/informant/cgroupmanager.go
+++ b/pkg/informant/cgroupmanager.go
@@ -242,15 +242,47 @@ func cgroupPath(groupName string, file string) string {
 	return filepath.Join("/sys/fs/cgroup", groupName, file) //nolint:gocritic // see comment above.
 }
 
-// SetMemLimit sets the memory.high limit of the cgroup, clearing
-func (c *CgroupManager) SetHighMem(bytes uint64) error {
-	klog.Infof("Updating cgroup memory.high to %v MiB (%d bytes)", float64(bytes)/float64(1<<20), bytes)
+type memoryLimits struct {
+	highBytes uint64
+	maxBytes  uint64
+}
+
+// SetMemLimits sets the cgroup's memory.high and memory.max to the values provided by the
+// memoryLimits.
+func (c *CgroupManager) SetMemLimits(limits memoryLimits) error {
+	// convert uint64 -> int64
+	hb, mb := int64(limits.highBytes), int64(limits.maxBytes)
+	return c.manager.Update(&cgroup2.Resources{
+		Memory: &cgroup2.Memory{High: &hb, Max: &mb},
+	})
+}
+
+func (c *CgroupManager) SetMemHigh(bytes uint64) error {
 	high := int64(bytes)
 	return c.manager.Update(&cgroup2.Resources{
 		Memory: &cgroup2.Memory{
 			High: &high,
 		},
 	})
+}
+
+func (c *CgroupManager) FetchMemoryHigh() (*uint64, error) {
+	path := cgroupPath(c.name, "memory.high")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading file at %q: %w", path, err)
+	}
+
+	stringContent := strings.TrimSpace(string(content))
+	if stringContent == "max" {
+		return nil, nil
+	}
+
+	amount, err := strconv.ParseUint(stringContent, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing as uint64: %w", err)
+	}
+	return &amount, nil
 }
 
 // FetchState returns a cgroup2.State indicating whether the cgroup is currently frozen

--- a/pkg/informant/cgroupmanager.go
+++ b/pkg/informant/cgroupmanager.go
@@ -257,7 +257,7 @@ func (c *CgroupManager) SetMemLimits(limits memoryLimits) error {
 	})
 }
 
-func (c *CgroupManager) SetMemHigh(bytes uint64) error {
+func (c *CgroupManager) SetMemHighBytes(bytes uint64) error {
 	high := int64(bytes)
 	return c.manager.Update(&cgroup2.Resources{
 		Memory: &cgroup2.Memory{
@@ -266,7 +266,7 @@ func (c *CgroupManager) SetMemHigh(bytes uint64) error {
 	})
 }
 
-func (c *CgroupManager) FetchMemoryHigh() (*uint64, error) {
+func (c *CgroupManager) FetchMemoryHighBytes() (*uint64, error) {
 	path := cgroupPath(c.name, "memory.high")
 	content, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/informant/cgroupmanager.go
+++ b/pkg/informant/cgroupmanager.go
@@ -250,8 +250,9 @@ type memoryLimits struct {
 // SetMemLimits sets the cgroup's memory.high and memory.max to the values provided by the
 // memoryLimits.
 func (c *CgroupManager) SetMemLimits(limits memoryLimits) error {
-	// convert uint64 -> int64
-	hb, mb := int64(limits.highBytes), int64(limits.maxBytes)
+	// convert uint64 -> int64 so we can produce pointers
+	hb := int64(limits.highBytes)
+	mb := int64(limits.maxBytes)
 	return c.manager.Update(&cgroup2.Resources{
 		Memory: &cgroup2.Memory{High: &hb, Max: &mb},
 	})

--- a/pkg/informant/consts.go
+++ b/pkg/informant/consts.go
@@ -28,9 +28,14 @@ var (
 
 	// DefaultCgroupConfig is the default CgroupConfig used for cgroup interaction logic
 	DefaultCgroupConfig CgroupConfig = CgroupConfig{
-		OOMBufferBytes:        200 * (1 << 20), // 200 MiB
+		OOMBufferBytes:        100 * (1 << 20), // 100 MiB
 		MemoryHighBufferBytes: 100 * (1 << 20), // 100 MiB
-		MaxUpscaleWaitMillis:  20,              // 20ms
+		// while waiting for upscale, don't freeze for more than 20ms every 1s
+		MaxUpscaleWaitMillis:           20,   // 20ms
+		DoNotFreezeMoreOftenThanMillis: 1000, // 1s
+		// while waiting for upscale, increase memory.high by 10 MiB every 25ms
+		MemoryHighIncreaseByBytes:     10 * (1 << 20), // 10 MiB
+		MemoryHighIncreaseEveryMillis: 25,             // 25ms
 	}
 
 	// DefaultFileCacheConfig is the default FileCacheConfig used for managing the file cache

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -124,12 +124,12 @@ func WithCgroup(cgm *CgroupManager, config CgroupConfig) NewStateOpts {
 
 			upscaleEventsSendr, upscaleEventsRecvr := util.NewCondChannelPair()
 			s.cgroup = &CgroupState{
-				updateMemHighLock:  sync.Mutex{},
-				mgr:                cgm,
-				config:             config,
-				upscaleEventsSendr: upscaleEventsSendr,
-				upscaleEventsRecvr: upscaleEventsRecvr,
-				requestUpscale:     func() { s.agents.RequestUpscale() },
+				updateMemLimitsLock: sync.Mutex{},
+				mgr:                 cgm,
+				config:              config,
+				upscaleEventsSendr:  upscaleEventsSendr,
+				upscaleEventsRecvr:  upscaleEventsRecvr,
+				requestUpscale:      func() { s.agents.RequestUpscale() },
 			}
 		},
 		post: func(s *State, memTotal uint64) error {
@@ -142,8 +142,8 @@ func WithCgroup(cgm *CgroupManager, config CgroupConfig) NewStateOpts {
 			//  4. Get downscaled (as approved earlier)
 			// A potential way to fix this would be writing to a file to record approved downscale
 			// operations.
-			if err := s.cgroup.setMemoryHigh(available); err != nil {
-				return fmt.Errorf("Error setting initial cgroup memory.high: %w", err)
+			if err := s.cgroup.setMemoryLimits(available); err != nil {
+				return fmt.Errorf("Error setting initial cgroup memory limits: %w", err)
 			}
 			go s.cgroup.handleCgroupSignalsLoop(config)
 			return nil
@@ -271,8 +271,8 @@ func (s *State) TryDownscale(ctx context.Context, target *api.RawResources) (*ap
 	// Also, lock changing the cgroup between the initial calculations and later using them.
 	var newCgroupMemHigh uint64
 	if s.cgroup != nil {
-		s.cgroup.updateMemHighLock.Lock()
-		defer s.cgroup.updateMemHighLock.Unlock()
+		s.cgroup.updateMemLimitsLock.Lock()
+		defer s.cgroup.updateMemLimitsLock.Unlock()
 
 		newCgroupMemHigh = s.cgroup.config.calculateMemoryHighValue(usableSystemMemory - expectedFileCacheMemUsage)
 
@@ -322,16 +322,26 @@ func (s *State) TryDownscale(ctx context.Context, target *api.RawResources) (*ap
 	}
 
 	if s.cgroup != nil {
+		availableMemory := usableSystemMemory - fileCacheMemUsage
+
 		if fileCacheMemUsage != expectedFileCacheMemUsage {
-			newCgroupMemHigh = s.cgroup.config.calculateMemoryHighValue(usableSystemMemory - fileCacheMemUsage)
+			newCgroupMemHigh = s.cgroup.config.calculateMemoryHighValue(availableMemory)
+		}
+
+		memLimits := memoryLimits{
+			highBytes: newCgroupMemHigh,
+			maxBytes:  availableMemory,
 		}
 
 		// TODO: see similar note above. We shouldn't call methods on s.cgroup.mgr from here.
-		if err := s.cgroup.mgr.SetHighMem(newCgroupMemHigh); err != nil {
+		if err := s.cgroup.mgr.SetMemLimits(memLimits); err != nil {
 			return internalError(fmt.Errorf("Error setting cgroup memory.high: %w", err))
 		}
 
-		status := fmt.Sprintf("Set cgroup memory.high to %g MiB", float64(newCgroupMemHigh)/mib)
+		status := fmt.Sprintf(
+			"Set cgroup memory.high to %g MiB, of new max %g MiB",
+			float64(newCgroupMemHigh)/mib, float64(availableMemory)/mib,
+		)
 		statusParts = append(statusParts, status)
 	}
 
@@ -368,8 +378,8 @@ func (s *State) NotifyUpscale(ctx context.Context, newResources *api.RawResource
 	mib := float64(1 << 20) // 1 MiB = 2^20 bytes. We'll use this for pretty-printing.
 
 	if s.cgroup != nil {
-		s.cgroup.updateMemHighLock.Lock()
-		defer s.cgroup.updateMemHighLock.Unlock()
+		s.cgroup.updateMemLimitsLock.Lock()
+		defer s.cgroup.updateMemLimitsLock.Unlock()
 	}
 
 	s.agents.ReceivedUpscale()
@@ -409,15 +419,24 @@ func (s *State) NotifyUpscale(ctx context.Context, newResources *api.RawResource
 	}
 
 	if s.cgroup != nil {
-		newMemHigh := s.cgroup.config.calculateMemoryHighValue(usableSystemMemory - fileCacheMemUsage)
+		availableMemory := usableSystemMemory - fileCacheMemUsage
+
+		newMemHigh := s.cgroup.config.calculateMemoryHighValue(availableMemory)
 		klog.Infof(
-			"Updating memory.high to %g MiB, of new total %g MiB",
+			"Updating memory.high to %g MiB, of new max %g MiB",
 			float64(newMemHigh)/mib, float64(newMem)/mib,
 		)
 
-		if err := s.cgroup.mgr.SetHighMem(newMemHigh); err != nil {
+		memLimits := memoryLimits{
+			highBytes: newMemHigh,
+			maxBytes:  availableMemory,
+		}
+
+		if err := s.cgroup.mgr.SetMemLimits(memLimits); err != nil {
 			return internalError(fmt.Errorf("Error setting cgroup memory.high: %w", err))
 		}
+
+		s.cgroup.upscaleEventsSendr.Send()
 	}
 
 	return &struct{}{}, 200, nil


### PR DESCRIPTION
Relevant context:

* https://github.com/neondatabase/autoscaling/issues/44#issuecomment-1522487217
* https://neondb.slack.com/archives/C03TN5G758R/p1682450906524189?thread_ts=1682410239.294789&cid=C03TN5G758R

Fixes #44 - tested locally with `allocate-loop`.

Bikeshed-able parameters are here:

https://github.com/neondatabase/autoscaling/blob/26e424006172167948ff6244bf60622b59bbb3c1/pkg/informant/consts.go#L30-L39