### PR TITLE
neonvm/controller: Set migration source ownerref

### DIFF
--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -233,9 +233,24 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 			log.Error(err, "Failed to get migration source pod")
 			return ctrl.Result{}, err
 		}
-		if err = controllerutil.SetOwnerReference(migration, sourceRunner, r.Scheme); err != nil {
-			log.Error(err, "Failed to set owner reference for source pod")
-			return ctrl.Result{}, err
+		ownedByMigration := false
+		gvk := vmv1.SchemeGroupVersion.String()
+		for _, ref := range sourceRunner.OwnerReferences {
+			if ref.APIVersion == gvk && ref.Kind == "VirtualMachineMigration" && ref.Name == migration.Name {
+				ownedByMigration = true
+				break
+			}
+		}
+		if !ownedByMigration {
+			if err = controllerutil.SetOwnerReference(migration, sourceRunner, r.Scheme); err != nil {
+				log.Error(err, "Failed to set owner reference for source pod")
+				return ctrl.Result{}, err
+			}
+			if err = r.Update(ctx, sourceRunner); err != nil {
+				log.Error(err, "Failed to update owner of source runner")
+				// Requeue so that we try again, even though we're not an owner of the source runner
+				return ctrl.Result{RequeueAfter: time.Second}, err
+			}
 		}
 
 		// now inspect target pod status and update migration

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -234,9 +234,8 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 			return ctrl.Result{}, err
 		}
 		ownedByMigration := false
-		gvk := vmv1.SchemeGroupVersion.String()
 		for _, ref := range sourceRunner.OwnerReferences {
-			if ref.APIVersion == gvk && ref.Kind == "VirtualMachineMigration" && ref.Name == migration.Name {
+			if ref.UID == migration.UID {
 				ownedByMigration = true
 				break
 			}


### PR DESCRIPTION
Part of #333, adds an owner reference for the migration to the _source_ runner pod, so that it's possible to check whether a pod is involved in a migration just by checking it (without e.g. cross-referencing with the VM phase).

**NB:** This PR builds on #256, and must not be merged before it.