### PR TITLE
billing: Revert value to int, not float

### DIFF
--- a/pkg/billing/model.go
+++ b/pkg/billing/model.go
@@ -21,5 +21,5 @@ type IncrementalEvent struct {
 	EndpointID     string    `json:"endpoint_id"`
 	StartTime      time.Time `json:"start_time"`
 	StopTime       time.Time `json:"stop_time"`
-	Value          float64   `json:"value"`
+	Value          int       `json:"value"`
 }


### PR DESCRIPTION
This was part of #172 that I'd mistakenly suggested. It turns out the control plane actually cannot accept fractional values for billing values.