### PR TITLE
neonvm/vm-builder: Fix/improve command passthrough

### DIFF
--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -124,12 +124,11 @@ if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
 else
     {{/*
 	A couple notes:
-	  - echo automatically puts spaces between arguments
 	  - .Entrypoint is already shell-escaped twice (everything is quoted)
 	  - the shell-escaping isn't perfect. In particular, it doesn't handle backslashes well.
 	  - It's good enough for now
 	*/}}
-    /neonvm/bin/echo -n {{range .Entrypoint}} {{.}}{{end}} >> /neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo -n {{range .Entrypoint}}' '{{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi
 
 {{/* args.sh is set by the runner with the contents of the VM's spec.guest.args, if it's set */}}
@@ -138,7 +137,7 @@ if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
     /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
 else
     {{/* Same as with .Entrypoint; refer there. We don't have '-n' because we want a trailing newline */}}
-    /neonvm/bin/echo -n {{range .Cmd}} {{.}}{{end}} >> /neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo -n {{range .Cmd}}' '{{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh

--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -112,8 +112,8 @@ fi
 
 {{if or .Entrypoint .Cmd | not}}
 # If we have no arguments *at all*, then emit an error. This matches docker's behavior.
-if /neonvm/bin/test ( ! -f /neonvm/runtime/command.sh ) -a ( ! -f /neonvm/runtime/args.sh ); then
-	/neonvm/bin/echo 'Error: No command specified' >&2
+if /neonvm/bin/test \( ! -f /neonvm/runtime/command.sh \) -a \( ! -f /neonvm/runtime/args.sh \); then
+	/neonvm/bin/echo 'Error: No command specified'
 	exit 1
 fi
 {{end}}

--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/alessio/shellescape"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -109,16 +110,35 @@ if /neonvm/bin/test -f /neonvm/runtime/env.sh; then
     /neonvm/bin/cat /neonvm/runtime/env.sh >>/neonvm/bin/vmstarter.sh
 fi
 
+{{if or .Entrypoint .Cmd | not}}
+# If we have no arguments *at all*, then emit an error. This matches docker's behavior.
+if /neonvm/bin/test ( ! -f /neonvm/runtime/command.sh ) -a ( ! -f /neonvm/runtime/args.sh ); then
+	/neonvm/bin/echo 'Error: No command specified' >&2
+	exit 1
+fi
+{{end}}
+
+{{/* command.sh is set by the runner with the contents of the VM's spec.guest.command, if it's set */}}
 if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
     /neonvm/bin/cat /neonvm/runtime/command.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo -n '{{$first := true}}{{range .Entrypoint}}{{if $first}}{{$first = false}}{{else}} {{end}}{{.}}{{end}}' >>/neonvm/bin/vmstarter.sh
+    {{/*
+	A couple notes:
+	  - echo automatically puts spaces between arguments
+	  - .Entrypoint is already shell-escaped (everything is quoted)
+	  - the shell-escaping isn't perfect. In particular, it doesn't handle backslashes well.
+	  - It's good enough for now
+	*/}}
+    /neonvm/bin/echo -n {{range .Entrypoint}} {{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi
-{{if and .Entrypoint .Cmd}}echo -n ' ' >>/neonvm/bin/vmstarter.sh{{end}}
+
+{{/* args.sh is set by the runner with the contents of the VM's spec.guest.args, if it's set */}}
 if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
+    /neonvm/bin/echo -n ' ' >>/neonvm/bin/vmstarter.sh
     /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo '{{$first := true}}{{range .Cmd}}{{if $first}}{{$first = false}}{{else}} {{end}}{{.}}{{end}}' >>/neonvm/bin/vmstarter.sh
+    {{/* Same as with .Entrypoint; refer there. We don't have '-n' because we want a trailing newline */}}
+    /neonvm/bin/echo -n {{range .Cmd}} {{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh
@@ -301,6 +321,15 @@ func main() {
 	imageSpec, _, err := cli.ImageInspectWithRaw(ctx, *srcImage)
 	if err != nil {
 		log.Fatalln(err)
+	}
+
+	// Shell-escape all the command pieces, twice. We need to do it twice because we're generating
+	// a shell script that appends these to a second shell script.
+	for i := range imageSpec.Config.Entrypoint {
+		imageSpec.Config.Entrypoint[i] = shellescape.Quote(shellescape.Quote(imageSpec.Config.Entrypoint[i]))
+	}
+	for i := range imageSpec.Config.Cmd {
+		imageSpec.Config.Cmd[i] = shellescape.Quote(shellescape.Quote(imageSpec.Config.Cmd[i]))
 	}
 
 	tmplArgs := TemplatesContext{

--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -125,7 +125,7 @@ else
     {{/*
 	A couple notes:
 	  - echo automatically puts spaces between arguments
-	  - .Entrypoint is already shell-escaped (everything is quoted)
+	  - .Entrypoint is already shell-escaped twice (everything is quoted)
 	  - the shell-escaping isn't perfect. In particular, it doesn't handle backslashes well.
 	  - It's good enough for now
 	*/}}

--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -344,11 +344,6 @@ func main() {
 		tmplArgs.User = "root"
 	}
 
-	// if no entrypoint and cmd in docker image then use sleep for 10 years as stub
-	if len(tmplArgs.Entrypoint) == 0 && len(tmplArgs.Cmd) == 0 {
-		tmplArgs.Cmd = []string{"/neonvm/bin/sleep", "3650d"}
-	}
-
 	tarBuffer := new(bytes.Buffer)
 	tw := tar.NewWriter(tarBuffer)
 	defer tw.Close()

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -507,11 +507,6 @@ func main() {
 		tmplArgs.User = "root"
 	}
 
-	// if no entrypoint and cmd in docker image then use sleep for 10 years as stub
-	if len(tmplArgs.Entrypoint) == 0 && len(tmplArgs.Cmd) == 0 {
-		tmplArgs.Cmd = []string{"/neonvm/bin/sleep", "3650d"}
-	}
-
 	tarBuffer := new(bytes.Buffer)
 	tw := tar.NewWriter(tarBuffer)
 	defer tw.Close()

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -21,6 +21,8 @@ import (
 
 // vm-builder --src alpine:3.16 --dst vm-alpine:dev --file vm-alpine.qcow2
 
+var entrypointPrefix = []string{"/usr/sbin/cgexec", "-g", "*:neon-postgres"}
+
 const (
 	dockerfileVmBuilder = `
 FROM {{.InformantImage}} as informant
@@ -111,8 +113,6 @@ COPY --from=libcgroup-builder /libcgroup-install/lib/*  /usr/lib/
 COPY --from=libcgroup-builder /libcgroup-install/sbin/* /usr/sbin/
 COPY --from=postgres-exporter /bin/postgres_exporter /bin/postgres_exporter
 COPY --from=pgbouncer         /usr/local/pgbouncer/bin/pgbouncer /usr/local/bin/pgbouncer
-
-ENTRYPOINT ["/usr/sbin/cgexec", "-g", "*:neon-postgres", "/usr/local/bin/compute_ctl"]
 
 FROM alpine:3.16 AS vm-runtime
 # add busybox
@@ -494,7 +494,7 @@ func main() {
 	}
 
 	tmplArgs := TemplatesContext{
-		Entrypoint:     imageSpec.Config.Entrypoint,
+		Entrypoint:     append(entrypointPrefix, imageSpec.Config.Entrypoint...),
 		Cmd:            imageSpec.Config.Cmd,
 		Env:            imageSpec.Config.Env,
 		RootDiskImage:  *srcImage,

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -216,12 +216,11 @@ if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
 else
     {{/*
 	A couple notes:
-	  - echo automatically puts spaces between arguments
 	  - .Entrypoint is already shell-escaped twice (everything is quoted)
 	  - the shell-escaping isn't perfect. In particular, it doesn't handle backslashes well.
 	  - It's good enough for now
 	*/}}
-    /neonvm/bin/echo -n {{range .Entrypoint}} {{.}}{{end}} >> /neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo -n {{range .Entrypoint}}' '{{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi
 
 {{/* args.sh is set by the runner with the contents of the VM's spec.guest.args, if it's set */}}
@@ -230,7 +229,7 @@ if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
     /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
 else
     {{/* Same as with .Entrypoint; refer there. We don't have '-n' because we want a trailing newline */}}
-    /neonvm/bin/echo -n {{range .Cmd}} {{.}}{{end}} >> /neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo -n {{range .Cmd}}' '{{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -217,8 +217,9 @@ else
     {{/*
 	A couple notes:
 	  - echo automatically puts spaces between arguments
-	  - .Entrypoint is already shell-escaped (everything is quoted)
-	  - therefore, this reproduces the arguments exactly.
+	  - .Entrypoint is already shell-escaped twice (everything is quoted)
+	  - the shell-escaping isn't perfect. In particular, it doesn't handle backslashes well.
+	  - It's good enough for now
 	*/}}
     /neonvm/bin/echo -n {{range .Entrypoint}} {{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -210,7 +210,7 @@ fi
 if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
     /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo '{{$first := true}}{{range .Cmd}}{{if $first}}{{$first = false}}{{else}} {{end}}{{.}}{{end}}' >>/neonvm/bin/vmstarter.sh
+    /neonvm/bin/echo '{{range .Cmd}} {{.}}{{end}}' >> /neonvm/bin/vmstarter.sh
 fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -21,8 +21,6 @@ import (
 
 // vm-builder --src alpine:3.16 --dst vm-alpine:dev --file vm-alpine.qcow2
 
-var entrypointPrefix = []string{"/usr/sbin/cgexec", "-g", "*:neon-postgres"}
-
 const (
 	dockerfileVmBuilder = `
 FROM {{.InformantImage}} as informant
@@ -113,6 +111,8 @@ COPY --from=libcgroup-builder /libcgroup-install/lib/*  /usr/lib/
 COPY --from=libcgroup-builder /libcgroup-install/sbin/* /usr/sbin/
 COPY --from=postgres-exporter /bin/postgres_exporter /bin/postgres_exporter
 COPY --from=pgbouncer         /usr/local/pgbouncer/bin/pgbouncer /usr/local/bin/pgbouncer
+
+ENTRYPOINT ["/usr/sbin/cgexec", "-g", "*:neon-postgres", "/usr/local/bin/compute_ctl"]
 
 FROM alpine:3.16 AS vm-runtime
 # add busybox
@@ -494,7 +494,7 @@ func main() {
 	}
 
 	tmplArgs := TemplatesContext{
-		Entrypoint:     append(entrypointPrefix, imageSpec.Config.Entrypoint...),
+		Entrypoint:     imageSpec.Config.Entrypoint,
 		Cmd:            imageSpec.Config.Cmd,
 		Env:            imageSpec.Config.Env,
 		RootDiskImage:  *srcImage,

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/alessio/shellescape"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -201,16 +202,34 @@ if /neonvm/bin/test -f /neonvm/runtime/env.sh; then
     /neonvm/bin/cat /neonvm/runtime/env.sh >>/neonvm/bin/vmstarter.sh
 fi
 
+{{if or .Entrypoint .Cmd | not}}
+# If we have no arguments *at all*, then emit an error. This matches docker's behavior.
+if /neonvm/bin/test \( ! -f /neonvm/runtime/command.sh \) -a \( ! -f /neonvm/runtime/args.sh \); then
+	/neonvm/bin/echo 'Error: No command specified' >&2
+	exit 1
+fi
+{{end}}
+
+{{/* command.sh is set by the runner with the contents of the VM's spec.guest.command, if it's set */}}
 if /neonvm/bin/test -f /neonvm/runtime/command.sh; then
     /neonvm/bin/cat /neonvm/runtime/command.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo -n '{{$first := true}}{{range .Entrypoint}}{{if $first}}{{$first = false}}{{else}} {{end}}{{.}}{{end}}' >>/neonvm/bin/vmstarter.sh
+    {{/*
+	A couple notes:
+	  - echo automatically puts spaces between arguments
+	  - .Entrypoint is already shell-escaped (everything is quoted)
+	  - therefore, this reproduces the arguments exactly.
+	*/}}
+    /neonvm/bin/echo -n {{range .Entrypoint}} {{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi
-{{if and .Entrypoint .Cmd}}echo -n ' ' >>/neonvm/bin/vmstarter.sh{{end}}
+
+{{/* args.sh is set by the runner with the contents of the VM's spec.guest.args, if it's set */}}
 if /neonvm/bin/test -f /neonvm/runtime/args.sh; then
+    /neonvm/bin/echo -n ' ' >>/neonvm/bin/vmstarter.sh
     /neonvm/bin/cat /neonvm/runtime/args.sh >>/neonvm/bin/vmstarter.sh
 else
-    /neonvm/bin/echo '{{range .Cmd}} {{.}}{{end}}' >> /neonvm/bin/vmstarter.sh
+    {{/* Same as with .Entrypoint; refer there. We don't have '-n' because we want a trailing newline */}}
+    /neonvm/bin/echo -n {{range .Cmd}} {{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh
@@ -463,6 +482,15 @@ func main() {
 	imageSpec, _, err := cli.ImageInspectWithRaw(ctx, *srcImage)
 	if err != nil {
 		log.Fatalln(err)
+	}
+
+	// Shell-escape all the command pieces, twice. We need to do it twice because we're generating
+	// a shell script that appends these to a second shell script.
+	for i := range imageSpec.Config.Entrypoint {
+		imageSpec.Config.Entrypoint[i] = shellescape.Quote(shellescape.Quote(imageSpec.Config.Entrypoint[i]))
+	}
+	for i := range imageSpec.Config.Cmd {
+		imageSpec.Config.Cmd[i] = shellescape.Quote(shellescape.Quote(imageSpec.Config.Cmd[i]))
 	}
 
 	tmplArgs := TemplatesContext{


### PR DESCRIPTION
Supersedes #258. This should offer a more complete solution, hopefully should ease some concerns.

## Problem

Ran into an issue on this PR: https://github.com/neondatabase/neon/pull/4155

[The logs](https://github.com/neondatabase/cloud/actions/runs/4961923787/jobs/8879661707#step:45:754) had things like this:

```
/neonvm/bin/vmstarter.sh: line 6: /usr/local/bin/compute_ctl-D: not found
```

This is because the control plane's first argument to compute_ctl is '-D ', and it was getting merged with the path to the binary.

(sources: [setting args](https://github.com/neondatabase/cloud/blob/3800327f76870b21f1fa2e7e8a6f66ab359d9be0/goapp/internal/operationsv2/provisioner_k8s.go#L478), [generating args](https://github.com/neondatabase/cloud/blob/3800327f76870b21f1fa2e7e8a6f66ab359d9be0/goapp/internal/operationsv2/provisioner_common.go#L53-L63))

## Solution

This PR aims to fix that by reworking the current implementation on the vm-builder side - primarily affecting what `vmstart` looks like. Now, `.Entrypoint` and `.Cmd` are both double shell-escaped (so that it's only singly-escaped in `vmstarter.sh`).

The shell-escaping isn't perfect — in particular, it doesn't handle backslashes. But it should be good enough for now.

Also changed:

- If no arguments at all are given (via VM spec or original image), then `vmstart` will just `exit 1`, matching Docker's behavior if you try to `docker run` something with no arguments.
- Whitespace issue should be fixed. `echo` will naturally put the whitespace in the right spots, and >1 space gets collapsed by the shell. The important thing is having ≥1 space, not =1 space. There's definitely some ways to generate 2 or more spaces, but that's ok.

## Remaining items

- [x] Testing this PR (requires a matrix of ENTRYPOINT/CMD vs Command/Args values, which is overridden, etc)