### PR TITLE
neonvm: Add current usage annotation to runner Pod

### DIFF
--- a/neonvm/Dockerfile
+++ b/neonvm/Dockerfile
@@ -12,6 +12,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
+COPY pkg/util            pkg/util
 COPY neonvm/main.go      neonvm/main.go
 COPY neonvm/apis/        neonvm/apis/
 COPY neonvm/controllers/ neonvm/controllers/

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -30,6 +30,19 @@ import (
 // VM's name).
 const VirtualMachineNameLabel string = "vm.neon.tech/name"
 
+// VirtualMachineUsageAnnotation is the annotation added to each runner Pod, mirroring information
+// about the resource allocations of the VM running in the pod.
+//
+// The value of this annotation is always a JSON-encoded VirtualMachineUsage object.
+const VirtualMachineUsageAnnotation string = "vm.neon.tech/usage"
+
+// VirtualMachineUsage provides information about a VM's current usage. This is the type of the
+// JSON-encoded data in the VirtualMachineUsageAnnotation attached to each runner pod.
+type VirtualMachineUsage struct {
+	CPU    int32              `json:"cpu"`
+	Memory *resource.Quantity `json:"memory"`
+}
+
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // VirtualMachineSpec defines the desired state of VirtualMachine

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -322,6 +322,13 @@ func (r *VirtualMachineMigrationReconciler) doReconcile(ctx context.Context, vir
 			virtualmachinemigration.Status.SourcePodIP = vm.Status.PodIP
 			virtualmachinemigration.Status.TargetPodIP = targetRunner.Status.PodIP
 
+			// Set the target runner's "usage" annotation before anything else, so that it will be
+			// correct even if the rest of the reconcile operation fails
+			if err := updateRunnerUsageAnnotation(ctx, r.Client, vm, targetRunner.Name); err != nil {
+				log.Error(err, "Failed to set target Pod usage annotation", "VirtualMachineMigration", virtualmachinemigration)
+				return err
+			}
+
 			readyToMigrateCPU := false
 			// do hotplugCPU in targetRunner before migration if .spec.guest.cpus.use defined
 			if vm.Spec.Guest.CPUs.Use != nil {


### PR DESCRIPTION
The annotation is based on the value of Spec.Guest.*.Use, not the status, because that's what the rest of the autoscaling system uses to make decisions with.

To observe this annotation changing live, you can use:

    kubectl get pod -w -o jsonpath='{.metadata.name}{": "}{.metadata.annotations.vm\\.neon\\.tech/usage}{"\n"}'

(different shells may handle the backslashes differently; the argument passed to kubectl should have single backslashes, like vm\\.neon\\.tech)

<!-- Ironically, we still need double backslashes in markdown in order to show the correct thing. The commit message has single backslashes. -->

This feature is probably the easiest path towards patching cluster-autoscaler to work with our VMs - it avoids needing to pass through an extra neonvm client everywhere.

~~This PR currently semantically conflicts with #172 and `VirtualMachineUsage.CPU` should be updated after that merges.~~