### PR TITLE
sched: Don't output command help on error

### DIFF
--- a/cmd/autoscale-scheduler/main.go
+++ b/cmd/autoscale-scheduler/main.go
@@ -54,6 +54,10 @@ func runProgram() (err error) {
 	}
 
 	command := app.NewSchedulerCommand(app.WithPlugin(plugin.Name, plugin.NewAutoscaleEnforcerPlugin(ctx, conf)))
+	// Don't output the full usage whenever any error occurs (otherwise, startup errors get drowned
+	// out by many pages of scheduler command flags)
+	command.SilenceUsage = true
+
 	if err := command.ExecuteContext(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
Copy-pasting from the added comment:

> Don't output the full usage whenever any error occurs (otherwise, startup errors get drowned out by many pages of scheduler command flags)

Worth noting that `ExecuteContext` will actually always return an error (because the scheduler always returns an error), so this will also happen on a "successful" exit, once those are possible.

Haven't _actually_ tested this (because #55), although it _should_ be possible to observe the change (due to #250).