### PR TITLE
neonvm/vm-builder: Fix missing whitespace before first CMD arg

### DIFF
--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -210,7 +210,7 @@ fi
 if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
     /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo '{{$first := true}}{{range .Cmd}}{{if $first}}{{$first = false}}{{else}} {{end}}{{.}}{{end}}' >>/neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo '{{range .Cmd}} {{.}}{{end}}' >> /neonvm/bin/vmstarter.sh
 fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh


### PR DESCRIPTION
Ran into this issue on this PR: https://github.com/neondatabase/neon/pull/4155

[The logs](https://github.com/neondatabase/cloud/actions/runs/4961923787/jobs/8879661707#step:45:754) had things like this:

    /neonvm/bin/vmstarter.sh: line 6: /usr/local/bin/compute_ctl-D: not found

This is because the control plane's first argument to compute_ctl is '-D <database dir>', and it was getting merged with the path to the binary.

(sources: [setting args](https://github.com/neondatabase/cloud/blob/3800327f76870b21f1fa2e7e8a6f66ab359d9be0/goapp/internal/operationsv2/provisioner_k8s.go#L478), [generating args](https://github.com/neondatabase/cloud/blob/3800327f76870b21f1fa2e7e8a6f66ab359d9be0/goapp/internal/operationsv2/provisioner_common.go#L53-L63))

Fixing this can be done (for now) by just adding a space before all arguments, although the long-term solution should probably be to rewrite the handling of arguments, as noted here: https://github.com/neondatabase/autoscaling/pull/184#issuecomment-1509900546