### PR TITLE
e2e: use 5m timeout on actions/setup-go

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+        # Sometimes setup-go gets stuck. Without this, it'll keep going until the job gets killed
+        timeout-minutes: 5
 
       - uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
Sometimes it gets stuck, and won't get killed for a very long time.