### PR TITLE
plugin: Fix Unreserve condition

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -732,11 +732,7 @@ func (e *AutoscaleEnforcer) Unreserve(
 			"\tvCPU verdict: %s\n" +
 			"\t mem verdict: %s"
 		klog.Infof(fmtString, otherPs.name, otherPs.node.name, vCPUVerdict, memVerdict)
-	} else {
-		klog.Warningf("[autoscale-enforcer] Unreserve: Cannot find pod %v in podMap or otherPods (this may be normal behavior)", pName)
-		return
-	}
-
+	} else if ok && !otherOk {
 		// Mark the resources as no longer reserved
 
 		currentlyMigrating := false // Unreserve is never called on bound pods, so it can't be migrating.
@@ -754,4 +750,8 @@ func (e *AutoscaleEnforcer) Unreserve(
 			"\tvCPU verdict: %s\n" +
 			"\t mem verdict: %s"
 		klog.Infof(fmtString, ps.name, ps.node.name, vCPUVerdict, memVerdict)
+	} else {
+		klog.Warningf("[autoscale-enforcer] Unreserve: Cannot find pod %v in podMap or otherPods (this may be normal behavior)", pName)
+		return
+	}
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -737,21 +737,21 @@ func (e *AutoscaleEnforcer) Unreserve(
 		return
 	}
 
-	// Mark the resources as no longer reserved
+		// Mark the resources as no longer reserved
 
-	currentlyMigrating := false // Unreserve is never called on bound pods, so it can't be migrating.
-	vCPUVerdict := collectResourceTransition(&ps.node.vCPU, &ps.vCPU).
-		handleDeleted(currentlyMigrating)
-	memVerdict := collectResourceTransition(&ps.node.memSlots, &ps.memSlots).
-		handleDeleted(currentlyMigrating)
+		currentlyMigrating := false // Unreserve is never called on bound pods, so it can't be migrating.
+		vCPUVerdict := collectResourceTransition(&ps.node.vCPU, &ps.vCPU).
+			handleDeleted(currentlyMigrating)
+		memVerdict := collectResourceTransition(&ps.node.memSlots, &ps.memSlots).
+			handleDeleted(currentlyMigrating)
 
-	// Delete our record of the pod
-	delete(e.state.podMap, pName)
-	delete(ps.node.pods, pName)
-	ps.node.mq.removeIfPresent(ps)
+		// Delete our record of the pod
+		delete(e.state.podMap, pName)
+		delete(ps.node.pods, pName)
+		ps.node.mq.removeIfPresent(ps)
 
-	fmtString := "[autoscale-enforcer] Unreserved VM pod %v from node %s:\n" +
-		"\tvCPU verdict: %s\n" +
-		"\t mem verdict: %s"
-	klog.Infof(fmtString, ps.name, ps.node.name, vCPUVerdict, memVerdict)
+		fmtString := "[autoscale-enforcer] Unreserved VM pod %v from node %s:\n" +
+			"\tvCPU verdict: %s\n" +
+			"\t mem verdict: %s"
+		klog.Infof(fmtString, ps.name, ps.node.name, vCPUVerdict, memVerdict)
 }


### PR DESCRIPTION
Previous to this commit, we wouldn't actually unreserve any VM pods.

An intermediate commit for indenting is split out from the main change, so that we can preserve some of the original blame with .git-blame-ignore-revs.

**NB: This PR should be merged by rebase, with the first commit added to .git-blame-ignore-revs**