### PR TITLE
agent: Stop SchedulerWatch when Runner finishes

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -347,6 +347,7 @@ func (r *Runner) Run(ctx context.Context, vmInfoUpdated util.CondChannelReceiver
 	if err != nil {
 		return fmt.Errorf("Error starting scheduler watcher: %w", err)
 	}
+	defer schedulerWatch.Stop()
 
 	if scheduler == nil {
 		r.logger.Warningf("No initial scheduler found")


### PR DESCRIPTION
Without this, future event publishing blocks, leaving *all* Runners stuck on an old scheduler (i.e. unable to connect to a new one).

AFAICT this commit fixes the "failure on scheduler restart" bug currently affecting prod.