### PR TITLE
agent/watch: Add custom vmEvent formatting

### DIFF
--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -123,3 +123,30 @@ func makeVMEvent(vm *vmapi.VirtualMachine, kind vmEventKind) (vmEvent, error) {
 		podIP:   vm.Status.PodIP,
 	}, nil
 }
+
+// custom formatting for vmEvent so that it prints in the same way as VmInfo
+func (e vmEvent) Format(state fmt.State, verb rune) {
+	switch {
+	case verb == 'v' && state.Flag('#'):
+		state.Write([]byte(fmt.Sprintf(
+			// note: intentionally order podName and podIP before vmInfo because vmInfo is large.
+			"agent.vmEvent{kind:%q, podName:%q, podIP:%q, vmInfo:%#v}",
+			e.kind, e.podName, e.podIP, e.vmInfo,
+		)))
+	default:
+		if verb != 'v' {
+			state.Write([]byte("%!"))
+			state.Write([]byte(string(verb)))
+			state.Write([]byte("(api.VmInfo="))
+		}
+
+		state.Write([]byte(fmt.Sprintf(
+			"{kind:%s podName:%s podIP:%s vmInfo:%s}",
+			e.kind, e.podName, e.podIP, e.vmInfo,
+		)))
+
+		if verb != 'v' {
+			state.Write([]byte{')'})
+		}
+	}
+}


### PR DESCRIPTION
This matches the existing vmInfo formatting, so that logs that print vmEvent will be able to have better formatting. Without this, we get things like:

    Handling VM event {... vmInfo:{... SlotSize:0xc0006cce00} ...}

("..." added for brevity)