### PR TITLE
deploy/sched: Mark scheduler as system-cluster-critical

### DIFF
--- a/deploy/autoscale-scheduler.yaml
+++ b/deploy/autoscale-scheduler.yaml
@@ -160,6 +160,7 @@ spec:
         name: autoscale-scheduler # stable name
         tier: control-plane
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: autoscale-scheduler
       containers:
       # hey! This image name is hard-coded in .github/workflows/release.yaml - make sure to


### PR DESCRIPTION
Just discovered `priorityClassName: system-cluster-critical` while reading about cluster-autoscaler:

> It is possible to run a customized deployment of Cluster Autoscaler on worker nodes, but extra care needs to be taken to ensure that Cluster Autoscaler remains up and running. Users can put it into kube-system namespace (Cluster Autoscaler doesn't scale down node with non-mirrored kube-system pods running on them) and **set a priorityClassName: system-cluster-critical property on your pod spec (to prevent your pod from being evicted).**

(emphasis added)

AFAIK we haven't yet run into any issues because of this, but maybe worthwhile to have? The scheduler handles restarts just fine, so it may also be ok if evicted, as long as a new pod comes up quickly.