### PR TITLE
agent: Fix vmEvent formatting typo

### DIFF
--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -142,7 +142,7 @@ func (e vmEvent) Format(state fmt.State, verb rune) {
 		}
 
 		state.Write([]byte(fmt.Sprintf(
-			"{kind:%s podName:%s podIP:%s vmInfo:%s}",
+			"{kind:%s podName:%s podIP:%s vmInfo:%v}",
 			e.kind, e.podName, e.podIP, e.vmInfo,
 		)))
 


### PR DESCRIPTION
Noticed in the logs here: https://github.com/neondatabase/autoscaling/actions/runs/5126882656/jobs/9221907427?pr=306#step:16:552