### PR TITLE
agent/metrics: Track Runner fatal errors

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -191,6 +191,7 @@ func (s *agentState) TriggerRestartIfNecessary(runnerCtx context.Context, podNam
 			"TriggerRestartIfNecessary called with nil endState for pod %v (should only be called after the pod is finished, when endState != nil)",
 			podName,
 		)
+		s.metrics.runnerFatalErrors.Inc()
 		return
 	}
 
@@ -199,6 +200,7 @@ func (s *agentState) TriggerRestartIfNecessary(runnerCtx context.Context, podNam
 	if endTime.IsZero() {
 		// If we don't check this, we run the risk of spinning on failures.
 		klog.Errorf("TriggerRestartIfNecessary called with zero'd Time for pod %v", podName)
+		s.metrics.runnerFatalErrors.Inc()
 		// Continue on, but with the time overridden, so we guarantee our minimum wait.
 		endTime = time.Now()
 	}
@@ -213,6 +215,7 @@ func (s *agentState) TriggerRestartIfNecessary(runnerCtx context.Context, podNam
 		// Should restart; continue.
 	default:
 		klog.Errorf("TriggerRestartIfNecessary called with unexpected ExitKind %q for pod %v", podName)
+		s.metrics.runnerFatalErrors.Inc()
 		return
 	}
 

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -9,6 +9,7 @@ type PromMetrics struct {
 	schedulerRequests         *prometheus.CounterVec
 	informantRequestsOutbound *prometheus.CounterVec
 	informantRequestsInbound  *prometheus.CounterVec
+	runnerFatalErrors         prometheus.Counter
 	runnerThreadPanics        prometheus.Counter
 	runnerStarts              prometheus.Counter
 	runnerRestarts            prometheus.Counter
@@ -36,6 +37,12 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 		},
 		[]string{"endpoint", "code"},
 	)
+	runnerFatalErrors := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "autoscaling_agent_runner_fatal_errors_total",
+			Help: "Number of fatal errors from autoscaler-agent per-VM main runner thread",
+		},
+	)
 	runnerThreadPanics := prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "autoscaling_agent_runner_thread_panics_total",
@@ -52,6 +59,31 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 		prometheus.CounterOpts{
 			Name: "autoscaling_agent_runner_restarts",
 			Help: "Number of existing per-VM Runners restarted due to failure",
+		},
+	)
+	totalErroredVMs := prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "autoscaling_errored_vm_runners_current",
+			Help: "Number of VMs whose per-VM runner has panicked (and not restarted)",
+		},
+		func() float64 {
+			globalstate.lock.Lock()
+			defer globalstate.lock.Unlock()
+
+			count := 0
+
+			for _, p := range globalstate.pods {
+				func() {
+					p.status.mu.Lock()
+					defer p.status.mu.Unlock()
+
+					if p.status.endState != nil && p.status.endState.ExitKind == podStatusExitErrored {
+						count += 1
+					}
+				}()
+			}
+
+			return float64(count)
 		},
 	)
 	totalPanickedVMs := prometheus.NewGaugeFunc(
@@ -119,7 +151,9 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 		schedulerRequests,
 		informantRequestsOutbound,
 		informantRequestsInbound,
+		runnerFatalErrors,
 		runnerThreadPanics,
+		totalErroredVMs,
 		totalPanickedVMs,
 		totalVMs,
 		totalVMsWithUnhealthyInformants,
@@ -129,6 +163,7 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 		schedulerRequests:         schedulerRequests,
 		informantRequestsOutbound: informantRequestsOutbound,
 		informantRequestsInbound:  informantRequestsInbound,
+		runnerFatalErrors:         runnerFatalErrors,
 		runnerThreadPanics:        runnerThreadPanics,
 		runnerStarts:              runnerStarts,
 		runnerRestarts:            runnerRestarts,

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -311,6 +311,7 @@ func (r *Runner) Spawn(ctx context.Context, vmInfoUpdated util.CondChannelReceiv
 		exitKind := podStatusExitCanceled // normal exit, only by context being canceled.
 		if err != nil {
 			exitKind = podStatusExitErrored
+			r.global.metrics.runnerFatalErrors.Inc()
 		}
 		r.setStatus(func(stat *podStatus) {
 			stat.endState = &podStatusEndState{


### PR DESCRIPTION
Builds on #273. This PR adds two new metrics:

1. `autoscaling_agent_runner_fatal_errors_total`
2. `autoscaling_errored_vms_runners_current`

We already have metrics for tracking when Runners panic, or the current number of Runners that are stopped because they panicked. These two do the same, but for cases where the Runner fails because of a fatal error during startup, rather than panicking.