### PR TITLE
deploy: Change metrics scrape interval 10s -> 60s

### DIFF
--- a/deploy/vmscrape.yaml
+++ b/deploy/vmscrape.yaml
@@ -8,7 +8,7 @@ spec:
   podMetricsEndpoints:
     - port: metrics
       path: /metrics
-      interval: 10s
+      interval: 30s
       scrapeTimeout: 10s
   selector:
     matchExpressions:

--- a/deploy/vmscrape.yaml
+++ b/deploy/vmscrape.yaml
@@ -8,7 +8,7 @@ spec:
   podMetricsEndpoints:
     - port: metrics
       path: /metrics
-      interval: 30s
+      interval: 60s
       scrapeTimeout: 10s
   selector:
     matchExpressions:


### PR DESCRIPTION
10 seconds is too often, for little gain, at the expense of shoving a bunch more data through VictoriaMetrics.

Realistically it's not *that* bad, but still worth changing.