### PR TITLE
agent/billing: Use NeonVM .status.cpus, not .spec.guest.cpus.use

### DIFF
--- a/pkg/agent/billing/billing.go
+++ b/pkg/agent/billing/billing.go
@@ -151,7 +151,7 @@ func (s *metricsState) collect(conf *Config, store VMStoreForNode, metrics PromM
 			continue
 		}
 
-		if !vm.Status.Phase.IsAlive() {
+		if !vm.Status.Phase.IsAlive() || vm.Status.CPUs == nil {
 			continue
 		}
 
@@ -160,7 +160,7 @@ func (s *metricsState) collect(conf *Config, store VMStoreForNode, metrics PromM
 			endpointID: endpointID,
 		}
 		presentMetrics := vmMetricsInstant{
-			cpu: *vm.Spec.Guest.CPUs.Use,
+			cpu: *vm.Status.CPUs,
 		}
 		if oldMetrics, ok := old[key]; ok {
 			// The VM was present from s.lastTime to now. Add a time slice to its metrics history.


### PR DESCRIPTION
AFAICT the status should be more accurate, because the fields in .spec are more like the "desired" state, whereas the status is more like the "actual" state.

I don't _think_ we've had any issues because of this, but it'd be good to fix it before it becomes an issue.