### PR TITLE
agent/schedwatch: Improve the logging situtation

### DIFF
--- a/pkg/agent/schedwatch/event.go
+++ b/pkg/agent/schedwatch/event.go
@@ -1,6 +1,8 @@
 package schedwatch
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -10,6 +12,31 @@ import (
 type WatchEvent struct {
 	info SchedulerInfo
 	kind eventKind
+}
+
+func (ev WatchEvent) Format(state fmt.State, verb rune) {
+	switch {
+	case verb == 'v' && state.Flag('#'):
+		state.Write([]byte(fmt.Sprintf(
+			"schedwatch.WatchEvent{kind:%q, info:%#v}",
+			string(ev.kind), ev.info,
+		)))
+	default:
+		if verb != 'v' {
+			state.Write([]byte("%!"))
+			state.Write([]byte(string(verb)))
+			state.Write([]byte("(schedwatch.WatchEvent="))
+		}
+
+		state.Write([]byte(fmt.Sprintf(
+			"{kind:%v info:%v}",
+			ev.kind, ev.info,
+		)))
+
+		if verb != 'v' {
+			state.Write([]byte{')'})
+		}
+	}
 }
 
 type eventKind string
@@ -30,5 +57,30 @@ func newSchedulerInfo(pod *corev1.Pod) SchedulerInfo {
 		PodName: util.NamespacedName{Name: pod.Name, Namespace: pod.Namespace},
 		UID:     pod.UID,
 		IP:      pod.Status.PodIP,
+	}
+}
+
+func (info SchedulerInfo) Format(state fmt.State, verb rune) {
+	switch {
+	case verb == 'v' && state.Flag('#'):
+		state.Write([]byte(fmt.Sprintf(
+			"schedwatch.SchedulerInfo{PodName:%#v, IP:%q, UID:%q}",
+			info.PodName, info.IP, string(info.UID),
+		)))
+	default:
+		if verb != 'v' {
+			state.Write([]byte("%!"))
+			state.Write([]byte(string(verb)))
+			state.Write([]byte("(schedwatch.SchedulerInfo="))
+		}
+
+		state.Write([]byte(fmt.Sprintf(
+			"{PodName:%v IP:%q UID:%q}",
+			info.PodName, info.IP, info.UID,
+		)))
+
+		if verb != 'v' {
+			state.Write([]byte{')'})
+		}
 	}
 }


### PR DESCRIPTION
I couldn't get the "agents not picking up on a new scheduler" issue to reproduce locally, and we didn't have good enough logs to tell what was happening. So this PR aims to fix those logs.

There's also some improved handling relating to checking whether pods have IP addresses (honestly don't know whether it's possible for a pod to be "ready" without an IP address, but it's reasonable enough to have those checks there). And the check for whether the pod's name changed is removed — there's no reasonable circumstance where that matters.

Commit messages should probably be improved before merging. I'll probably merge with rebase, because the commits here are kind of separate.

**NB: This PR builds on #289 and must not be merged before that**