### PR TITLE
util/watch: Add metrics

### DIFF
--- a/pkg/agent/entrypoint.go
+++ b/pkg/agent/entrypoint.go
@@ -31,7 +31,7 @@ func (r MainRunner) Run(ctx context.Context) error {
 	klog.Infof("buildInfo.GitInfo:   %s", buildInfo.GitInfo)
 	klog.Infof("buildInfo.GoVersion: %s", buildInfo.GoVersion)
 
-	watchMetrics := watch.NewMetrics("autoscaling_agent_watchers_")
+	watchMetrics := watch.NewMetrics("autoscaling_agent_watchers")
 
 	klog.Info("Starting VM watcher")
 	vmWatchStore, err := startVMWatcher(ctx, r.Config, r.VMClient, watchMetrics, r.EnvArgs.K8sNodeName, vmEvents)

--- a/pkg/agent/schedwatch/watch.go
+++ b/pkg/agent/schedwatch/watch.go
@@ -22,6 +22,7 @@ func StartSchedulerWatcher(
 	ctx context.Context,
 	logger util.PrefixLogger,
 	kubeClient *kubernetes.Clientset,
+	metrics watch.Metrics,
 	eventBroker *pubsub.Broker[WatchEvent],
 	schedulerName string,
 ) (*watch.Store[corev1.Pod], error) {
@@ -30,6 +31,10 @@ func StartSchedulerWatcher(
 		kubeClient.CoreV1().Pods(schedulerNamespace),
 		watch.Config{
 			LogName: "scheduler",
+			Metrics: &watch.MetricsConfig{
+				Metrics:  metrics,
+				Instance: "Scheduler Pod",
+			},
 			// We don't need to be super responsive to scheduler changes.
 			//
 			// FIXME: make these configurable.

--- a/pkg/agent/schedwatch/watch.go
+++ b/pkg/agent/schedwatch/watch.go
@@ -31,7 +31,7 @@ func StartSchedulerWatcher(
 		kubeClient.CoreV1().Pods(schedulerNamespace),
 		watch.Config{
 			LogName: "scheduler",
-			Metrics: &watch.MetricsConfig{
+			Metrics: watch.MetricsConfig{
 				Metrics:  metrics,
 				Instance: "Scheduler Pod",
 			},

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -46,7 +46,7 @@ func startVMWatcher(
 		vmClient.NeonvmV1().VirtualMachines(corev1.NamespaceAll),
 		watch.Config{
 			LogName: "VMs",
-			Metrics: &watch.MetricsConfig{
+			Metrics: watch.MetricsConfig{
 				Metrics:  metrics,
 				Instance: "VirtualMachines",
 			},

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -37,6 +37,7 @@ func startVMWatcher(
 	ctx context.Context,
 	config *Config,
 	vmClient *vmclient.Clientset,
+	metrics watch.Metrics,
 	nodeName string,
 	vmEvents chan<- vmEvent,
 ) (*watch.Store[vmapi.VirtualMachine], error) {
@@ -45,6 +46,10 @@ func startVMWatcher(
 		vmClient.NeonvmV1().VirtualMachines(corev1.NamespaceAll),
 		watch.Config{
 			LogName: "VMs",
+			Metrics: &watch.MetricsConfig{
+				Metrics:  metrics,
+				Instance: "VirtualMachines",
+			},
 			// We want to be relatively snappy; don't wait for too long before retrying.
 			RetryRelistAfter: util.NewTimeRange(time.Millisecond, 500, 1000),
 			RetryWatchAfter:  util.NewTimeRange(time.Millisecond, 500, 1000),

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -122,13 +122,15 @@ func makeAutoscaleEnforcerPlugin(ctx context.Context, obj runtime.Object, h fram
 		pushToQueue(func() { p.handleUpdatedScalingBounds(vm, podName) })
 	}
 
+	watchMetrics := watch.NewMetrics("autoscaling_plugin_watchers_")
+
 	klog.Infof("[autoscale-enforcer] Starting pod watcher")
-	if err := p.watchPodEvents(ctx, submitVMPodDeletion, submitNonVMPodDeletion); err != nil {
+	if err := p.watchPodEvents(ctx, watchMetrics, submitVMPodDeletion, submitNonVMPodDeletion); err != nil {
 		return nil, fmt.Errorf("Error starting pod watcher: %w", err)
 	}
 
 	klog.Infof("[autoscale-enforcer] Starting VM watcher")
-	vmStore, err := p.watchVMEvents(ctx, submitVMDisabledScaling, submitVMBoundsChanged)
+	vmStore, err := p.watchVMEvents(ctx, watchMetrics, submitVMDisabledScaling, submitVMBoundsChanged)
 	if err != nil {
 		return nil, fmt.Errorf("Error starting VM watcher: %w", err)
 	}
@@ -153,6 +155,8 @@ func makeAutoscaleEnforcerPlugin(ctx context.Context, obj runtime.Object, h fram
 	}()
 
 	promReg := p.makePrometheusRegistry()
+	watchMetrics.MustRegister(promReg)
+
 	if err := util.StartPrometheusMetricsServer(ctx, 9100, promReg); err != nil {
 		return nil, fmt.Errorf("Error starting prometheus server: %w", err)
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -122,7 +122,7 @@ func makeAutoscaleEnforcerPlugin(ctx context.Context, obj runtime.Object, h fram
 		pushToQueue(func() { p.handleUpdatedScalingBounds(vm, podName) })
 	}
 
-	watchMetrics := watch.NewMetrics("autoscaling_plugin_watchers_")
+	watchMetrics := watch.NewMetrics("autoscaling_plugin_watchers")
 
 	klog.Infof("[autoscale-enforcer] Starting pod watcher")
 	if err := p.watchPodEvents(ctx, watchMetrics, submitVMPodDeletion, submitNonVMPodDeletion); err != nil {

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -28,6 +28,7 @@ import (
 // Events occurring before this method is called will not be sent.
 func (e *AutoscaleEnforcer) watchPodEvents(
 	ctx context.Context,
+	metrics watch.Metrics,
 	submitVMDeletion func(util.NamespacedName),
 	submitPodDeletion func(util.NamespacedName),
 ) error {
@@ -36,6 +37,10 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 		e.handle.ClientSet().CoreV1().Pods(corev1.NamespaceAll),
 		watch.Config{
 			LogName: "pods",
+			Metrics: &watch.MetricsConfig{
+				Metrics:  metrics,
+				Instance: "Pods",
+			},
 			// We want to be up-to-date in tracking deletions, so that our reservations are correct.
 			//
 			// FIXME: make these configurable.
@@ -112,6 +117,7 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 // handled by cancelled contexts in *almost all* cases.
 func (e *AutoscaleEnforcer) watchVMEvents(
 	ctx context.Context,
+	metrics watch.Metrics,
 	submitVMDisabledScaling func(util.NamespacedName),
 	submitVMBoundsChanged func(_ *api.VmInfo, podName string),
 ) (*watch.Store[vmapi.VirtualMachine], error) {
@@ -120,6 +126,10 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 		e.vmClient.NeonvmV1().VirtualMachines(corev1.NamespaceAll),
 		watch.Config{
 			LogName: "VMs",
+			Metrics: &watch.MetricsConfig{
+				Metrics:  metrics,
+				Instance: "VirtualMachines",
+			},
 			// FIXME: make these durations configurable.
 			RetryRelistAfter: util.NewTimeRange(time.Millisecond, 250, 750),
 			RetryWatchAfter:  util.NewTimeRange(time.Millisecond, 250, 750),

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -37,7 +37,7 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 		e.handle.ClientSet().CoreV1().Pods(corev1.NamespaceAll),
 		watch.Config{
 			LogName: "pods",
-			Metrics: &watch.MetricsConfig{
+			Metrics: watch.MetricsConfig{
 				Metrics:  metrics,
 				Instance: "Pods",
 			},
@@ -126,7 +126,7 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 		e.vmClient.NeonvmV1().VirtualMachines(corev1.NamespaceAll),
 		watch.Config{
 			LogName: "VMs",
-			Metrics: &watch.MetricsConfig{
+			Metrics: watch.MetricsConfig{
 				Metrics:  metrics,
 				Instance: "VirtualMachines",
 			},

--- a/pkg/util/watch/metrics.go
+++ b/pkg/util/watch/metrics.go
@@ -54,6 +54,8 @@ const metricInstanceLabel = "watcher_instance"
 // All metrics' names will be prefixed with the provided string.
 func NewMetrics(prefix string) Metrics {
 	return Metrics{
+		isFailing: false,
+
 		clientCallsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: fmt.Sprint(prefix, "_client_calls_total"),

--- a/pkg/util/watch/metrics.go
+++ b/pkg/util/watch/metrics.go
@@ -21,7 +21,7 @@ import (
 // - alive_current (1 iff the watcher is currently running or failing, else 0)
 // - failing_current (1 iff the watcher's last request failed *and* it's waiting to retry, else 0)
 //
-// Prefixes are typically of the form "COMPONENT_watchers_" (e.g. "autoscaling_agent_watchers_").
+// Prefixes are typically of the form "COMPONENT_watchers" (e.g. "autoscaling_agent_watchers").
 // Separate reporting per call to Watch is automatically done with the "watcher_instance" label
 // attached to the metrics, using MetricsConfig.
 //
@@ -56,42 +56,42 @@ func NewMetrics(prefix string) Metrics {
 	return Metrics{
 		clientCallsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprint(prefix, "client_calls_total"),
+				Name: fmt.Sprint(prefix, "_client_calls_total"),
 				Help: "Number of calls to k8s client.{Watch,List}, labeled by method",
 			},
 			[]string{metricInstanceLabel, "method"},
 		),
 		relistRequestsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprint(prefix, "relist_requests_total"),
+				Name: fmt.Sprint(prefix, "_relist_requests_total"),
 				Help: "Number of internal manual relisting requests",
 			},
 			[]string{metricInstanceLabel},
 		),
 		eventsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprint(prefix, "events_total"),
+				Name: fmt.Sprint(prefix, "_events_total"),
 				Help: "Number of k8s watch.Events that have occurred, including errors, labeled by type",
 			},
 			[]string{metricInstanceLabel, "type"},
 		),
 		errorsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: fmt.Sprint(prefix, "errors_total"),
+				Name: fmt.Sprint(prefix, "_errors_total"),
 				Help: "Number of errors, either error events or re-list errors, labeled by source",
 			},
 			[]string{metricInstanceLabel, "source"},
 		),
 		aliveCurrent: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: fmt.Sprint(prefix, "alive_current"),
+				Name: fmt.Sprint(prefix, "_alive_current"),
 				Help: "For each watcher, 1 iff the watcher is currently running or failing, else 0",
 			},
 			[]string{metricInstanceLabel},
 		),
 		failingCurrent: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: fmt.Sprint(prefix, "failing_current"),
+				Name: fmt.Sprint(prefix, "_failing_current"),
 				Help: "For each watcher, 1 iff the watcher's last request failed *and* it's waiting to retry, else 0",
 			},
 			[]string{metricInstanceLabel},

--- a/pkg/util/watch/watch.go
+++ b/pkg/util/watch/watch.go
@@ -33,11 +33,11 @@ type Config struct {
 	// LogName is the name of the watcher for use in logs
 	LogName string
 
-	// Metrics, if provided, will be used by the Watch call to report some information about its
-	// internal operations
+	// Metrics will be used by the Watch call to report some information about its internal
+	// operations
 	//
 	// Refer to the Metrics and MetricsConfig types for more information.
-	Metrics *MetricsConfig
+	Metrics MetricsConfig
 
 	// RetryRelistAfter gives a retry interval when a re-list fails. If left nil, then Watch will
 	// not retry.
@@ -208,8 +208,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 			}
 		}
 
-		failing := false
-		defer config.Metrics.unfailing(&failing)
+		defer config.Metrics.unfailing()
 
 		for {
 			// this is used exclusively for relisting, but must be defined up here so that our gotos
@@ -317,7 +316,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 					retryAfter := config.RetryRelistAfter.Random()
 					klog.Infof("watch %s: retrying re-list after %s", config.LogName, retryAfter)
 
-					config.Metrics.failing(&failing)
+					config.Metrics.failing()
 
 					select {
 					case <-time.After(retryAfter):
@@ -330,7 +329,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 					}
 				}
 
-				config.Metrics.unfailing(&failing)
+				config.Metrics.unfailing()
 
 				// err == nil, process relistList
 				relistItems := accessors.Items(relistList)
@@ -411,7 +410,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 					retryAfter := config.RetryWatchAfter.Random()
 					klog.Infof("watch %s: retrying re-watch after %s", config.LogName, retryAfter)
 
-					config.Metrics.failing(&failing)
+					config.Metrics.failing()
 
 					select {
 					case <-time.After(retryAfter):
@@ -425,7 +424,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 				}
 
 				// err == nil
-				config.Metrics.unfailing(&failing)
+				config.Metrics.unfailing()
 				break newWatcher
 			}
 		}


### PR DESCRIPTION
Adds metrics to `util/watch.Watch` calls, for better observability on deeply internal systems. These are aggregated per _binary_, so the new metrics are:

* `$PREFIX_client_calls_total`
* `$PREFIX_relist_requests_total`
* `$PREFIX_events_total`
* `$PREFIX_errors_total`
* `$PREFIX_alive_current`
* `$PREFIX_failing_current`

where `$PREFIX` is either `autoscaling_agent_watchers` or `autoscaling_plugin_watchers`.

A fuller description of each metric can be found in `pkg/util/watch/metrics.go`.

All metrics have the `watcher_instance` label, which associates the metrics with an individual call to `watch.Watch` .