### PR TITLE
deploy: Clean up rbac

### DIFF
--- a/deploy/autoscale-scheduler.yaml
+++ b/deploy/autoscale-scheduler.yaml
@@ -1,24 +1,3 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: vm-patcher
-rules:
-- apiGroups: ["vm.neon.tech"]
-  resources: ["virtualmachines"]
-  verbs: ["create", "delete", "get", "list", "watch", "patch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: autoscale-scheduler-config-reader
-  namespace: kube-system
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "list", "watch"]
-  # watching is ok as long as we use ListOptions.FieldSelector to limit it to the appropriate name
-  resourceNames: ["scheduler-plugin-config"]
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -28,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: autoscale-scheduler-as-vm-patcher
+  name: autoscale-scheduler-virtualmachine-viewer
   namespace: kube-system
 subjects:
 - kind: ServiceAccount
@@ -36,7 +15,21 @@ subjects:
   namespace: kube-system
 roleRef:
   kind: ClusterRole
-  name: vm-patcher
+  name: neonvm-virtualmachine-viewer-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: autoscale-scheduler-virtualmachinemigration-editor
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: autoscale-scheduler
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: neonvm-virtualmachinemigration-editor-role
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -78,20 +71,6 @@ roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
   name: extension-apiserver-authentication-reader
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: autoscale-scheduler-config-reader
-  namespace: kube-system
-subjects:
-- kind: ServiceAccount
-  name: autoscale-scheduler
-  namespace: kube-system
-roleRef:
-  kind: Role
-  name: autoscale-scheduler-config-reader
-  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/autoscaler-agent.yaml
+++ b/deploy/autoscaler-agent.yaml
@@ -18,21 +18,12 @@ subjects:
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: vm-view
-rules:
-- apiGroups: ["vm.neon.tech"]
-  resources: ["virtualmachines"]
-  verbs: ["get", "list", "patch", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: autoscaler-vm-view
+  name: autoscaler-virtualmachine-editor
 roleRef:
   kind: ClusterRole
-  name: vm-view
+  name: neonvm-virtualmachine-editor-role
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/neonvm/config/common/rbac/kustomization.yaml
+++ b/neonvm/config/common/rbac/kustomization.yaml
@@ -9,6 +9,10 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- virtualmachine_viewer_role.yaml
+- virtualmachine_editor_role.yaml
+- virtualmachinemigration_viewer_role.yaml
+- virtualmachinemigration_editor_role.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.


### PR DESCRIPTION
This PR retains the original functionality, with some unused objects removed, some unused permissions revoked, and ClusterRoles standardized.

It also fixes the scheduler not having any permissions relating to VirtualMachineMigrations, which it will need once those are re-enabled.

This PR removes:

- ClusterRole vm-view
- ClusterRole vm-patcher
- ClusterRoleBinding kube-system/autoscaler-vm-view
- ClusterRoleBinding kube-system/autoscale-scheduler-as-vm-patcher
- Role kube-system/autoscale-scheduler-config-reader
- RoleBinding kube-system/autoscale-scheduler-config-reader

And instead adds:

- NeonVM's various user RBAC ClusterRoles:
  - neonvm-virtualmachine-viewer-role
  - neonvm-virtualmachine-editor-role
  - neonvm-virtualmachinemigration-viewer-role
  - neonvm-virtualmachinemigration-editor-role
- ClusterRoleBinding kube-system/autoscale-scheduler-virtualmachine-viewer
- ClusterRoleBinding kube-system/autoscale-scheduler-virtualmachinemigration-editor
- ClusterRoleBinding kube-system/autoscaler-virtualmachine-editor

The NeonVM RBAC roles were present before, but not included in the rendered manifests.