### PR TITLE
make: Build vm-builder w/o cgo - avoid dynamic linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,11 +125,11 @@ build: fmt vet bin/vm-builder bin/vm-builder-generic ## Build all neonvm binarie
 
 .PHONY: bin/vm-builder
 bin/vm-builder: ## Build vm-builder binary.
-	go build -o bin/vm-builder -ldflags "-X main.Version=${GIT_INFO} -X main.VMInformant=${VM_INFORMANT_IMG}" neonvm/tools/vm-builder/main.go
+	CGO_ENABLED=0 go build -o bin/vm-builder -ldflags "-X main.Version=${GIT_INFO} -X main.VMInformant=${VM_INFORMANT_IMG}" neonvm/tools/vm-builder/main.go
 
 .PHONY: bin/vm-builder-generic
 bin/vm-builder-generic: ## Build vm-builder-generic binary.
-	go build -o bin/vm-builder-generic  neonvm/tools/vm-builder-generic/main.go
+	CGO_ENABLED=0 go build -o bin/vm-builder-generic  neonvm/tools/vm-builder-generic/main.go
 
 .PHONY: run
 run: fmt vet ## Run a controller from your host.


### PR DESCRIPTION
Ran into this issue here: https://github.com/neondatabase/neon/actions/runs/4949327913/jobs/8853330006#step:5:11

```
./vm-builder: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./vm-builder)
```

Go is only dynamically linked when cgo is enabled, so we _should_ be able to fix this by disabling cgo :)