### PR TITLE
agent/informant: Fix informant server exit logs

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -194,7 +194,11 @@ func NewInformantServer(
 				logFunc = runner.logger.Infof
 			}
 
-			logFunc("Informant server exiting with retry: %v, err: %s", status.RetryShouldFix, status.Err)
+			errDesc := "nil"
+			if status.Err != nil {
+				errDesc = fmt.Sprintf("%s", status.Err)
+			}
+			logFunc("Informant server exiting with: retry=%v, err=%s", status.RetryShouldFix, errDesc)
 		}
 
 		shutdownName := fmt.Sprintf("InformantServer shutdown (%s)", server.desc.AgentID)

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -196,7 +196,7 @@ func NewInformantServer(
 
 			errDesc := "nil"
 			if status.Err != nil {
-				errDesc = fmt.Sprintf("%s", status.Err)
+				errDesc = fmt.Sprintf("%q", status.Err.Error())
 			}
 			logFunc("Informant server exiting with: retry=%v, err=%s", status.RetryShouldFix, errDesc)
 		}

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -194,11 +194,7 @@ func NewInformantServer(
 				logFunc = runner.logger.Infof
 			}
 
-			errDesc := "nil"
-			if status.Err != nil {
-				errDesc = fmt.Sprintf("%q", status.Err.Error())
-			}
-			logFunc("Informant server exiting with: retry=%v, err=%s", status.RetryShouldFix, errDesc)
+			logFunc("Informant server exiting with: retry=%v, err=%v", status.RetryShouldFix, status.Err)
 		}
 
 		shutdownName := fmt.Sprintf("InformantServer shutdown (%s)", server.desc.AgentID)


### PR DESCRIPTION
This commit contains both (a) a fix so that we're not logging %!s(\<nil\>) and (b) minor formatting improvements. The end result is that our logs should go from:

    Informant server exiting with retry: false, err: %!s(<nil>)

to:

    Informant server exiting with: retry=false, err=nil