### PR TITLE
neonvm: Rename 'runner' container to 'neonvm-runner'

### DIFF
--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -794,7 +794,7 @@ func podSpec(virtualmachine *vmv1.VirtualMachine) (*corev1.Pod, error) {
 			},
 			Containers: []corev1.Container{{
 				Image:           image,
-				Name:            "runner",
+				Name:            "neonvm-runner",
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				// Ensure restrictive context for the container
 				// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -930,7 +930,7 @@ func podSpec(virtualmachine *vmv1.VirtualMachine) (*corev1.Pod, error) {
 	if pod.ObjectMeta.Annotations == nil {
 		pod.ObjectMeta.Annotations = map[string]string{}
 	}
-	pod.ObjectMeta.Annotations["kubectl.kubernetes.io/default-container"] = "runner"
+	pod.ObjectMeta.Annotations["kubectl.kubernetes.io/default-container"] = "neonvm-runner"
 
 	// use multus network to add extra network interface
 	if virtualmachine.Spec.ExtraNetwork != nil {


### PR DESCRIPTION
Currently "runner" makes it hard to understand the log output of other systems (e.g. k8s events) interacting with NeonVM. IMO renaming should help make things more understandable to others.

NB: this may require updating some Grafana dashboards.