### PR TITLE
build: Be more precise about COPYing go files

### DIFF
--- a/build/autoscale-scheduler/Dockerfile
+++ b/build/autoscale-scheduler/Dockerfile
@@ -7,10 +7,12 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
 
-COPY pkg/ pkg/
-COPY cmd/ cmd/
-COPY neonvm/apis neonvm/apis
-COPY neonvm/client neonvm/client
+COPY neonvm/apis             neonvm/apis
+COPY neonvm/client           neonvm/client
+COPY pkg/api                 pkg/api
+COPY pkg/plugin              pkg/plugin
+COPY pkg/util                pkg/util
+COPY cmd/autoscale-scheduler cmd/autoscale-scheduler
 
 ARG GIT_INFO
 

--- a/build/autoscaler-agent/Dockerfile
+++ b/build/autoscaler-agent/Dockerfile
@@ -7,10 +7,13 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
 
-COPY pkg/ pkg/
-COPY cmd/ cmd/
-COPY neonvm/apis neonvm/apis
-COPY neonvm/client neonvm/client
+COPY neonvm/apis          neonvm/apis
+COPY neonvm/client        neonvm/client
+COPY pkg/agent            pkg/agent
+COPY pkg/api              pkg/api
+COPY pkg/billing          pkg/billing
+COPY pkg/util             pkg/util
+COPY cmd/autoscaler-agent cmd/autoscaler-agent
 
 ARG GIT_INFO
 

--- a/build/vm-informant/Dockerfile
+++ b/build/vm-informant/Dockerfile
@@ -7,10 +7,11 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
 
-COPY pkg/ pkg/
-COPY cmd/ cmd/
-COPY neonvm/apis neonvm/apis
-COPY neonvm/client neonvm/client
+COPY neonvm/apis      neonvm/apis
+COPY pkg/api          pkg/api
+COPY pkg/informant    pkg/informant
+COPY pkg/util         pkg/util
+COPY cmd/vm-informant cmd/vm-informant
 
 ARG GIT_INFO
 


### PR DESCRIPTION
The general idea of the change here is that instead of just blanket including `pkg/` and `cmd/`, we should only copy over the specific packages that are actually being used.

This will let us do a better job using the docker cache. Without it, changes in e.g. cmd/autoscale-scheduler/main.go will cause the cache for the autoscaler-agent to be invalidated, meaning `make docker-build` will recompile it unnecessarily.