### PR TITLE
Include AgentID in /downscale and /upscale responses

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -232,11 +232,11 @@ The protocol is as follows:
     1. The informant's `/health-check` endpoint (via PUT), with `AgentIdentification`. This allows
        the autoscaler-agent to check that the informant is up and running, and that it still
        recognizes the agent.
-    2. The informant's `/downscale` endpoint (via PUT), with `RawResources`. This serves as the
+    2. The informant's `/downscale` endpoint (via PUT), with `AgentResourceMessage`. This serves as the
        agent _politely asking_ the informant to decrease resource usage to the specified amount.
        The informant returns a `DownscaleResult` indicating whether it was able to downscale (it may
        not, if e.g. memory usage is too high).
-    3. The informant's `/upscale` endpoint (via PUT), with `RawResources`. This serves as the agent
+    3. The informant's `/upscale` endpoint (via PUT), with `AgentResourceMessage`. This serves as the agent
        _notifying_ the informant that its resources have increased to the provided amount.
     4. The agent's `/suspend` endpoint (via POST), with `SuspendAgent`. This allows the informant to
        inform the agent that it is no longer in use for the VM. While suspended, the agent **must

--- a/cmd/vm-informant/main.go
+++ b/cmd/vm-informant/main.go
@@ -121,8 +121,8 @@ func main() {
 	util.AddHandler("", mux, "/register", http.MethodPost, "AgentDesc", state.RegisterAgent)
 	util.AddHandler("", mux, "/health-check", http.MethodPut, "AgentIdentification", state.HealthCheck)
 	// FIXME: /downscale and /upscale should have the AgentID in the request body
-	util.AddHandler("", mux, "/downscale", http.MethodPut, "RawResources", state.TryDownscale)
-	util.AddHandler("", mux, "/upscale", http.MethodPut, "RawResources", state.NotifyUpscale)
+	util.AddHandler("", mux, "/downscale", http.MethodPut, "SignedRawResources", state.TryDownscale)
+	util.AddHandler("", mux, "/upscale", http.MethodPut, "SignedRawResources", state.NotifyUpscale)
 	util.AddHandler("", mux, "/unregister", http.MethodDelete, "AgentDesc", state.UnregisterAgent)
 
 	addr := "0.0.0.0:10301"

--- a/cmd/vm-informant/main.go
+++ b/cmd/vm-informant/main.go
@@ -120,9 +120,8 @@ func main() {
 	mux := http.NewServeMux()
 	util.AddHandler("", mux, "/register", http.MethodPost, "AgentDesc", state.RegisterAgent)
 	util.AddHandler("", mux, "/health-check", http.MethodPut, "AgentIdentification", state.HealthCheck)
-	// FIXME: /downscale and /upscale should have the AgentID in the request body
-	util.AddHandler("", mux, "/downscale", http.MethodPut, "AgentMessage[SignedRawResources]", state.TryDownscale)
-	util.AddHandler("", mux, "/upscale", http.MethodPut, "AgentMessage[SignedRawResources]", state.NotifyUpscale)
+	util.AddHandler("", mux, "/downscale", http.MethodPut, "AgentResourceMessage", state.TryDownscale)
+	util.AddHandler("", mux, "/upscale", http.MethodPut, "AgentResourceMessage", state.NotifyUpscale)
 	util.AddHandler("", mux, "/unregister", http.MethodDelete, "AgentDesc", state.UnregisterAgent)
 
 	addr := "0.0.0.0:10301"

--- a/cmd/vm-informant/main.go
+++ b/cmd/vm-informant/main.go
@@ -121,8 +121,8 @@ func main() {
 	util.AddHandler("", mux, "/register", http.MethodPost, "AgentDesc", state.RegisterAgent)
 	util.AddHandler("", mux, "/health-check", http.MethodPut, "AgentIdentification", state.HealthCheck)
 	// FIXME: /downscale and /upscale should have the AgentID in the request body
-	util.AddHandler("", mux, "/downscale", http.MethodPut, "SignedRawResources", state.TryDownscale)
-	util.AddHandler("", mux, "/upscale", http.MethodPut, "SignedRawResources", state.NotifyUpscale)
+	util.AddHandler("", mux, "/downscale", http.MethodPut, "AgentMessage[SignedRawResources]", state.TryDownscale)
+	util.AddHandler("", mux, "/upscale", http.MethodPut, "AgentMessage[SignedRawResources]", state.NotifyUpscale)
 	util.AddHandler("", mux, "/unregister", http.MethodDelete, "AgentDesc", state.UnregisterAgent)
 
 	addr := "0.0.0.0:10301"

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -984,7 +984,7 @@ func (s *InformantServer) Downscale(ctx context.Context, to api.Resources) (*api
 	var statusCode int
 	var resp *api.DownscaleResult
 	if s.protoVersion.SignsResourceUpdates() {
-		signedRawResources := api.SignedRawResources{RawResources: rawResources, Id: id}
+		signedRawResources := api.ResourceMessage{RawResources: rawResources, Id: id}
 		reqData := api.AgentResourceMessage{Data: signedRawResources, SequenceNumber: s.incrementSequenceNumber()}
 		resp, statusCode, err = doInformantRequest[api.AgentResourceMessage, api.DownscaleResult](
 			ctx, s, timeout, http.MethodPut, "/downscale", &reqData,
@@ -1037,7 +1037,7 @@ func (s *InformantServer) Upscale(ctx context.Context, to api.Resources) error {
 
 	var statusCode int
 	if s.protoVersion.SignsResourceUpdates() {
-		signedRawResources := api.SignedRawResources{RawResources: rawResources, Id: id}
+		signedRawResources := api.ResourceMessage{RawResources: rawResources, Id: id}
 		reqData := api.AgentResourceMessage{Data: signedRawResources, SequenceNumber: s.incrementSequenceNumber()}
 		_, statusCode, err = doInformantRequest[api.AgentResourceMessage, struct{}](
 			ctx, s, timeout, http.MethodPut, "/upscale", &reqData,

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -20,7 +20,7 @@ import (
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
-// The autoscaler-agent currently supports v1.0 to v1.1 of the agent<->informant protocol.
+// The autoscaler-agent currently supports v1.0 to v2.0 of the agent<->informant protocol.
 //
 // If you update either of these values, make sure to also update VERSIONING.md.
 const (

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -978,10 +978,11 @@ func (s *InformantServer) Downscale(ctx context.Context, to api.Resources) (*api
 	s.runner.logger.Infof("Sending downscale %+v", to)
 
 	timeout := time.Second * time.Duration(s.runner.global.config.Informant.DownscaleTimeoutSeconds)
-	rawResources := to.ConvertToRaw(s.runner.vm.Mem.SlotSize)
+	id := api.AgentIdentification{AgentID: s.desc.AgentID}
+	signedRawResources := api.SignedRawResources{RawResources: to.ConvertToRaw(s.runner.vm.Mem.SlotSize), Id: id}
 
-	resp, statusCode, err := doInformantRequest[api.RawResources, api.DownscaleResult](
-		ctx, s, timeout, http.MethodPut, "/downscale", &rawResources,
+	resp, statusCode, err := doInformantRequest[api.SignedRawResources, api.DownscaleResult](
+		ctx, s, timeout, http.MethodPut, "/downscale", &signedRawResources,
 	)
 	if err != nil {
 		func() {
@@ -1020,9 +1021,10 @@ func (s *InformantServer) Upscale(ctx context.Context, to api.Resources) error {
 	s.runner.logger.Infof("Sending upscale %+v", to)
 
 	timeout := time.Second * time.Duration(s.runner.global.config.Informant.DownscaleTimeoutSeconds)
-	rawResources := to.ConvertToRaw(s.runner.vm.Mem.SlotSize)
+	id := api.AgentIdentification{AgentID: s.desc.AgentID}
+	rawResources := api.SignedRawResources{RawResources: to.ConvertToRaw(s.runner.vm.Mem.SlotSize), Id: id}
 
-	_, statusCode, err := doInformantRequest[api.RawResources, struct{}](
+	_, statusCode, err := doInformantRequest[api.SignedRawResources, struct{}](
 		ctx, s, timeout, http.MethodPut, "/upscale", &rawResources,
 	)
 	if err != nil {

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -983,10 +983,10 @@ func (s *InformantServer) Downscale(ctx context.Context, to api.Resources) (*api
 
 	var statusCode int
 	var resp *api.DownscaleResult
-	if s.protoVersion.ResourceUpdatesSigned() {
+	if s.protoVersion.SignsResourceUpdates() {
 		signedRawResources := api.SignedRawResources{RawResources: rawResources, Id: id}
-		reqData := api.AgentMessage[api.SignedRawResources]{Data: signedRawResources, SequenceNumber: s.incrementSequenceNumber()}
-		resp, statusCode, err = doInformantRequest[api.AgentMessage[api.SignedRawResources], api.DownscaleResult](
+		reqData := api.AgentResourceMessage{Data: signedRawResources, SequenceNumber: s.incrementSequenceNumber()}
+		resp, statusCode, err = doInformantRequest[api.AgentResourceMessage, api.DownscaleResult](
 			ctx, s, timeout, http.MethodPut, "/downscale", &reqData,
 		)
 	} else {
@@ -1036,16 +1036,15 @@ func (s *InformantServer) Upscale(ctx context.Context, to api.Resources) error {
 	rawResources := to.ConvertToRaw(s.runner.vm.Mem.SlotSize)
 
 	var statusCode int
-	if s.protoVersion.ResourceUpdatesSigned() {
+	if s.protoVersion.SignsResourceUpdates() {
 		signedRawResources := api.SignedRawResources{RawResources: rawResources, Id: id}
-		reqData := api.AgentMessage[api.SignedRawResources]{Data: signedRawResources, SequenceNumber: s.incrementSequenceNumber()}
-		_, statusCode, err = doInformantRequest[api.AgentMessage[api.SignedRawResources], struct{}](
+		reqData := api.AgentResourceMessage{Data: signedRawResources, SequenceNumber: s.incrementSequenceNumber()}
+		_, statusCode, err = doInformantRequest[api.AgentResourceMessage, struct{}](
 			ctx, s, timeout, http.MethodPut, "/upscale", &reqData,
 		)
 	} else {
-		reqData := api.AgentMessage[api.RawResources]{Data: rawResources, SequenceNumber: s.incrementSequenceNumber()}
-		_, statusCode, err = doInformantRequest[api.AgentMessage[api.RawResources], struct{}](
-			ctx, s, timeout, http.MethodPut, "/upscale", &reqData,
+		_, statusCode, err = doInformantRequest[api.RawResources, struct{}](
+			ctx, s, timeout, http.MethodPut, "/upscale", &rawResources,
 		)
 	}
 

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -981,8 +981,8 @@ func (s *InformantServer) Downscale(ctx context.Context, to api.Resources) (*api
 	id := api.AgentIdentification{AgentID: s.desc.AgentID}
 	rawResources := to.ConvertToRaw(s.runner.vm.Mem.SlotSize)
 
-	var	statusCode int;
-	var	resp *api.DownscaleResult;
+	var statusCode int
+	var resp *api.DownscaleResult
 	if s.protoVersion.ResourceUpdatesSigned() {
 		signedRawResources := api.SignedRawResources{RawResources: rawResources, Id: id}
 		reqData := api.AgentMessage[api.SignedRawResources]{Data: signedRawResources, SequenceNumber: s.incrementSequenceNumber()}
@@ -1036,7 +1036,7 @@ func (s *InformantServer) Upscale(ctx context.Context, to api.Resources) error {
 	id := api.AgentIdentification{AgentID: s.desc.AgentID}
 	rawResources := to.ConvertToRaw(s.runner.vm.Mem.SlotSize)
 
-	var	statusCode int;
+	var statusCode int
 	if s.protoVersion.ResourceUpdatesSigned() {
 		signedRawResources := api.SignedRawResources{RawResources: rawResources, Id: id}
 		reqData := api.AgentMessage[api.SignedRawResources]{Data: signedRawResources, SequenceNumber: s.incrementSequenceNumber()}

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -25,7 +25,7 @@ import (
 // If you update either of these values, make sure to also update VERSIONING.md.
 const (
 	MinInformantProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_0
-	MaxInformantProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_2
+	MaxInformantProtocolVersion api.InformantProtoVersion = api.InformantProtoV2_0
 )
 
 type InformantServer struct {
@@ -959,7 +959,7 @@ func (s *InformantServer) HealthCheck(ctx context.Context) (*api.InformantHealth
 	return resp, nil
 }
 
-// Downscale makes a request to the informant's /downscale endpoit with the api.Resources
+// Downscale makes a request to the informant's /downscale endpoint with the api.Resources
 //
 // This method MUST NOT be called while holding i.server.runner.lock OR i.server.requestLock.
 func (s *InformantServer) Downscale(ctx context.Context, to api.Resources) (*api.DownscaleResult, error) {
@@ -990,9 +990,8 @@ func (s *InformantServer) Downscale(ctx context.Context, to api.Resources) (*api
 			ctx, s, timeout, http.MethodPut, "/downscale", &reqData,
 		)
 	} else {
-		reqData := api.AgentMessage[api.RawResources]{Data: rawResources, SequenceNumber: s.incrementSequenceNumber()}
-		resp, statusCode, err = doInformantRequest[api.AgentMessage[api.RawResources], api.DownscaleResult](
-			ctx, s, timeout, http.MethodPut, "/downscale", &reqData,
+		resp, statusCode, err = doInformantRequest[api.RawResources, api.DownscaleResult](
+			ctx, s, timeout, http.MethodPut, "/downscale", &rawResources,
 		)
 	}
 

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -14,11 +14,11 @@ commit in this repository, possibly unreleased.
 | Release | autoscaler-agent | VM informant |
 |---------|------------------|--------------|
 | _Current_ | **v1.0 - v2.0** | **v2.0 - v2.0** |
-| v0.9.0 | v1.0 - v1.2 | v1.1 - v1.2 |
+| v0.9.0 | h1.0 - v1.2 | v1.1 - v1.2 |
 | v0.8.0 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.7.2 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.7.1 | v1.0 - v1.2 | v1.1 - v1.2 |
-| v0.7.0 | v1.0 - v1.2 | v1.1 - v1.2 |
+| v0.7.0 | **v1.0 - v1.2** | **v1.1 - v1.2** |
 | v0.6.0 | v1.0 - v1.1 | v1.1 only |
 | v0.5.2 | v1.0 - v1.1 | v1.1 only |
 | v0.5.1 | v1.0 - v1.1 | v1.1 only |

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -13,12 +13,12 @@ commit in this repository, possibly unreleased.
 
 | Release | autoscaler-agent | VM informant |
 |---------|------------------|--------------|
-| Forthcoming | **v1.0 - v1.3** | **v1.1 - v1.2** |
+| _Current_ | **v1.0 - v2.0** | **v2.0 - v2.0** |
 | v0.9.0 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.8.0 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.7.2 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.7.1 | v1.0 - v1.2 | v1.1 - v1.2 |
-| v0.7.0 | **v1.0 - v1.2** | **v1.1 - v1.2** |
+| v0.7.0 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.6.0 | v1.0 - v1.1 | v1.1 only |
 | v0.5.2 | v1.0 - v1.1 | v1.1 only |
 | v0.5.1 | v1.0 - v1.1 | v1.1 only |

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -14,7 +14,7 @@ commit in this repository, possibly unreleased.
 | Release | autoscaler-agent | VM informant |
 |---------|------------------|--------------|
 | _Current_ | **v1.0 - v2.0** | **v2.0 - v2.0** |
-| v0.9.0 | h1.0 - v1.2 | v1.1 - v1.2 |
+| v0.9.0 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.8.0 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.7.2 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.7.1 | v1.0 - v1.2 | v1.1 - v1.2 |

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -13,7 +13,7 @@ commit in this repository, possibly unreleased.
 
 | Release | autoscaler-agent | VM informant |
 |---------|------------------|--------------|
-| _Current_ | v1.0 - v1.2 | v1.1 - v1.2 |
+| Forthcoming | **v1.0 - v1.3** | **v1.1 - v1.2** |
 | v0.9.0 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.8.0 | v1.0 - v1.2 | v1.1 - v1.2 |
 | v0.7.2 | v1.0 - v1.2 | v1.1 - v1.2 |

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -293,7 +293,7 @@ const (
 	// Last used in release version v0.9.0
 	InformantProtoV1_2
 
-	// InformantProtoV1_3 represents v1.3 of the agent<->informant protocol.
+	// InformantProtoV2_0 represents v1.3 of the agent<->informant protocol.
 	//
 	// Changes from v1.2:
 	//
@@ -301,7 +301,7 @@ const (
 	//   /upscale and /downscale requests
 	//
 	// Currently the latest version.
-	InformantProtoV1_3
+	InformantProtoV2_0
 
 	// latestInformantProtoVersion represents the latest version of the agent<->informant protocol
 	//
@@ -323,7 +323,7 @@ func (v InformantProtoVersion) String() string {
 		return "v1.1"
 	case InformantProtoV1_2:
 		return "v1.2"
-	case InformantProtoV1_3:
+	case InformantProtoV2_0:
 		return "v1.3"
 	default:
 		diff := v - latestInformantProtoVersion
@@ -355,7 +355,7 @@ func (v InformantProtoVersion) AllowsHealthCheck() bool {
 //
 // This is true for version v1.2 and greater
 func (v InformantProtoVersion) ResourceUpdatesSigned() bool {
-	return v >= InformantProtoV1_3
+	return v >= InformantProtoV2_0
 }
 
 // AgentMessage is used for (almost) every message sent from the autoscaler-agent to the VM

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -290,8 +290,18 @@ const (
 	//
 	// * Adds /health-check endpoint to the vm-informant.
 	//
-	// Currently the latest version.
+	// Last used in release version v0.9.0
 	InformantProtoV1_2
+
+	// InformantProtoV1_3 represents v1.3 of the agent<->informant protocol.
+	//
+	// Changes from v1.2:
+	//
+	// * Agents now return their ID along with any resource updates during
+	//   /upscale and /downscale requests
+	//
+	// Currently the latest version.
+	InformantProtoV1_3
 
 	// latestInformantProtoVersion represents the latest version of the agent<->informant protocol
 	//
@@ -313,6 +323,8 @@ func (v InformantProtoVersion) String() string {
 		return "v1.1"
 	case InformantProtoV1_2:
 		return "v1.2"
+	case InformantProtoV1_3:
+		return "v1.3"
 	default:
 		diff := v - latestInformantProtoVersion
 		return fmt.Sprintf("<unknown = %v + %d>", latestInformantProtoVersion, diff)
@@ -337,6 +349,13 @@ func (v InformantProtoVersion) HasTryUpscale() bool {
 // This is true for version v1.2 and greater.
 func (v InformantProtoVersion) AllowsHealthCheck() bool {
 	return v >= InformantProtoV1_2
+}
+
+// ResourceUpdatesSigned returns whether agents sign /{up,down}scale requests with their AgentId
+//
+// This is true for version v1.2 and greater
+func (v InformantProtoVersion) ResourceUpdatesSigned() bool {
+	return v >= InformantProtoV1_3
 }
 
 // AgentMessage is used for (almost) every message sent from the autoscaler-agent to the VM

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -297,10 +297,11 @@ const (
 	//
 	// Changes from v1.2:
 	//
-	// * Agents now return a AgentResourceMessage when delivering responses
-	//   to /upscale and /downscale requests. Since RawResources (the response
-	//   type in previous protocols) is not deserializable out of an
-	//   AgentResourceMessage, this is a breaking change.
+	// * Agents now return a AgentResourceMessage when notifying VM's of changes
+	//   in resources on their /upscale and /downscale endpoints. Since
+	//   RawResources (the response type in previous protocols) is not
+	//   deserializable out of an AgentResourceMessage, this is a breaking
+	//   change.
 	//
 	// Currently the latest version.
 	InformantProtoV2_0
@@ -353,7 +354,8 @@ func (v InformantProtoVersion) AllowsHealthCheck() bool {
 	return v >= InformantProtoV1_2
 }
 
-// SignsResourceUpdates returns whether agents respond to /{up,down}scale with an AgentResourceMessage
+// SignsResourceUpdates returns whether agents inform VMs of resource updates with an
+// AgentResourceMessage in this version of the protocol
 //
 // This is true for version v2.0 and greater
 func (v InformantProtoVersion) SignsResourceUpdates() bool {
@@ -513,9 +515,6 @@ func (m MoreResources) And(cmp MoreResources) MoreResources {
 // informant because it doesn't know about things like memory slots.
 //
 // This is used in protocol versions <2. In later versions, AgentResourceMessage is used.
-//
-// TODO: once we are fully migrated to protocol version >=2, inline this type into
-// ResourceMessage and delete it.
 type RawResources struct {
 	Cpu    *resource.Quantity `json:"cpu"`
 	Memory *resource.Quantity `json:"memory"`
@@ -524,8 +523,8 @@ type RawResources struct {
 type AgentResourceMessage = AgentMessage[ResourceMessage]
 
 // Similar to RawResources, stores raw resource amounts. However, it also stores the ID of the agent
-// responding to the VM's resource request. In protocol versions 2 and on, agents respond to
-// /{up,down}scale requests with an AgentResourceMessage. This allows VM informants to verify
+// notifying the VM of a change in resources. In protocol versions 2 and on, agents notify VM's of
+// changes to their available resources with an AgentResourceMessage. This allows VM informants to verify
 // the authenticity of the agent responding.
 type ResourceMessage struct {
 	RawResources

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -299,7 +299,7 @@ const (
 	//
 	// * Agents now return a AgentResourceMessage when delivering responses
 	//   to /upscale and /downscale requests. Since RawResources (the response
-	//	 type in previous protocols) is not deserializable out of an
+	//   type in previous protocols) is not deserializable out of an
 	//   AgentResourceMessage, this is a breaking change.
 	//
 	// Currently the latest version.
@@ -326,7 +326,7 @@ func (v InformantProtoVersion) String() string {
 	case InformantProtoV1_2:
 		return "v1.2"
 	case InformantProtoV2_0:
-		return "v1.3"
+		return "v2.0"
 	default:
 		diff := v - latestInformantProtoVersion
 		return fmt.Sprintf("<unknown = %v + %d>", latestInformantProtoVersion, diff)
@@ -355,7 +355,7 @@ func (v InformantProtoVersion) AllowsHealthCheck() bool {
 
 // SignsResourceUpdates returns whether agents respond to /{up,down}scale with an AgentResourceMessage
 //
-// This is true for version v1.2 and greater
+// This is true for version v2.0 and greater
 func (v InformantProtoVersion) SignsResourceUpdates() bool {
 	return v >= InformantProtoV2_0
 }
@@ -513,6 +513,9 @@ func (m MoreResources) And(cmp MoreResources) MoreResources {
 // informant because it doesn't know about things like memory slots.
 //
 // This is used in protocol versions <2. In later versions, AgentResourceMessage is used.
+//
+// TODO: once we are fully migrated to protocol version >=2, inline this type into
+// ResourceMessage and delete it.
 type RawResources struct {
 	Cpu    *resource.Quantity `json:"cpu"`
 	Memory *resource.Quantity `json:"memory"`
@@ -520,7 +523,7 @@ type RawResources struct {
 
 type AgentResourceMessage = AgentMessage[ResourceMessage]
 
-// Similar to RawResources, stores raw resource amounts. However, also stores the ID of the agent
+// Similar to RawResources, stores raw resource amounts. However, it also stores the ID of the agent
 // responding to the VM's resource request. In protocol versions 2 and on, agents respond to
 // /{up,down}scale requests with an AgentResourceMessage. This allows VM informants to verify
 // the authenticity of the agent responding.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -293,12 +293,14 @@ const (
 	// Last used in release version v0.9.0
 	InformantProtoV1_2
 
-	// InformantProtoV2_0 represents v1.3 of the agent<->informant protocol.
+	// InformantProtoV2_0 represents v2.0 of the agent<->informant protocol.
 	//
 	// Changes from v1.2:
 	//
-	// * Agents now return their ID along with any resource updates during
-	//   /upscale and /downscale requests
+	// * Agents now return a AgentResourceMessage when delivering responses
+	//   to /upscale and /downscale requests. Since RawResources (the response
+	//	 type in previous protocols) is not deserializable out of an
+	//   AgentResourceMessage, this is a breaking change.
 	//
 	// Currently the latest version.
 	InformantProtoV2_0
@@ -351,8 +353,7 @@ func (v InformantProtoVersion) AllowsHealthCheck() bool {
 	return v >= InformantProtoV1_2
 }
 
-// SignsResourceUpdates returns whether agents respond to /{up,down}scale with
-// an AgentResourceMessage
+// SignsResourceUpdates returns whether agents respond to /{up,down}scale with an AgentResourceMessage
 //
 // This is true for version v1.2 and greater
 func (v InformantProtoVersion) SignsResourceUpdates() bool {
@@ -509,18 +510,21 @@ func (m MoreResources) And(cmp MoreResources) MoreResources {
 }
 
 // RawResources signals raw resource amounts, and is primarily used in communications with the VM
-// informant because it doesn't know about things like memory slots
+// informant because it doesn't know about things like memory slots.
+//
+// This is used in protocol versions <2. In later versions, AgentResourceMessage is used.
 type RawResources struct {
 	Cpu    *resource.Quantity `json:"cpu"`
 	Memory *resource.Quantity `json:"memory"`
 }
 
-type AgentResourceMessage = AgentMessage[SignedRawResources]
+type AgentResourceMessage = AgentMessage[ResourceMessage]
 
 // Similar to RawResources, stores raw resource amounts. However, also stores the ID of the agent
 // responding to the VM's resource request. In protocol versions 2 and on, agents respond to
-// /{up,down}scale requests with an AgentResourceMessage.
-type SignedRawResources struct {
+// /{up,down}scale requests with an AgentResourceMessage. This allows VM informants to verify
+// the authenticity of the agent responding.
+type ResourceMessage struct {
 	RawResources
 	Id AgentIdentification `json:"id"`
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -351,10 +351,11 @@ func (v InformantProtoVersion) AllowsHealthCheck() bool {
 	return v >= InformantProtoV1_2
 }
 
-// ResourceUpdatesSigned returns whether agents sign /{up,down}scale requests with their AgentId
+// SignsResourceUpdates returns whether agents respond to /{up,down}scale with
+// an AgentResourceMessage
 //
 // This is true for version v1.2 and greater
-func (v InformantProtoVersion) ResourceUpdatesSigned() bool {
+func (v InformantProtoVersion) SignsResourceUpdates() bool {
 	return v >= InformantProtoV2_0
 }
 
@@ -514,8 +515,11 @@ type RawResources struct {
 	Memory *resource.Quantity `json:"memory"`
 }
 
+type AgentResourceMessage = AgentMessage[SignedRawResources]
+
 // Similar to RawResources, stores raw resource amounts. However, also stores the ID of the agent
-// notifying the VM of the granted resource request
+// responding to the VM's resource request. In protocol versions 2 and on, agents respond to
+// /{up,down}scale requests with an AgentResourceMessage.
 type SignedRawResources struct {
 	RawResources
 	Id AgentIdentification `json:"id"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -495,6 +495,13 @@ type RawResources struct {
 	Memory *resource.Quantity `json:"memory"`
 }
 
+// Similar to RawResources, stores raw resource amounts. However, also stores the ID of the agent
+// notifying the VM of the granted resource request
+type SignedRawResources struct {
+	RawResources
+	Id AgentIdentification `json:"id"`
+}
+
 // DownscaleResult is used by the VM informant to return whether it downscaled successfully, and
 // some indication of its status when doing so
 type DownscaleResult struct {

--- a/pkg/informant/agent.go
+++ b/pkg/informant/agent.go
@@ -416,6 +416,13 @@ func (s *AgentSet) ReceivedUpscale() {
 	s.wantsMemoryUpscale = false
 }
 
+// Returns the current agent, which can be nil
+func (s *AgentSet) Current() (_ *Agent) {
+	s.lock.Lock()		
+	defer s.lock.Unlock()
+	return s.current
+}
+
 // Get returns the requested Agent, if it exists
 func (s *AgentSet) Get(id uuid.UUID) (_ *Agent, ok bool) {
 	s.lock.Lock()

--- a/pkg/informant/agent.go
+++ b/pkg/informant/agent.go
@@ -26,8 +26,8 @@ import (
 //
 // If you update either of these values, make sure to also update VERSIONING.md.
 const (
-	MinProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_1
-	MaxProtocolVersion api.InformantProtoVersion = api.InformantProtoV1_2
+	MinProtocolVersion api.InformantProtoVersion = api.InformantProtoV2_0
+	MaxProtocolVersion api.InformantProtoVersion = api.InformantProtoV2_0
 )
 
 // AgentSet is the global state handling various autoscaler-agents that we could connect to

--- a/pkg/informant/agent.go
+++ b/pkg/informant/agent.go
@@ -418,14 +418,14 @@ func (s *AgentSet) ReceivedUpscale() {
 
 // Returns the current agent, which can be nil
 func (s *AgentSet) Current() *Agent {
-	s.lock.Lock()		
+	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.current
 }
 
 // Returns the id of the AgentSet's current agent as a string. If the current agent is nil,
 // returns "<nil>"
-func CurrentIdStr(s *AgentSet) string {
+func (s *AgentSet) CurrentIdStr() string {
 	if current := s.Current(); current == nil {
 		return "<nil>"
 	} else {

--- a/pkg/informant/agent.go
+++ b/pkg/informant/agent.go
@@ -417,10 +417,20 @@ func (s *AgentSet) ReceivedUpscale() {
 }
 
 // Returns the current agent, which can be nil
-func (s *AgentSet) Current() (_ *Agent) {
+func (s *AgentSet) Current() *Agent {
 	s.lock.Lock()		
 	defer s.lock.Unlock()
 	return s.current
+}
+
+// Returns the id of the AgentSet's current agent as a string. If the current agent is nil,
+// returns "<nil>"
+func CurrentIdStr(s *AgentSet) string {
+	if current := s.Current(); current == nil {
+		return "<nil>"
+	} else {
+		return current.id.String()
+	}
 }
 
 // Get returns the requested Agent, if it exists

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -242,7 +242,7 @@ func (s *State) HealthCheck(ctx context.Context, info *api.AgentIdentification) 
 // amount is ok
 //
 // Returns: body (if successful), status code and error (if unsuccessful)
-func (s *State) TryDownscale(ctx context.Context, target *api.AgentMessage[api.SignedRawResources]) (*api.DownscaleResult, int, error) {
+func (s *State) TryDownscale(ctx context.Context, target *api.AgentResourceMessage) (*api.DownscaleResult, int, error) {
 	currentId := s.agents.current.id
 	incomingId := target.Data.Id.AgentID
 	// This condition deals with two cases:
@@ -371,7 +371,7 @@ func (s *State) TryDownscale(ctx context.Context, target *api.AgentMessage[api.S
 // Returns: body (if successful), status code and error (if unsuccessful)
 func (s *State) NotifyUpscale(
 	ctx context.Context,
-	newResources *api.AgentMessage[api.SignedRawResources],
+	newResources *api.AgentResourceMessage,
 ) (*struct{}, int, error) {
 	// FIXME: we shouldn't just trust what the agent says
 	//

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -246,11 +246,7 @@ func (s *State) TryDownscale(ctx context.Context, target *api.AgentResourceMessa
 	currentId := s.agents.current.id
 	incomingId := target.Data.Id.AgentID
 
-	// This condition verifies the authenticity of the agent, dealing with two cases
-	// 1: The agent that responded is legitimately an unknown agent
-	// 2: The agent that responded is using an old protocol, and thus did not respond with an AgentId.
-	//    In this case, due to Go's uninitialized variable semantics, the "AgentID" we read will be
-	//    all 0's, which will never match, since UUID's cannot be all 0's
+	// First verify agent's authenticity before doing anything
 	if incomingId != currentId {
 		klog.Errorf(
 			"Got downscale response from agent %v, while current agent is %v",
@@ -386,11 +382,7 @@ func (s *State) NotifyUpscale(
 	currentId := s.agents.current.id
 	incomingId := newResources.Data.Id.AgentID
 
-	// This condition verifies the authenticity of the agent, dealing with two cases
-	// 1: The agent that responded is legitimately an unknown agent
-	// 2: The agent that responded is using an old protocol, and thus did not respond with an AgentId.
-	//    In this case, due to Go's uninitialized variable semantics, the "AgentID" we read will be
-	//    all 0's, which will never match, since UUID's cannot be all 0's
+	// First verify agent's authenticity before doing anything
 	if incomingId != currentId {
 		klog.Errorf(
 			"Got upscale response from agent %v, while current agent is %v",

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -260,12 +260,17 @@ func (s *State) TryDownscale(ctx context.Context, target *api.AgentMessage[api.S
 
 	currentId := s.agents.current.id
 	incomingId := target.Data.Id.AgentID
+	// This condition deals with two cases:
+	// 1: The agent that responded is legitimately an unknown agent
+	// 2: The agent that responded is using an old protocol, and thus did not respond with an AgentId.
+	//    In this case, due to Go's uninitialized variable semantics, the "AgentID" we read will be
+	//    all 0's, which will never match, since UUID's cannot be all 0's
 	if incomingId != currentId {
 		klog.Errorf(
 			"Got downscale response from agent %v, while current agent is %v",
 			incomingId, currentId,
 		)
-		return nil, 400, fmt.Errorf("Received response from unknown agent %v", incomingId)
+		return nil, 400, fmt.Errorf("Received downscale response from unknown agent %v", incomingId)
 	}
 
 	requestedMem := uint64(target.Data.Memory.Value())
@@ -390,12 +395,17 @@ func (s *State) NotifyUpscale(
 
 	currentId := s.agents.current.id
 	incomingId := newResources.Data.Id.AgentID
+	// This condition deals with two cases:
+	// 1: The agent that responded is legitimately an unknown agent
+	// 2: The agent that responded is using an old protocol, and thus did not respond with an AgentId.
+	//    In this case, due to Go's uninitialized variable semantics, the "AgentID" we read will be
+	//    all 0's, which will never match, since UUID's cannot be all 0's
 	if incomingId != currentId {
 		klog.Errorf(
 			"Got upscale response from agent %v, while current agent is %v",
 			incomingId, currentId,
 		)
-		return nil, 400, fmt.Errorf("Received response from unknown agent %v", incomingId)
+		return nil, 400, fmt.Errorf("Received upscale response from unknown agent %v", incomingId)
 	}
 
 	newMem := uint64(newResources.Data.Memory.Value())

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -245,7 +245,8 @@ func (s *State) HealthCheck(ctx context.Context, info *api.AgentIdentification) 
 func (s *State) TryDownscale(ctx context.Context, target *api.AgentResourceMessage) (*api.DownscaleResult, int, error) {
 	currentId := s.agents.current.id
 	incomingId := target.Data.Id.AgentID
-	// This condition deals with two cases:
+
+	// This condition verifies the authenticity of the agent, dealing with two cases
 	// 1: The agent that responded is legitimately an unknown agent
 	// 2: The agent that responded is using an old protocol, and thus did not respond with an AgentId.
 	//    In this case, due to Go's uninitialized variable semantics, the "AgentID" we read will be
@@ -384,7 +385,8 @@ func (s *State) NotifyUpscale(
 
 	currentId := s.agents.current.id
 	incomingId := newResources.Data.Id.AgentID
-	// This condition deals with two cases:
+
+	// This condition verifies the authenticity of the agent, dealing with two cases
 	// 1: The agent that responded is legitimately an unknown agent
 	// 2: The agent that responded is using an old protocol, and thus did not respond with an AgentId.
 	//    In this case, due to Go's uninitialized variable semantics, the "AgentID" we read will be

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -242,7 +242,7 @@ func (s *State) HealthCheck(ctx context.Context, info *api.AgentIdentification) 
 // amount is ok
 //
 // Returns: body (if successful), status code and error (if unsuccessful)
-func (s *State) TryDownscale(ctx context.Context, target *api.RawResources) (*api.DownscaleResult, int, error) {
+func (s *State) TryDownscale(ctx context.Context, target *api.SignedRawResources) (*api.DownscaleResult, int, error) {
 	// Helper functions for abbreviating returns.
 	resultFromStatus := func(ok bool, status string) (*api.DownscaleResult, int, error) {
 		return &api.DownscaleResult{Ok: ok, Status: status}, 200, nil
@@ -354,7 +354,7 @@ func (s *State) TryDownscale(ctx context.Context, target *api.RawResources) (*ap
 // NotifyUpscale signals that the VM's resource usage has been increased to the new amount
 //
 // Returns: body (if successful), status code and error (if unsuccessful)
-func (s *State) NotifyUpscale(ctx context.Context, newResources *api.RawResources) (*struct{}, int, error) {
+func (s *State) NotifyUpscale(ctx context.Context, newResources *api.SignedRawResources) (*struct{}, int, error) {
 	// FIXME: we shouldn't just trust what the agent says
 	//
 	// Because of race conditions like in <https://github.com/neondatabase/autoscaling/issues/23>,

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -252,7 +252,7 @@ func (s *State) TryDownscale(ctx context.Context, target *api.AgentResourceMessa
 			"Got downscale response from agent %v, while current agent is %v",
 			incomingId, currentId,
 		)
-		return nil, 400, fmt.Errorf("Received downscale response from unknown agent %v", incomingId)
+		return nil, 400, fmt.Errorf("Received downscale response from inactive agent %v", incomingId)
 	}
 
 	// Helper functions for abbreviating returns.
@@ -388,7 +388,7 @@ func (s *State) NotifyUpscale(
 			"Got upscale response from agent %v, while current agent is %v",
 			incomingId, currentId,
 		)
-		return nil, 400, fmt.Errorf("Received upscale response from unknown agent %v", incomingId)
+		return nil, 400, fmt.Errorf("Received upscale response from inactive agent %v", incomingId)
 	}
 
 	// Helper function for abbreviating returns.

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -243,14 +243,16 @@ func (s *State) HealthCheck(ctx context.Context, info *api.AgentIdentification) 
 //
 // Returns: body (if successful), status code and error (if unsuccessful)
 func (s *State) TryDownscale(ctx context.Context, target *api.AgentResourceMessage) (*api.DownscaleResult, int, error) {
-	currentAgent := s.agents.Current()
-	incomingId := target.Data.Id.AgentID
+	currentId := CurrentIdStr(s.agents)
+	incomingId := target.Data.Id.AgentID.String()
 
-	// First verify agent's authenticity before doing anything
-	if currentAgent == nil || incomingId != currentAgent.id {
+	// First verify agent's authenticity before doing anything.
+	// Note: if the current agent is nil, its id string will be "<nil>", which
+	// does not match any valid UUID
+	if incomingId != currentId {
 		klog.Errorf(
 			"Got downscale response from agent %v, while current agent is %v",
-			incomingId, currentAgent.id,
+			incomingId, currentId,
 		)
 		return nil, 400, fmt.Errorf("Received downscale response from inactive agent %v", incomingId)
 	}
@@ -379,14 +381,16 @@ func (s *State) NotifyUpscale(
 	// So until the race condition described in #23 is fixed, we have to just trust that the agent
 	// is telling the truth, *especially because it might not be*.
 
-	currentAgent := s.agents.Current()
-	incomingId := newResources.Data.Id.AgentID
+	currentId := CurrentIdStr(s.agents)
+	incomingId := newResources.Data.Id.AgentID.String()
 
-	// First verify agent's authenticity before doing anything
-	if currentAgent == nil || incomingId != currentAgent.id {
+	// First verify agent's authenticity before doing anything.
+	// Note: if the current agent is nil, its id string will be "<nil>", which
+	// does not match any valid UUID
+	if incomingId != currentId {
 		klog.Errorf(
 			"Got upscale response from agent %v, while current agent is %v",
-			incomingId, currentAgent.id,
+			incomingId, currentId,
 		)
 		return nil, 400, fmt.Errorf("Received upscale response from inactive agent %v", incomingId)
 	}

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -243,7 +243,7 @@ func (s *State) HealthCheck(ctx context.Context, info *api.AgentIdentification) 
 //
 // Returns: body (if successful), status code and error (if unsuccessful)
 func (s *State) TryDownscale(ctx context.Context, target *api.AgentResourceMessage) (*api.DownscaleResult, int, error) {
-	currentId := CurrentIdStr(s.agents)
+	currentId := s.agents.CurrentIdStr()
 	incomingId := target.Data.Id.AgentID.String()
 
 	// First verify agent's authenticity before doing anything.
@@ -381,7 +381,7 @@ func (s *State) NotifyUpscale(
 	// So until the race condition described in #23 is fixed, we have to just trust that the agent
 	// is telling the truth, *especially because it might not be*.
 
-	currentId := CurrentIdStr(s.agents)
+	currentId := s.agents.CurrentIdStr()
 	incomingId := newResources.Data.Id.AgentID.String()
 
 	// First verify agent's authenticity before doing anything.

--- a/pkg/informant/endpoints.go
+++ b/pkg/informant/endpoints.go
@@ -10,9 +10,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	klog "k8s.io/klog/v2"
 
-	"github.com/google/uuid"
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )


### PR DESCRIPTION
Not sure if this is the exact right way to do it. It seems protocol version agnostic.