### PR TITLE
util: Move TimeRange into its own time.go

### DIFF
--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+)
+
+type TimeRange struct {
+	min   int
+	max   int
+	units time.Duration
+}
+
+func NewTimeRange(units time.Duration, min, max int) *TimeRange {
+	if min < 0 {
+		panic(errors.New("bad time range: min < 0"))
+	} else if min == 0 && max == 0 {
+		panic(errors.New("bad time range: min and max = 0"))
+	} else if max < min {
+		panic(errors.New("bad time range: max < min"))
+	}
+
+	return &TimeRange{min: min, max: max, units: units}
+}
+
+// Random returns a random time.Duration within the range
+func (r TimeRange) Random() time.Duration {
+	if r.max == r.min {
+		return time.Duration(r.min) * r.units
+	}
+
+	count := rand.Intn(r.max-r.min) + r.min
+	return time.Duration(count) * r.units
+}

--- a/pkg/util/watch.go
+++ b/pkg/util/watch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	stdruntime "runtime"
 	"sync"
 	"sync/atomic"
@@ -38,34 +37,6 @@ type WatchConfig struct {
 	// RetryWatchAfter gives a retry interval when a non-initial watch fails. If left nil, then
 	// Watch will not retry.
 	RetryWatchAfter *TimeRange
-}
-
-type TimeRange struct {
-	min   int
-	max   int
-	units time.Duration
-}
-
-func NewTimeRange(units time.Duration, min, max int) *TimeRange {
-	if min < 0 {
-		panic(errors.New("bad time range: min < 0"))
-	} else if min == 0 && max == 0 {
-		panic(errors.New("bad time range: min and max = 0"))
-	} else if max < min {
-		panic(errors.New("bad time range: max < min"))
-	}
-
-	return &TimeRange{min: min, max: max, units: units}
-}
-
-// Random returns a random time.Duration within the range
-func (r TimeRange) Random() time.Duration {
-	if r.max == r.min {
-		return time.Duration(r.min) * r.units
-	}
-
-	count := rand.Intn(r.max-r.min) + r.min
-	return time.Duration(count) * r.units
 }
 
 // WatchAccessors provides the "glue" functions for Watch to go from a list L (returned by the


### PR DESCRIPTION
Precursor to #297. Should also set up (finally) resolving #35 nicely.