### PR TITLE
agent: Improve network error observability

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -623,7 +623,7 @@ func doInformantRequest[Q any, R any](
 
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
-		result = "[error doing request]"
+		result = fmt.Sprintf("[error doing request: %s]", util.RootError(err))
 		return nil, statusCode, fmt.Errorf("Error doing request: %w", err)
 	}
 	defer response.Body.Close()

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1696,7 +1696,8 @@ func (s *Scheduler) DoRequest(ctx context.Context, reqData *api.AgentRequest) (*
 
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
-		s.runner.global.metrics.schedulerRequests.WithLabelValues("[error doing request]").Inc()
+		description := fmt.Sprintf("[error doing request: %s]", util.RootError(err))
+		s.runner.global.metrics.schedulerRequests.WithLabelValues(description).Inc()
 		return nil, s.handleRequestError(reqData, fmt.Errorf("Error doing request: %w", err))
 	}
 	defer response.Body.Close()

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -1,0 +1,18 @@
+package util
+
+// Utilities for errors
+
+import (
+	"errors"
+)
+
+// RootError returns the root cause of the error, calling errors.Unwrap until it returns nil
+func RootError(err error) error {
+	for {
+		next := errors.Unwrap(err)
+		if next == nil {
+			return err
+		}
+		err = next
+	}
+}


### PR DESCRIPTION
This commit changes the "code" label for outbound HTTP requests to the scheduler and informant to include the root cause of the error when it's network-related.

For an example of how this can function, see this demo: https://go.dev/play/p/DRmbNPz4E6t

tl;dr: From an error like:

    Get "http://127.0.0.254:4890/": dial tcp 127.0.0.254:4890: connect: connection refused

The root cause is just:

    connection refused

... which is reasonable enough for us to put in the metrics.