### PR TITLE
agent: Restart panicked/errored runners (+metrics)

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -126,42 +126,16 @@ func (s *agentState) handleVMEventAdded(
 	runnerCtx, cancelRunnerContext := context.WithCancel(ctx)
 
 	status := &podStatus{
-		mu:       sync.Mutex{},
-		done:     false,
-		errored:  nil,
-		panicked: false,
-		vmInfo:   event.vmInfo,
+		mu:                sync.Mutex{},
+		endState:          nil,
+		previousEndStates: nil,
+		vmInfo:            event.vmInfo,
 
 		startTime:                   time.Now(),
 		lastSuccessfulInformantComm: nil,
 	}
 
-	runner := &Runner{
-		global: s,
-		status: status,
-		logger: RunnerLogger{
-			prefix: fmt.Sprintf("Runner %v: ", podName),
-		},
-		schedulerRespondedWithMigration: false,
-
-		shutdown:              nil, // set by (*Runner).Run
-		vm:                    event.vmInfo,
-		podName:               podName,
-		podIP:                 event.podIP,
-		lock:                  util.NewChanMutex(),
-		requestLock:           util.NewChanMutex(),
-		requestedUpscale:      api.MoreResources{Cpu: false, Memory: false},
-		lastMetrics:           nil,
-		scheduler:             nil,
-		server:                nil,
-		informant:             nil,
-		computeUnit:           nil,
-		lastApproved:          nil,
-		lastSchedulerError:    nil,
-		lastInformantError:    nil,
-		backgroundWorkerCount: atomic.Int64{},
-		backgroundPanic:       make(chan error),
-	}
+	runner := s.newRunner(status, event.vmInfo, podName, event.podIP)
 
 	txVMUpdate, rxVMUpdate := util.NewCondChannelPair()
 
@@ -172,7 +146,168 @@ func (s *agentState) handleVMEventAdded(
 		status:        status,
 		vmInfoUpdated: txVMUpdate,
 	}
+	s.metrics.runnerStarts.Inc()
 	runner.Spawn(runnerCtx, rxVMUpdate)
+}
+
+// FIXME: make these timings configurable.
+const (
+	RunnerRestartMinWaitSeconds = 5
+	RunnerRestartMaxWaitSeconds = 10
+)
+
+func (s *agentState) TriggerRestartIfNecessary(runnerCtx context.Context, podName util.NamespacedName, podIP string) {
+	// Three steps:
+	//  1. Check if the Runner needs to restart. If no, we're done.
+	//  2. Wait for a random amount of time (between RunnerRestartMinWaitSeconds and RunnerRestartMaxWaitSeconds)
+	//  3. Restart the Runner (if it still should be restarted)
+
+	pod, ok := func() (*podState, bool) {
+		// note: intentionally release s.lock as soon as we're done with it, so that there's no
+		// possibility of holding onto it longer than we need.
+		s.lock.Lock()
+		defer s.lock.Unlock()
+		pod, ok := s.pods[podName]
+		return pod, ok
+	}()
+
+	if !ok {
+		return
+	}
+
+	pod.status.mu.Lock()
+	defer pod.status.mu.Unlock()
+
+	if pod.status.endState != nil {
+		klog.Errorf(
+			"TriggerRestartIfNecessary called with nil endState for pod %v (should only be called after the pod is finished, when endState != nil)",
+			podName,
+		)
+		s.metrics.runnerFatalErrors.Inc()
+		return
+	}
+
+	endTime := pod.status.endState.Time
+
+	if endTime.IsZero() {
+		// If we don't check this, we run the risk of spinning on failures.
+		klog.Errorf("TriggerRestartIfNecessary called with zero'd Time for pod %v", podName)
+		s.metrics.runnerFatalErrors.Inc()
+		// Continue on, but with the time overridden, so we guarantee our minimum wait.
+		endTime = time.Now()
+	}
+
+	// keep this for later.
+	exitKind := pod.status.endState.ExitKind
+
+	switch exitKind {
+	case podStatusExitCanceled:
+		return // successful exit, no need to restart.
+	case podStatusExitPanicked, podStatusExitErrored:
+		// Should restart; continue.
+	default:
+		klog.Errorf("TriggerRestartIfNecessary called with unexpected ExitKind %q for pod %v", podName)
+		s.metrics.runnerFatalErrors.Inc()
+		return
+	}
+
+	// Begin steps (2) and (3) -- wait, then restart.
+	var waitDuration time.Duration
+	totalRuntime := endTime.Sub(pod.status.startTime)
+
+	// If the runner was running for a while, restart immediately.
+	//
+	// NOTE: this will have incorrect behavior when the system clock is behaving weirdly, but that's
+	// mostly ok. It's ok to e.g. restart an extra time at the switchover to daylight saving time.
+	if totalRuntime > time.Second*time.Duration(RunnerRestartMaxWaitSeconds) {
+		waitDuration = 0
+	} else /* Otherwise, randomly pick within RunnerRestartMinWait..RunnerRestartMaxWait */ {
+		r := util.NewTimeRange(time.Second, RunnerRestartMinWaitSeconds, RunnerRestartMaxWaitSeconds)
+		waitDuration = r.Random()
+		klog.Info("Waiting for %s before restarting Runner %v", waitDuration, podName)
+	}
+
+	// Run the waiting (if necessary) and restarting in another goroutine, so we're not blocking the
+	// caller of this function.
+	go func() {
+		if waitDuration != 0 {
+			select {
+			case <-time.After(waitDuration):
+			case <-runnerCtx.Done():
+				klog.Infof("Canceling restart of Runner %v after %s: %s", podName, time.Since(endTime), runnerCtx.Err())
+				return
+			}
+		}
+
+		s.lock.Lock()
+		defer s.lock.Unlock()
+
+		pod, ok := s.pods[podName]
+		if !ok {
+			klog.Warningf("Canceling restart of Runner %v after %s: no longer present in pod map", podName, time.Since(endTime))
+			return
+		}
+
+		pod.status.mu.Lock()
+		defer pod.status.mu.Unlock()
+
+		// Runner was already restarted
+		if pod.status.endState == nil {
+			addedInfo := "this generally shouldn't happen, but could if there's a new pod with the same name"
+			klog.Warningf(
+				"Canceling restart of Runner %v after %s: Runner was already restarted (%s)",
+				podName, time.Since(endTime), addedInfo,
+			)
+		}
+
+		klog.Infof("Restarting %s Runner %v after %s, was running for %s", exitKind, podName, time.Since(endTime), totalRuntime)
+		//                     ^^
+		// note: exitKind is one of "panicked" or "errored" - e.g. "Restarting panicked Runner ..."
+
+		runner := s.newRunner(pod.status, pod.status.vmInfo, podName, podIP)
+
+		txVMUpdate, rxVMUpdate := util.NewCondChannelPair()
+		// note: pod is *podState, so we don't need to re-assign to the map.
+		pod.vmInfoUpdated = txVMUpdate
+		pod.runner = runner
+
+		pod.status.previousEndStates = append(pod.status.previousEndStates, *pod.status.endState)
+		pod.status.startTime = time.Now()
+
+		s.metrics.runnerRestarts.Inc()
+		runner.Spawn(runnerCtx, rxVMUpdate)
+	}()
+}
+
+func (s *agentState) newRunner(status *podStatus, vmInfo api.VmInfo, podName util.NamespacedName, podIP string) *Runner {
+	return &Runner{
+		global: s,
+		status: status,
+		logger: RunnerLogger{
+			prefix: fmt.Sprintf("Runner %v: ", podName),
+		},
+		schedulerRespondedWithMigration: false,
+
+		shutdown:         nil, // set by (*Runner).Run
+		vm:               vmInfo,
+		podName:          podName,
+		podIP:            podIP,
+		lock:             util.NewChanMutex(),
+		requestLock:      util.NewChanMutex(),
+		requestedUpscale: api.MoreResources{Cpu: false, Memory: false},
+
+		lastMetrics:        nil,
+		scheduler:          nil,
+		server:             nil,
+		informant:          nil,
+		computeUnit:        nil,
+		lastApproved:       nil,
+		lastSchedulerError: nil,
+		lastInformantError: nil,
+
+		backgroundWorkerCount: atomic.Int64{},
+		backgroundPanic:       make(chan error),
+	}
 }
 
 type podState struct {
@@ -207,11 +342,13 @@ func (p *podState) dump(ctx context.Context) podStateDump {
 }
 
 type podStatus struct {
-	mu        sync.Mutex
-	done      bool // if true, the runner finished
-	errored   error
-	panicked  bool // if true, errored will be non-nil
+	mu sync.Mutex
+
 	startTime time.Time
+
+	// if non-nil, the runner is finished
+	endState          *podStatusEndState
+	previousEndStates []podStatusEndState
 
 	lastSuccessfulInformantComm *time.Time
 
@@ -223,15 +360,31 @@ type podStatus struct {
 }
 
 type podStatusDump struct {
-	Done      bool      `json:"done"`
-	Errored   error     `json:"errored"`
-	Panicked  bool      `json:"panicked"`
 	StartTime time.Time `json:"startTime"`
+
+	EndState          *podStatusEndState  `json:"endState"`
+	PreviousEndStates []podStatusEndState `json:"previousEndStates"`
 
 	LastSuccessfulInformantComm *time.Time `json:"lastSuccessfulInformantComm"`
 
 	VMInfo api.VmInfo `json:"vmInfo"`
 }
+
+type podStatusEndState struct {
+	// The reason the Runner exited.
+	ExitKind podStatusExitKind `json:"exitKind"`
+	// If ExitKind is "panicked" or "errored", the error message.
+	Error error     `json:"error"`
+	Time  time.Time `json:"time"`
+}
+
+type podStatusExitKind string
+
+const (
+	podStatusExitPanicked podStatusExitKind = "panicked"
+	podStatusExitErrored  podStatusExitKind = "errored"
+	podStatusExitCanceled podStatusExitKind = "canceled" // top-down signal that the Runner should stop.
+)
 
 func (s *podStatus) informantIsUnhealthy(config *Config) bool {
 	s.mu.Lock()
@@ -251,10 +404,16 @@ func (s *podStatus) dump() podStatusDump {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	var endState *podStatusEndState
+
+	if s.endState != nil {
+		es := *s.endState
+		endState = &es
+	}
+
 	return podStatusDump{
-		Done:     s.done,
-		Errored:  s.errored,
-		Panicked: s.panicked,
+		EndState: endState,
+
 		// FIXME: api.VmInfo contains a resource.Quantity - is that safe to copy by value?
 		VMInfo:    s.vmInfo,
 		StartTime: s.startTime,

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -405,14 +405,17 @@ func (s *podStatus) dump() podStatusDump {
 	defer s.mu.Unlock()
 
 	var endState *podStatusEndState
-
 	if s.endState != nil {
 		es := *s.endState
 		endState = &es
 	}
 
+	previousEndStates := make([]podStatusEndState, len(s.previousEndStates))
+	copy(previousEndStates, s.previousEndStates)
+
 	return podStatusDump{
-		EndState: endState,
+		EndState:          endState,
+		PreviousEndStates: previousEndStates,
 
 		// FIXME: api.VmInfo contains a resource.Quantity - is that safe to copy by value?
 		VMInfo:    s.vmInfo,

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -183,7 +183,6 @@ func (s *agentState) TriggerRestartIfNecessary(runnerCtx context.Context, podNam
 			"TriggerRestartIfNecessary called with nil endState for pod %v (should only be called after the pod is finished, when endState != nil)",
 			podName,
 		)
-		s.metrics.runnerFatalErrors.Inc()
 		return
 	}
 
@@ -192,7 +191,6 @@ func (s *agentState) TriggerRestartIfNecessary(runnerCtx context.Context, podNam
 	if endTime.IsZero() {
 		// If we don't check this, we run the risk of spinning on failures.
 		klog.Errorf("TriggerRestartIfNecessary called with zero'd Time for pod %v", podName)
-		s.metrics.runnerFatalErrors.Inc()
 		// Continue on, but with the time overridden, so we guarantee our minimum wait.
 		endTime = time.Now()
 	}
@@ -207,7 +205,6 @@ func (s *agentState) TriggerRestartIfNecessary(runnerCtx context.Context, podNam
 		// Should restart; continue.
 	default:
 		klog.Errorf("TriggerRestartIfNecessary called with unexpected ExitKind %q for pod %v", podName)
-		s.metrics.runnerFatalErrors.Inc()
 		return
 	}
 

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -264,6 +264,7 @@ func (s *agentState) TriggerRestartIfNecessary(runnerCtx context.Context, podNam
 				"Canceling restart of Runner %v after %s: Runner was already restarted (%s)",
 				podName, time.Since(endTime), addedInfo,
 			)
+			return
 		}
 
 		klog.Infof("Restarting %s Runner %v after %s, was running for %s", exitKind, podName, time.Since(endTime), totalRuntime)

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -292,11 +292,12 @@ func (r *Runner) Spawn(ctx context.Context, vmInfoUpdated util.CondChannelReceiv
 		// Gracefully handle panics, plus trigger restart
 		defer func() {
 			if err := recover(); err != nil {
+				now := time.Now()
 				r.setStatus(func(stat *podStatus) {
 					stat.endState = &podStatusEndState{
 						ExitKind: podStatusExitPanicked,
 						Error:    fmt.Errorf("Runner %v panicked: %v", r.vm.NamespacedName(), err),
-						Time:     time.Now(),
+						Time:     now,
 					}
 				})
 			}

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -302,7 +302,7 @@ func (r *Runner) Spawn(ctx context.Context, vmInfoUpdated util.CondChannelReceiv
 				})
 			}
 
-			r.global.TriggerRestartIfNecessary(ctx, r.vm.NamespacedName(), r.podIP)
+			r.global.TriggerRestartIfNecessary(ctx, r.podName, r.podIP)
 		}()
 
 		err := r.Run(ctx, vmInfoUpdated)

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -289,9 +289,7 @@ func (r *Runner) State(ctx context.Context) (*RunnerState, error) {
 
 func (r *Runner) Spawn(ctx context.Context, vmInfoUpdated util.CondChannelReceiver) {
 	go func() {
-		// Trigger restart if necessary *after* we've handled any panics.
-		defer r.global.TriggerRestartIfNecessary(ctx, r.vm.NamespacedName(), r.podIP)
-		// Gracefully handle panics:
+		// Gracefully handle panics, plus trigger restart
 		defer func() {
 			if err := recover(); err != nil {
 				r.setStatus(func(stat *podStatus) {
@@ -302,6 +300,8 @@ func (r *Runner) Spawn(ctx context.Context, vmInfoUpdated util.CondChannelReceiv
 					}
 				})
 			}
+
+			r.global.TriggerRestartIfNecessary(ctx, r.vm.NamespacedName(), r.podIP)
 		}()
 
 		err := r.Run(ctx, vmInfoUpdated)

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -310,7 +310,6 @@ func (r *Runner) Spawn(ctx context.Context, vmInfoUpdated util.CondChannelReceiv
 		exitKind := podStatusExitCanceled // normal exit, only by context being canceled.
 		if err != nil {
 			exitKind = podStatusExitErrored
-			r.global.metrics.runnerFatalErrors.Inc()
 		}
 		r.setStatus(func(stat *podStatus) {
 			stat.endState = &podStatusEndState{

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -289,22 +289,35 @@ func (r *Runner) State(ctx context.Context) (*RunnerState, error) {
 
 func (r *Runner) Spawn(ctx context.Context, vmInfoUpdated util.CondChannelReceiver) {
 	go func() {
+		// Trigger restart if necessary *after* we've handled any panics.
+		defer r.global.TriggerRestartIfNecessary(ctx, r.vm.NamespacedName(), r.podIP)
 		// Gracefully handle panics:
 		defer func() {
 			if err := recover(); err != nil {
 				r.setStatus(func(stat *podStatus) {
-					stat.panicked = true
-					stat.done = true
-					stat.errored = fmt.Errorf("runner panicked: %v", err)
+					stat.endState = &podStatusEndState{
+						ExitKind: podStatusExitPanicked,
+						Error:    fmt.Errorf("Runner %v panicked: %v", r.vm.NamespacedName(), err),
+						Time:     time.Now(),
+					}
 				})
 			}
 		}()
 
 		err := r.Run(ctx, vmInfoUpdated)
+		endTime := time.Now()
 
+		exitKind := podStatusExitCanceled // normal exit, only by context being canceled.
+		if err != nil {
+			exitKind = podStatusExitErrored
+			r.global.metrics.runnerFatalErrors.Inc()
+		}
 		r.setStatus(func(stat *podStatus) {
-			r.status.done = true
-			r.status.errored = err
+			stat.endState = &podStatusEndState{
+				ExitKind: exitKind,
+				Error:    err,
+				Time:     endTime,
+			}
 		})
 
 		if err != nil {


### PR DESCRIPTION
This doesn't directly fix any individual bug, but it should lessen the impact of some behaviors we're currently seeing.

The bulk of this PR is adding a new function, `(*agentState).TriggerRestartIfNecessary`. It is called each time the Runner exits, and queues restarting the Runner if it failed (from panic or other fatal error). If the Runner was long-running, it's immediately restarted. If it has not been up for long, it is restarted after a random delay of 5-10s.

This PR also:

* Changes `podStatusDump` to have a record of previous "end states" (time, error, why it exited)
* Adds a metric `autoscaling_agent_runner_starts`
* Adds a metric `autoscaling_agent_runner_restarts`

## Todo before merge

- [x] Split some of the metrics changes into a separate PR
- [x] Testing
- [x] Write a more descriptive commit message