### PR TITLE
neonvm: Fix default ports from Go client

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -57,13 +57,13 @@ type VirtualMachineSpec struct {
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:default:=20183
 	// +optional
-	QMP int32 `json:"qmp"`
+	QMP int32 `json:"qmp,omitempty"`
 
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:default:=25183
 	// +optional
-	RunnerPort int32 `json:"runnerPort"`
+	RunnerPort int32 `json:"runnerPort,omitempty"`
 
 	// +kubebuilder:default:=5
 	// +optional


### PR DESCRIPTION
**The problem:**

Even though the NeonVM CRD marks the QMP and Runner ports as optional, because the Go client still includes them in the JSON (as the zero value), this "default" isn't used from Go, because the ports are being explicitly set to zero (which is an invalid value!)

Ran into this for this PR: https://github.com/neondatabase/cloud/pull/4904

```
2023-05-12T16:26:31.9283678Z 2023-05-12T16:25:23.881Z	ERROR	operations_executor.op_manager	could not execute operation	{"source": "background_worker", "worker_type": "operations_executor", "trace_id": "P5BUpSFvzpccG5yAWMAXVy", "op_id": "c0da49a5-482c-4f91-b1c8-49fa67173327", "op_action": "start_compute", "project_id": "icy-boat-776944", "executor_id": "console.neon.local", "branch_id": "br-long-pine-329735", "endpoint_id": "ep-winter-mud-626891", "error": "could not execute operation: could not create compute for endpoint: VirtualMachine.vm.neon.tech \"compute-node-ep-winter-mud-626891\" is invalid: spec.runnerPort: Invalid value: 0: spec.runnerPort in body should be greater than or equal to 1"}
```

**The fix:**

Use JSON omitempty, so the default value in Go (zero) is not sent, so that the value can be set by its *actual* default.