### PR TITLE
util/watch: Set failingCurrent to zero so it shows up

### DIFF
--- a/pkg/util/watch/metrics.go
+++ b/pkg/util/watch/metrics.go
@@ -117,6 +117,8 @@ func (m *Metrics) MustRegister(reg *prometheus.Registry) {
 
 func (m *MetricsConfig) alive() {
 	m.aliveCurrent.WithLabelValues(m.Instance).Inc()
+	// Explicitly set the 'failing' count so that it's present (and set to zero)
+	m.failingCurrent.WithLabelValues(m.Instance).Add(0.0)
 }
 
 func (m *MetricsConfig) unalive() {


### PR DESCRIPTION
Without this, we'll get "no data" in grafana until something starts failing. It's better to have "yes data, and nothing's failing".