### PR TITLE
deploy/agent: use '|' for configmap data, not single-quote

### DIFF
--- a/deploy/agent/config_map.yaml
+++ b/deploy/agent/config_map.yaml
@@ -5,35 +5,35 @@ metadata:
   namespace: kube-system
 data:
   config.json: '{
-    "scaling": {
-      "requestTimeoutSeconds": 10,
-      "defaultConfig": {
-        "loadAverageFractionTarget": 0.9
+      "scaling": {
+        "requestTimeoutSeconds": 10,
+        "defaultConfig": {
+          "loadAverageFractionTarget": 0.9
+        }
+      },
+      "informant": {
+        "serverPort": 10301,
+        "retryServerMinWaitSeconds": 5,
+        "retryServerNormalWaitSeconds": 5,
+        "registerRetrySeconds": 5,
+        "requestTimeoutSeconds": 1,
+        "registerTimeoutSeconds": 2,
+        "downscaleTimeoutSeconds": 2,
+        "unhealthyAfterSilenceDurationSeconds": 20,
+        "unhealthyStartupGracePeriodSeconds": 20
+      },
+      "metrics": {
+        "loadMetricPrefix": "host_",
+        "requestTimeoutSeconds": 2,
+        "secondsBetweenRequests": 5
+      },
+      "scheduler": {
+        "schedulerName": "autoscale-scheduler",
+        "requestTimeoutSeconds": 2,
+        "requestPort": 10299
+      },
+      "dumpState": {
+        "port": 10300,
+        "timeoutSeconds": 5
       }
-    },
-    "informant": {
-      "serverPort": 10301,
-      "retryServerMinWaitSeconds": 5,
-      "retryServerNormalWaitSeconds": 5,
-      "registerRetrySeconds": 5,
-      "requestTimeoutSeconds": 1,
-      "registerTimeoutSeconds": 2,
-      "downscaleTimeoutSeconds": 2,
-      "unhealthyAfterSilenceDurationSeconds": 20,
-      "unhealthyStartupGracePeriodSeconds": 20
-    },
-    "metrics": {
-      "loadMetricPrefix": "host_",
-      "requestTimeoutSeconds": 2,
-      "secondsBetweenRequests": 5
-    },
-    "scheduler": {
-      "schedulerName": "autoscale-scheduler",
-      "requestTimeoutSeconds": 2,
-      "requestPort": 10299
-    },
-    "dumpState": {
-      "port": 10300,
-      "timeoutSeconds": 5
-    }
   }'

--- a/deploy/agent/config_map.yaml
+++ b/deploy/agent/config_map.yaml
@@ -4,7 +4,8 @@ metadata:
   name: autoscaler-agent-config
   namespace: kube-system
 data:
-  config.json: '{
+  config.json: |
+    {
       "scaling": {
         "requestTimeoutSeconds": 10,
         "defaultConfig": {
@@ -36,4 +37,4 @@ data:
         "port": 10300,
         "timeoutSeconds": 5
       }
-  }'
+    }


### PR DESCRIPTION
Without using '|', the data in the string will be collapsed and line-wrapped by kustomize, making it very difficult to make changes to the ConfigMap in the final manifest(s).

This PR also includes an intermediate commit to handle the indenting, so that it can be put in .git-blame-ignore-revs. (**This PR must be merged via rebase.**)