### PR TITLE
neonvm/api: Add (MilliCPU).AsFloat64()

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -179,6 +179,14 @@ func (m MilliCPU) ToResourceQuantity() *resource.Quantity {
 	return resource.NewMilliQuantity(int64(m), resource.BinarySI)
 }
 
+// AsFloat64 converts the MilliCPU value into a float64 of CPU
+//
+// This should be preferred over calling m.ToResourceQuantity().AsApproximateFloat64(), because
+// going through the resource.Quantity can produce less precise floats.
+func (m MilliCPU) AsFloat64() float64 {
+	return float64(m) / 1000
+}
+
 // this is used to parse scheduler config and communication between components
 // we used resource.Quantity as underlying transport format for MilliCPU
 func (m *MilliCPU) UnmarshalJSON(data []byte) error {
@@ -207,8 +215,7 @@ func (m MilliCPU) Format(state fmt.State, verb rune) {
 	case verb == 'v' && state.Flag('#'):
 		state.Write([]byte(fmt.Sprintf("%v", uint32(m))))
 	default:
-		quantity := m.ToResourceQuantity()
-		state.Write([]byte(fmt.Sprintf("%v", quantity.AsApproximateFloat64())))
+		state.Write([]byte(fmt.Sprintf("%v", m.AsFloat64())))
 	}
 }
 

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -182,7 +182,7 @@ func (m MilliCPU) ToResourceQuantity() *resource.Quantity {
 // AsFloat64 converts the MilliCPU value into a float64 of CPU
 //
 // This should be preferred over calling m.ToResourceQuantity().AsApproximateFloat64(), because
-// going through the resource.Quantity can produce less precise floats.
+// going through the resource.Quantity can produce less accurate floats.
 func (m MilliCPU) AsFloat64() float64 {
 	return float64(m) / 1000
 }

--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -643,7 +643,7 @@ func handleCPUChange(w http.ResponseWriter, r *http.Request, cgroupPath string) 
 	}
 
 	// update cgroup
-	log.Printf("got CPU update %v", parsed.VCPUs.ToResourceQuantity().AsApproximateFloat64())
+	log.Printf("got CPU update %v", parsed.VCPUs.AsFloat64())
 	err = setCgroupLimit(parsed.VCPUs, cgroupPath)
 	if err != nil {
 		log.Printf("could not set cgroup limit: %s\n", err)

--- a/pkg/agent/billing.go
+++ b/pkg/agent/billing.go
@@ -203,7 +203,7 @@ func (h *vmMetricsHistory) finalizeCurrentTimeSlice() {
 	// TODO: This approach is imperfect. Floating-point math is probably *fine*, but really not
 	// something we want to rely on. A "proper" solution is a lot of work, but long-term valuable.
 	metricsSeconds := vmMetricsSeconds{
-		cpu:        duration.Seconds() * h.lastSlice.metrics.cpu.ToResourceQuantity().AsApproximateFloat64(),
+		cpu:        duration.Seconds() * h.lastSlice.metrics.cpu.AsFloat64(),
 		activeTime: duration,
 	}
 	h.total.cpu += metricsSeconds.cpu


### PR DESCRIPTION
In general, resource.Quantity's AsApproximateFloat64() method is less precise than if we do the conversion ourselves. This PR adds a new method to do that, and switches to it in all our usage.

---

Originally spotted this in the logs. As a reproduction, take for example, this program:

```go
package main

import (
	"fmt"

	"k8s.io/apimachinery/pkg/api/resource"
)

func main() {
	milli := int64(27278)

	q := resource.NewMilliQuantity(milli, resource.BinarySI)
	fmt.Println("resource:", q.AsApproximateFloat64())
	f := float64(milli) / 1000
	fmt.Println("float:", f)
}
```

With current K8s versions, outputs:

```
resource: 27.278000000000002
float: 27.278
```

(Go playground link: https://go.dev/play/p/S7gW9hxgE7C)
