### PR TITLE
change dev scheduler image to match release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ env:
   INFORMANT_IMAGE: "neondatabase/vm-informant"
 
   LOCAL_AGENT_IMAGE: "autoscaler-agent:dev"
-  LOCAL_SCHED_IMAGE: "kube-autoscale-scheduler:dev"
+  LOCAL_SCHED_IMAGE: "autoscale-scheduler:dev"
 
   KUSTOMIZE_VERSION:        "4.5.7"
   CONTROLLER_TOOLS_VERSION: "0.9.2"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ IMG_RUNNER ?= runner:dev
 IMG_VXLAN ?= vxlan-controller:dev
 
 # Autoscaler related images
-AUTOSCALER_SCHEDULER_IMG ?= kube-autoscale-scheduler:dev
+AUTOSCALER_SCHEDULER_IMG ?= autoscale-scheduler:dev
 AUTOSCALER_AGENT_IMG ?= autoscaler-agent:dev
 VM_INFORMANT_IMG ?= vm-informant:dev
 E2E_TESTS_VM_IMG ?= vm-postgres:15-bullseye

--- a/deploy/autoscale-scheduler.yaml
+++ b/deploy/autoscale-scheduler.yaml
@@ -164,7 +164,7 @@ spec:
       containers:
       # hey! This image name is hard-coded in .github/workflows/release.yaml - make sure to
       # update that as well if you change this line!
-      - image: kube-autoscale-scheduler:dev
+      - image: autoscale-scheduler:dev
         command: ["/usr/bin/kube-scheduler", "--config=/etc/kubernetes/autoscale-scheduler-config/scheduler-config.yaml"]
         livenessProbe:
           httpGet:
@@ -172,7 +172,7 @@ spec:
             port: 10259
             scheme: HTTPS
           initialDelaySeconds: 15
-        name: kube-second-scheduler
+        name: autoscale-scheduler
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Changes from "kube-autoscale-scheduler" to "autoscale-scheduler".

Also updates the container name from "kube-second-scheduler" to "autoscale-scheduler".