### PR TITLE
agent/informant: Fix inverted 'ErrServerClosed' check

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -238,7 +238,7 @@ func NewInformantServer(
 	// handling, but that's about it.
 	serverName := fmt.Sprintf("InformantServer (%s)", server.desc.AgentID)
 	runner.spawnBackgroundWorker(ctx, serverName, func(c context.Context) {
-		if err := httpServer.Serve(listener); errors.Is(err, http.ErrServerClosed) {
+		if err := httpServer.Serve(listener); !errors.Is(err, http.ErrServerClosed) {
 			runner.logger.Errorf("InformantServer exited with unexpected error: %s", err)
 		}
 


### PR DESCRIPTION
Spotted in CI while looking at an unrelated failure. Link:

https://github.com/neondatabase/autoscaling/actions/runs/4801094505/jobs/8544531968#step:16:955