### PR TITLE
plugin: Print node when handling resource request

### DIFF
--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -724,8 +724,8 @@ func (s *pluginState) startMigration(ctx context.Context, pod *podState, vmClien
 	pod.node.vCPU.PressureAccountedFor += pod.vCPU.Reserved + pod.vCPU.CapacityPressure
 
 	klog.Infof(
-		"[autoscale-enforcer] Migrate pod %v; node.vCPU.capacityPressure %d -> %d (%d -> %d spoken for)",
-		pod.name, oldNodeVCPUPressure, pod.node.vCPU.CapacityPressure, oldNodeVCPUPressureAccountedFor, pod.node.vCPU.PressureAccountedFor,
+		"[autoscale-enforcer] Migrate pod %v from node %s; node.vCPU.capacityPressure %d -> %d (%d -> %d spoken for)",
+		pod.name, pod.node.name, oldNodeVCPUPressure, pod.node.vCPU.CapacityPressure, oldNodeVCPUPressureAccountedFor, pod.node.vCPU.PressureAccountedFor,
 	)
 
 	// Unlock to make the API request, then make sure we're locked on return.


### PR DESCRIPTION
Currently, all of the extension point handlers (e.g. Filter, Score, etc) already print the node on every log line. This allows us to use regex text filtering after-the-fact to restrict logs to a single node, while still including resource handlers.

(in particular, this fixes the "node" selector not fully working [here](https://neonprod.grafana.net/d/cc4f137c-f2fd-4e18-a00a-c92234e3b33a/neon-logs-autoscaling?orgId=1))