### PR TITLE
agent: Fix stale comment: podEvents -> vmEvents

### DIFF
--- a/pkg/agent/entrypoint.go
+++ b/pkg/agent/entrypoint.go
@@ -72,7 +72,7 @@ func (r MainRunner) Run(ctx context.Context) error {
 			vmWatchStore.Stop()
 			schedulerStore.Stop()
 
-			// Remove anything else from podEvents
+			// Remove anything else from vmEvents
 		loop:
 			for {
 				select {


### PR DESCRIPTION
Maybe not *strictly* a typo. Should have been changed in #111 (along with the rest of the change from podEvents -> vmEvents), but oh well.