### PR TITLE
plugin/watch: Fix comment description of pod events

### DIFF
--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -19,7 +19,7 @@ import (
 )
 
 // watchPodEvents continuously tracks a handful of Pod-related events that we care about. These
-// events are: non-VM pod deletion, VM deletion, and VMs that disable scaling.
+// events are non-VM pod deletion and VM deletion.
 //
 // This method starts its own goroutine, and guarantees that we have started listening for FUTURE
 // events once it returns (unless it returns error).


### PR DESCRIPTION
```diff
diff --git a/pkg/plugin/watch.go b/pkg/plugin/watch.go
index 1813046..d2d517a 100644
--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -19,7 +19,7 @@ import (
 )
 
 // watchPodEvents continuously tracks a handful of Pod-related events that we care about. These
-// events are: non-VM pod deletion, VM deletion, and VMs that disable scaling.
+// events are non-VM pod deletion and VM deletion.
 //
 // This method starts its own goroutine, and guarantees that we have started listening for FUTURE
 // events once it returns (unless it returns error).
```

Since #128, VM disabled scaling events are handled by `watchVMEvents`, not `watchPodEvents`.