### PR TITLE
agent/informant: Fix log for /unregister response

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -577,7 +577,7 @@ func (s *InformantServer) unregisterFromInformant(ctx context.Context) error {
 		return err // the errors returned by doInformantRequest are descriptive enough.
 	}
 
-	s.runner.logger.Infof("Unregister %s request successful: %+v", *resp)
+	s.runner.logger.Infof("Unregister %s request successful: %+v", s.desc.AgentID, *resp)
 	return nil
 }
 


### PR DESCRIPTION
Spotted in CI while looking at an unrelated failure. Link:

https://github.com/neondatabase/autoscaling/actions/runs/4801094505/jobs/8544531968#step:16:962