### PR TITLE
agent/billing: Don't count VMs that aren't running

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -390,6 +390,16 @@ const (
 	VmMigrating VmPhase = "Migrating"
 )
 
+// IsAlive returns whether the guest in the VM is expected to be running
+func (p VmPhase) IsAlive() bool {
+	switch p {
+	case VmRunning, VmMigrating:
+		return true
+	default:
+		return false
+	}
+}
+
 //+genclient
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status

--- a/pkg/agent/billing.go
+++ b/pkg/agent/billing.go
@@ -138,6 +138,10 @@ func (s *billingMetricsState) collect(conf *BillingConfig, store VMStoreForNode)
 			continue
 		}
 
+		if !vm.Status.Phase.IsAlive() {
+			continue
+		}
+
 		key := billingMetricsKey{
 			uid:        vm.UID,
 			endpointID: endpointID,

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -64,7 +64,7 @@ func (r MainRunner) newAgentState(
 
 func vmIsOurResponsibility(vm *vmapi.VirtualMachine, config *Config, nodeName string) bool {
 	return vm.Status.Node == nodeName &&
-		(vm.Status.Phase.IsAlive() && vm.Status.Phase != vmapi.VmRunning) &&
+		(vm.Status.Phase.IsAlive() && vm.Status.Phase != vmapi.VmMigrating) &&
 		vm.Status.PodIP != "" &&
 		api.HasAutoscalingEnabled(vm) &&
 		vm.Spec.SchedulerName == config.Scheduler.SchedulerName

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -64,7 +64,7 @@ func (r MainRunner) newAgentState(
 
 func vmIsOurResponsibility(vm *vmapi.VirtualMachine, config *Config, nodeName string) bool {
 	return vm.Status.Node == nodeName &&
-		vm.Status.Phase == vmapi.VmRunning &&
+		(vm.Status.Phase.IsAlive() && vm.Status.Phase != vmapi.VmRunning) &&
 		vm.Status.PodIP != "" &&
 		api.HasAutoscalingEnabled(vm) &&
 		vm.Spec.SchedulerName == config.Scheduler.SchedulerName


### PR DESCRIPTION
To do this, adds the `(VirtualMachineStatus).IsAlive()` method, so that the autoscaler-agent doesn't need to be kept up-to-date with changes in NeonVM.

Also adds a call to IsAlive() in the agent's `vmIsOurResponsibility` check, so that future changes to NeonVM don't require modification there.

This requires updating #256 after merging, but should mean that changes are localized to `IsAlive`, instead of updating the autoscaler-agent as well.