### PR TITLE
agent/runner: Deduplicate initial scheduler info logs 

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -796,10 +796,13 @@ startScheduler:
 
 	// Set the current scheduler
 	fatal = func() util.SignalReceiver {
-		r.logger.Infof(
-			"Updating scheduler to pod %v (UID = %s) with IP %s",
-			currentInfo.PodName, currentInfo.UID, currentInfo.IP,
-		)
+		// Print info about a new scheduler, unless this is the first one.
+		if init != nil || init.UID != currentInfo.UID {
+			r.logger.Infof(
+				"Updating scheduler to pod %v (UID = %s) with IP %s",
+				currentInfo.PodName, currentInfo.UID, currentInfo.IP,
+			)
+		}
 
 		sendFatal, recvFatal := util.NewSingleSignalPair()
 

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -797,7 +797,7 @@ startScheduler:
 	// Set the current scheduler
 	fatal = func() util.SignalReceiver {
 		// Print info about a new scheduler, unless this is the first one.
-		if init != nil || init.UID != currentInfo.UID {
+		if init == nil || init.UID != currentInfo.UID {
 			r.logger.Infof(
 				"Updating scheduler to pod %v (UID = %s) with IP %s",
 				currentInfo.PodName, currentInfo.UID, currentInfo.IP,


### PR DESCRIPTION
Without this, we get log messages on Runner startup like:

    Got initial scheduler pod kube-system/autoscale-scheduler-5989d49744-g7tb6 ...
    ...
    Updating scheduler to pod kube-system/autoscale-scheduler-5989d49744-g7tb6 ...

This can be confusing! Let's be less confusing.