### PR TITLE
neonvm/vm-builder: Fix cgexec being ignored

### DIFF
--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -21,6 +21,8 @@ import (
 
 // vm-builder --src alpine:3.16 --dst vm-alpine:dev --file vm-alpine.qcow2
 
+var entrypointPrefix = []string{"/usr/sbin/cgexec", "-g", "*:neon-postgres"}
+
 const (
 	dockerfileVmBuilder = `
 FROM {{.InformantImage}} as informant
@@ -111,8 +113,6 @@ COPY --from=libcgroup-builder /libcgroup-install/lib/*  /usr/lib/
 COPY --from=libcgroup-builder /libcgroup-install/sbin/* /usr/sbin/
 COPY --from=postgres-exporter /bin/postgres_exporter /bin/postgres_exporter
 COPY --from=pgbouncer         /usr/local/pgbouncer/bin/pgbouncer /usr/local/bin/pgbouncer
-
-ENTRYPOINT ["/usr/sbin/cgexec", "-g", "*:neon-postgres", "/usr/local/bin/compute_ctl"]
 
 FROM alpine:3.16 AS vm-runtime
 # add busybox
@@ -495,7 +495,7 @@ func main() {
 	}
 
 	tmplArgs := TemplatesContext{
-		Entrypoint:     imageSpec.Config.Entrypoint,
+		Entrypoint:     append(entrypointPrefix, imageSpec.Config.Entrypoint...),
 		Cmd:            imageSpec.Config.Cmd,
 		Env:            imageSpec.Config.Env,
 		RootDiskImage:  *srcImage,

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -21,7 +21,7 @@ import (
 
 // vm-builder --src alpine:3.16 --dst vm-alpine:dev --file vm-alpine.qcow2
 
-var entrypointPrefix = []string{"/usr/sbin/cgexec", "-g", "*:neon-postgres"}
+var entrypointPrefix = []string{"/usr/bin/cgexec", "-g", "memory:neon-postgres"}
 
 const (
 	dockerfileVmBuilder = `


### PR DESCRIPTION
Moves the 'cgexec ...' entrypoint into TemplatesContext, so that it actually gets called.

~~NB: As written, this currently doesn't work with vm-postgres:15-bullseye. More work necessary to fix that.~~
Have tested, issue is fixed.

Extracted from #263, to not block that.