### PR TITLE
deploy: Add ports, VMPodScrape for metrics

### DIFF
--- a/deploy/autoscale-scheduler.yaml
+++ b/deploy/autoscale-scheduler.yaml
@@ -160,6 +160,10 @@ spec:
       containers:
       - image: autoscale-scheduler:dev
         command: ["/usr/bin/kube-scheduler", "--config=/etc/kubernetes/autoscale-scheduler-config/scheduler-config.yaml"]
+        ports:
+        - name: metrics
+          containerPort: 9100
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/autoscaler-agent.yaml
+++ b/deploy/autoscaler-agent.yaml
@@ -97,6 +97,10 @@ spec:
       containers:
         - name: autoscaler-agent
           image: autoscaler-agent:dev
+          ports:
+            - name: metrics
+              containerPort: 9100
+              protocol: TCP
           resources:
             limits:
               memory: 100Mi

--- a/deploy/vmscrape.yaml
+++ b/deploy/vmscrape.yaml
@@ -1,0 +1,20 @@
+# Victoria Metrics scraper for autoscaler-agent and autoscale-scheduler
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: autoscaling-components
+  namespace: monitoring
+spec:
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 10s
+      scrapeTimeout: 10s
+  selector:
+    matchExpressions:
+      - key: name
+        operator: In
+        values: [autoscaler-agent, autoscale-scheduler]
+  namespaceSelector:
+    matchNames:
+      - kube-system


### PR DESCRIPTION
This is what we already have deployed in staging + production, taken from the `staging` and `prod` branches.

Edit: Merging this to accurately reflect the current state. Happy to discuss changes in a follow-up (e.g. maybe we should scrape every 30s or 1min, not 10s)