### PR TITLE
neonvm/multus: Add node affinity to kube-multus-ds DaemonSet

### DIFF
--- a/neonvm/config/default-vxlan/multus/daemonset_patch.yaml
+++ b/neonvm/config/default-vxlan/multus/daemonset_patch.yaml
@@ -1,0 +1,24 @@
+# patch the DaemonSet so that it's only running on nodes that we'd support
+#
+# The image we're is a linux amd64 image; it doesn't work on ARM or non-Linux.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux

--- a/neonvm/config/default-vxlan/multus/kustomization.yaml
+++ b/neonvm/config/default-vxlan/multus/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 
 bases:
 - https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/v3.9.3/deployments/multus-daemonset-thick-plugin.yml
+
+patchesStrategicMerge:
+- daemonset_patch.yaml


### PR DESCRIPTION
Ran into an issue because of this while deploying to dev-eu-central-1-alpha, because there's currently a graviton node there. Manually fixed it there with `nodeSelector: { "kubernetes.io/arch": "amd64" }` — in this PR, I've instead copied the node affinity rules from the vxlan daemonset.