### PR TITLE
agent: Use queue for global vmEvents, not channel

### DIFF
--- a/pkg/agent/entrypoint.go
+++ b/pkg/agent/entrypoint.go
@@ -25,17 +25,24 @@ type MainRunner struct {
 }
 
 func (r MainRunner) Run(ctx context.Context) error {
-	vmEvents := make(chan vmEvent)
-
 	buildInfo := util.GetBuildInfo()
 	klog.Infof("buildInfo.GitInfo:   %s", buildInfo.GitInfo)
 	klog.Infof("buildInfo.GoVersion: %s", buildInfo.GoVersion)
 
+	vmEventQueue := pubsub.NewUnlimitedQueue[vmEvent]()
+	defer vmEventQueue.Close()
+	pushToQueue := func(ev vmEvent) {
+		if err := vmEventQueue.Add(ev); err != nil {
+			klog.Warningf("error adding vmEvent %+v to queue: %s", ev, err)
+		}
+	}
+
 	klog.Info("Starting VM watcher")
-	vmWatchStore, err := startVMWatcher(ctx, r.Config, r.VMClient, r.EnvArgs.K8sNodeName, vmEvents)
+	vmWatchStore, err := startVMWatcher(ctx, r.Config, r.VMClient, r.EnvArgs.K8sNodeName, pushToQueue)
 	if err != nil {
 		return fmt.Errorf("Error starting VM watcher: %w", err)
 	}
+	defer vmWatchStore.Stop()
 	klog.Info("VM watcher started")
 
 	broker := pubsub.NewBroker[schedwatch.WatchEvent](ctx, pubsub.BrokerOptions{})
@@ -48,6 +55,7 @@ func (r MainRunner) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("starting scheduler watch server: %w", err)
 	}
+	defer schedulerStore.Stop()
 
 	if r.Config.Billing != nil {
 		klog.Info("Starting billing metrics collector")
@@ -70,25 +78,15 @@ func (r MainRunner) Run(ctx context.Context) error {
 
 	klog.Info("Entering main loop")
 	for {
-		select {
-		case <-ctx.Done():
-			vmWatchStore.Stop()
-			schedulerStore.Stop()
-
-			// Remove anything else from vmEvents
-		loop:
-			for {
-				select {
-				case <-vmEvents:
-				default:
-					break loop
-				}
+		event, err := vmEventQueue.Wait(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			} else {
+				klog.Errorf("vmEventQueue returned error: %s", err)
+				return err
 			}
-
-			globalState.Stop()
-			return nil
-		case event := <-vmEvents:
-			globalState.handleEvent(ctx, event)
 		}
+		globalState.handleEvent(ctx, event)
 	}
 }

--- a/pkg/agent/entrypoint.go
+++ b/pkg/agent/entrypoint.go
@@ -81,11 +81,12 @@ func (r MainRunner) Run(ctx context.Context) error {
 		event, err := vmEventQueue.Wait(ctx)
 		if err != nil {
 			if ctx.Err() != nil {
+				// treat context canceled as a "normal" exit (because it is)
 				return nil
-			} else {
-				klog.Errorf("vmEventQueue returned error: %s", err)
-				return err
 			}
+
+			klog.Errorf("vmEventQueue returned error: %s", err)
+			return err
 		}
 		globalState.handleEvent(ctx, event)
 	}

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -38,7 +38,7 @@ func startVMWatcher(
 	config *Config,
 	vmClient *vmclient.Clientset,
 	nodeName string,
-	vmEvents chan<- vmEvent,
+	submitEvent func(vmEvent),
 ) (*watch.Store[vmapi.VirtualMachine], error) {
 	return watch.Watch(
 		ctx,
@@ -62,7 +62,7 @@ func startVMWatcher(
 						klog.Errorf("Error handling VM added: %s", err)
 						return
 					}
-					vmEvents <- event
+					submitEvent(event)
 				}
 			},
 			UpdateFunc: func(oldVM, newVM *vmapi.VirtualMachine) {
@@ -93,7 +93,7 @@ func startVMWatcher(
 					return
 				}
 
-				vmEvents <- event
+				submitEvent(event)
 			},
 			DeleteFunc: func(vm *vmapi.VirtualMachine, maybeStale bool) {
 				if vmIsOurResponsibility(vm, config, nodeName) {
@@ -102,7 +102,7 @@ func startVMWatcher(
 						klog.Errorf("Error handling VM deletion: %s", err)
 						return
 					}
-					vmEvents <- event
+					submitEvent(event)
 				}
 			},
 		},


### PR DESCRIPTION
Pre-req of a later fix in util/watch (#305). This change is similar in spirit to #160 (using a queue in the plugin), arising from a similar need: It's hard to avoid deadlocks without using a queue.