### PR TITLE
agent: Add scaling metrics

### DIFF
--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -198,11 +198,13 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 	// unil the value is non-zero (because something's happened), which makes it harder to
 	// distinguish between "valid signal of nothing" vs "no signal".
 	metricsWithDirection := []resourceChangePair{
-		// sched requested/approved
-		metrics.schedulerRequestedChange, metrics.schedulerApprovedChange,
-		// informant requested/approved
-		metrics.informantRequestedChange, metrics.informantApprovedChange,
-		// neonvm requested
+		// scheduler:
+		metrics.schedulerRequestedChange,
+		metrics.schedulerApprovedChange,
+		// informant:
+		metrics.informantRequestedChange,
+		metrics.informantApprovedChange,
+		// neonvm:
 		metrics.neonvmRequestedChange,
 	}
 	for _, p := range metricsWithDirection {

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -32,9 +32,9 @@ type resourceChangePair struct {
 }
 
 const (
-	directionLabel     = "direction"
-	directionValueUp   = "up"
-	directionValueDown = "down"
+	directionLabel    = "direction"
+	directionValueInc = "inc"
+	directionValueDec = "dec"
 )
 
 func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Registry) {
@@ -207,8 +207,8 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 	}
 	for _, p := range metricsWithDirection {
 		for _, m := range []*prometheus.CounterVec{p.cpu, p.mem} {
-			m.WithLabelValues(directionValueUp).Add(0.0)
-			m.WithLabelValues(directionValueDown).Add(0.0)
+			m.WithLabelValues(directionValueInc).Add(0.0)
+			m.WithLabelValues(directionValueDec).Add(0.0)
 		}
 	}
 

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -8,13 +8,27 @@ import (
 )
 
 type PromMetrics struct {
-	schedulerRequests         *prometheus.CounterVec
+	schedulerRequests        *prometheus.CounterVec
+	schedulerRequestedChange resourceChangePair
+	schedulerApprovedChange  resourceChangePair
+
 	informantRequestsOutbound *prometheus.CounterVec
 	informantRequestsInbound  *prometheus.CounterVec
-	runnerFatalErrors         prometheus.Counter
-	runnerThreadPanics        prometheus.Counter
-	runnerStarts              prometheus.Counter
-	runnerRestarts            prometheus.Counter
+	informantRequestedChange  resourceChangePair
+	informantApprovedChange   resourceChangePair
+
+	neonvmRequestsOutbound *prometheus.CounterVec
+	neonvmRequestedChange  resourceChangePair
+
+	runnerFatalErrors  prometheus.Counter
+	runnerThreadPanics prometheus.Counter
+	runnerStarts       prometheus.Counter
+	runnerRestarts     prometheus.Counter
+}
+
+type resourceChangePair struct {
+	cpu *prometheus.CounterVec
+	mem *prometheus.CounterVec
 }
 
 func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Registry) {
@@ -30,6 +44,8 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 	metrics := PromMetrics{
 		// the util.RegisterMetric() function registers the collector and returns
 		// it so we can set it directly on the output structure.
+
+		// ---- SCHEDULER ----
 		schedulerRequests: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "autoscaling_agent_scheduler_plugin_requests_total",
@@ -37,6 +53,40 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 			},
 			[]string{"code"},
 		)),
+		schedulerRequestedChange: resourceChangePair{
+			cpu: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_scheduler_plugin_requested_cpu_change_total",
+					Help: "Total change in CPU requested from the scheduler",
+				},
+				[]string{"direction"},
+			)),
+			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_scheduler_plugin_requested_mem_change_total",
+					Help: "Total change in memory (in MiB) requested from the scheduler",
+				},
+				[]string{"direction"},
+			)),
+		},
+		schedulerApprovedChange: resourceChangePair{
+			cpu: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_scheduler_plugin_accepted_cpu_change_total",
+					Help: "Total change in CPU approved by the scheduler",
+				},
+				[]string{"direction"},
+			)),
+			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_scheduler_plugin_accepted_mem_change_total",
+					Help: "Total change in memory (in MiB) approved by the scheduler",
+				},
+				[]string{"direction"},
+			)),
+		},
+
+		// ---- INFORMANT ----
 		informantRequestsOutbound: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "autoscaling_agent_informant_outbound_requests_total",
@@ -45,11 +95,71 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 			[]string{"code"},
 		)),
 		informantRequestsInbound: util.RegisterMetric(reg, prometheus.NewCounterVec(
-			prometheus.CounterOpts{Name: "autoscaling_agent_informant_inbound_requests_total",
+			prometheus.CounterOpts{
+				Name: "autoscaling_agent_informant_inbound_requests_total",
 				Help: "Number of HTTP requests from vm-informants received by autoscaler-agents",
 			},
 			[]string{"endpoint", "code"},
 		)),
+		informantRequestedChange: resourceChangePair{
+			cpu: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_informant_requested_cpu_change_total",
+					Help: "Total change in CPU requested from the informant(s)",
+				},
+				[]string{"direction"},
+			)),
+			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_informant_requested_mem_change_total",
+					Help: "Total change in memory (in MiB) requested from the informant(s)",
+				},
+				[]string{"direction"},
+			)),
+		},
+		informantApprovedChange: resourceChangePair{
+			cpu: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_informant_approved_cpu_change_total",
+					Help: "Total change in CPU approved by the informant(s)",
+				},
+				[]string{"direction"},
+			)),
+			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_informant_approved_mem_change_total",
+					Help: "Total change in memory (in MiB) approved by the informant(s)",
+				},
+				[]string{"direction"},
+			)),
+		},
+
+		// ---- NEONVM ----
+		neonvmRequestsOutbound: util.RegisterMetric(reg, prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "autoscaling_agent_neonvm_outbound_requests_total",
+				Help: "Number of k8s patch requests to NeonVM objects",
+			},
+			[]string{"result"},
+		)),
+		neonvmRequestedChange: resourceChangePair{
+			cpu: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_neonvm_requested_cpu_change_total",
+					Help: "Total change in CPU requested for VMs",
+				},
+				[]string{"direction"},
+			)),
+			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "autoscaling_agent_neonvm_requested_mem_changed_total",
+					Help: "Total change in memory (in MiB) requested for VMs",
+				},
+				[]string{"direction"},
+			)),
+		},
+
+		// ---- RUNNER LIFECYCLE ----
 		runnerFatalErrors: util.RegisterMetric(reg, prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Name: "autoscaling_agent_runner_fatal_errors_total",
@@ -74,6 +184,24 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 				Help: "Number of existing per-VM Runners restarted due to failure",
 			},
 		)),
+	}
+
+	// Some of of the metrics should have default keys set to zero. Otherwise, these won't be filled
+	// unil the value is non-zero (because something's happened), which makes it harder to
+	// distinguish between "valid signal of nothing" vs "no signal".
+	metricsWithDirection := []resourceChangePair{
+		// sched requested/approved
+		metrics.schedulerRequestedChange, metrics.schedulerApprovedChange,
+		// informant requested/approved
+		metrics.informantRequestedChange, metrics.informantApprovedChange,
+		// neonvm requested
+		metrics.neonvmRequestedChange,
+	}
+	for _, p := range metricsWithDirection {
+		for _, m := range []*prometheus.CounterVec{p.cpu, p.mem} {
+			m.WithLabelValues("up").Add(0.0)
+			m.WithLabelValues("down").Add(0.0)
+		}
 	}
 
 	// the remaining metrics are computed at scrape time by prom:

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -31,6 +31,12 @@ type resourceChangePair struct {
 	mem *prometheus.CounterVec
 }
 
+const (
+	directionLabel     = "direction"
+	directionValueUp   = "up"
+	directionValueDown = "down"
+)
+
 func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Registry) {
 	reg := prometheus.NewRegistry()
 
@@ -59,14 +65,14 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 					Name: "autoscaling_agent_scheduler_plugin_requested_cpu_change_total",
 					Help: "Total change in CPU requested from the scheduler",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
 				prometheus.CounterOpts{
 					Name: "autoscaling_agent_scheduler_plugin_requested_mem_change_total",
 					Help: "Total change in memory (in MiB) requested from the scheduler",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 		},
 		schedulerApprovedChange: resourceChangePair{
@@ -75,14 +81,14 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 					Name: "autoscaling_agent_scheduler_plugin_accepted_cpu_change_total",
 					Help: "Total change in CPU approved by the scheduler",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
 				prometheus.CounterOpts{
 					Name: "autoscaling_agent_scheduler_plugin_accepted_mem_change_total",
 					Help: "Total change in memory (in MiB) approved by the scheduler",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 		},
 
@@ -107,14 +113,14 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 					Name: "autoscaling_agent_informant_requested_cpu_change_total",
 					Help: "Total change in CPU requested from the informant(s)",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
 				prometheus.CounterOpts{
 					Name: "autoscaling_agent_informant_requested_mem_change_total",
 					Help: "Total change in memory (in MiB) requested from the informant(s)",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 		},
 		informantApprovedChange: resourceChangePair{
@@ -123,14 +129,14 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 					Name: "autoscaling_agent_informant_approved_cpu_change_total",
 					Help: "Total change in CPU approved by the informant(s)",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
 				prometheus.CounterOpts{
 					Name: "autoscaling_agent_informant_approved_mem_change_total",
 					Help: "Total change in memory (in MiB) approved by the informant(s)",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 		},
 
@@ -150,14 +156,14 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 					Name: "autoscaling_agent_neonvm_requested_cpu_change_total",
 					Help: "Total change in CPU requested for VMs",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 			mem: util.RegisterMetric(reg, prometheus.NewCounterVec(
 				prometheus.CounterOpts{
 					Name: "autoscaling_agent_neonvm_requested_mem_changed_total",
 					Help: "Total change in memory (in MiB) requested for VMs",
 				},
-				[]string{"direction"},
+				[]string{directionLabel},
 			)),
 		},
 
@@ -201,8 +207,8 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 	}
 	for _, p := range metricsWithDirection {
 		for _, m := range []*prometheus.CounterVec{p.cpu, p.mem} {
-			m.WithLabelValues("up").Add(0.0)
-			m.WithLabelValues("down").Add(0.0)
+			m.WithLabelValues(directionValueUp).Add(0.0)
+			m.WithLabelValues(directionValueDown).Add(0.0)
 		}
 	}
 

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -140,6 +140,8 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 				Name: "autoscaling_agent_neonvm_outbound_requests_total",
 				Help: "Number of k8s patch requests to NeonVM objects",
 			},
+			// NOTE: "result" is either "ok" or "[error: $CAUSE]", with $CAUSE as the root cause of
+			// the request error.
 			[]string{"result"},
 		)),
 		neonvmRequestedChange: resourceChangePair{

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -59,10 +59,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1571,24 +1571,26 @@ func (r *Runner) doVMUpdate(
 }
 
 func (r *Runner) recordResourceChange(current, target api.Resources, metrics resourceChangePair) {
+	getDirection := func(targetIsGreater bool) string {
+		if targetIsGreater {
+			return directionValueInc
+		} else {
+			return directionValueDec
+		}
+	}
+
 	abs := current.AbsDiff(target)
 
 	// Add CPU
 	if abs.VCPU != 0 {
-		direction := directionValueInc
-		if target.VCPU < current.VCPU {
-			direction = directionValueDec
-		}
+		direction := getDirection(target.VCPU > current.VCPU)
 
 		metrics.cpu.WithLabelValues(direction).Add(abs.VCPU.AsFloat64())
 	}
 
 	// Add memory
 	if abs.Mem != 0 {
-		direction := directionValueInc
-		if target.Mem < current.Mem {
-			direction = directionValueDec
-		}
+		direction := getDirection(target.Mem > current.Mem)
 
 		// Avoid floating-point inaccuracy.
 		byteTotal := r.vm.Mem.SlotSize.Value() * int64(abs.Mem)

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1575,9 +1575,9 @@ func (r *Runner) recordResourceChange(current, target api.Resources, metrics res
 
 	// Add CPU
 	if abs.VCPU != 0 {
-		direction := "up"
+		direction := directionValueUp
 		if target.VCPU < current.VCPU {
-			direction = "down"
+			direction = directionValueDown
 		}
 
 		metrics.cpu.WithLabelValues(direction).Add(abs.VCPU.AsFloat64())
@@ -1585,9 +1585,9 @@ func (r *Runner) recordResourceChange(current, target api.Resources, metrics res
 
 	// Add memory
 	if abs.Mem != 0 {
-		direction := "up"
+		direction := directionValueUp
 		if target.Mem < current.Mem {
-			direction = "down"
+			direction = directionValueDown
 		}
 
 		// Avoid floating-point inaccuracy.

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1575,9 +1575,9 @@ func (r *Runner) recordResourceChange(current, target api.Resources, metrics res
 
 	// Add CPU
 	if abs.VCPU != 0 {
-		direction := directionValueUp
+		direction := directionValueInc
 		if target.VCPU < current.VCPU {
-			direction = directionValueDown
+			direction = directionValueDec
 		}
 
 		metrics.cpu.WithLabelValues(direction).Add(abs.VCPU.AsFloat64())
@@ -1585,9 +1585,9 @@ func (r *Runner) recordResourceChange(current, target api.Resources, metrics res
 
 	// Add memory
 	if abs.Mem != 0 {
-		direction := directionValueUp
+		direction := directionValueInc
 		if target.Mem < current.Mem {
-			direction = directionValueDown
+			direction = directionValueDec
 		}
 
 		// Avoid floating-point inaccuracy.

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -59,8 +59,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 
@@ -1102,6 +1104,7 @@ func (r *Runner) updateVMResources(
 
 	// state variables
 	var (
+		start  api.Resources // r.vm.Using(), at the time of the start of this function - for metrics.
 		target api.Resources
 		capped api.Resources // target, but capped by r.lastApproved
 	)
@@ -1130,6 +1133,7 @@ func (r *Runner) updateVMResources(
 		target = state.desiredVMState(true) // note: this sets the state value in the loop body
 
 		current := state.vm.Using()
+		start = current
 
 		msg := "Target VM state is equal to current"
 		if target != current {
@@ -1215,6 +1219,8 @@ func (r *Runner) updateVMResources(
 		}
 	}
 
+	r.recordResourceChange(start, target, r.global.metrics.schedulerRequestedChange)
+
 	request := api.AgentRequest{
 		ProtoVersion: PluginProtocolVersion,
 		Pod:          r.podName,
@@ -1232,6 +1238,7 @@ func (r *Runner) updateVMResources(
 	}
 
 	permit := response.Permit
+	r.recordResourceChange(start, permit, r.global.metrics.schedulerApprovedChange)
 
 	// sched.DoRequest should have validated the permit, meaning that it's not less than the
 	// current resource usage.
@@ -1452,12 +1459,16 @@ func (r *Runner) doVMUpdate(
 	// If there's any fields that are being downscaled, request that from the VM informant.
 	downscaled := current.Min(target)
 	if downscaled != current {
+		r.recordResourceChange(current, downscaled, r.global.metrics.informantRequestedChange)
+
 		resp, err := r.doInformantDownscale(ctx, logger, downscaled)
 		if err != nil || resp == nil /* resp = nil && err = nil when the error has been handled */ {
 			return nil, err
 		}
 
-		if !resp.Ok {
+		if resp.Ok {
+			r.recordResourceChange(current, downscaled, r.global.metrics.informantApprovedChange)
+		} else {
 			newTarget, err := rejectedDownscale()
 			if err != nil {
 				resetVMTo(current)
@@ -1476,6 +1487,8 @@ func (r *Runner) doVMUpdate(
 			target = newTarget
 		}
 	}
+
+	r.recordResourceChange(downscaled, target, r.global.metrics.neonvmRequestedChange)
 
 	// Make the NeonVM request
 	patches := []util.JSONPatch{{
@@ -1507,6 +1520,8 @@ func (r *Runner) doVMUpdate(
 
 	// We couldn't update the VM
 	if err != nil {
+		r.global.metrics.neonvmRequestsOutbound.WithLabelValues(fmt.Sprintf("[error: %s]", util.RootError(err))).Inc()
+
 		// If the context was cancelled, we generally don't need to worry about whether setting r.vm
 		// back to current is sound. All operations on this VM are done anyways.
 		if ctx.Err() != nil {
@@ -1520,6 +1535,8 @@ func (r *Runner) doVMUpdate(
 		// runners.
 		panic(fmt.Errorf("Unexpected VM patch request failure: %w", err))
 	}
+
+	r.global.metrics.neonvmRequestsOutbound.WithLabelValues("ok").Inc()
 
 	// We scaled. If we run into an issue around further communications with the informant, then
 	// it'll be left with an inconsistent state - there's not really anything we can do about that,
@@ -1540,15 +1557,48 @@ func (r *Runner) doVMUpdate(
 			r.requestedUpscale = r.requestedUpscale.And(upscaled.IncreaseFrom(current).Not())
 		}()
 
+		r.recordResourceChange(downscaled, upscaled, r.global.metrics.informantRequestedChange)
+
 		if ok, err := r.doInformantUpscale(ctx, logger, upscaled); err != nil || !ok {
 			return nil, err
 		}
+
+		r.recordResourceChange(downscaled, upscaled, r.global.metrics.informantApprovedChange)
 	}
 
 	logger.Info("Updated VM resources", zap.Object("current", current), zap.Object("target", target))
 
 	// Everything successful.
 	return &target, nil
+}
+
+func (r *Runner) recordResourceChange(current, target api.Resources, metrics resourceChangePair) {
+	abs := current.AbsDiff(target)
+
+	// Add CPU
+	if abs.VCPU != 0 {
+		direction := "up"
+		if target.VCPU < current.VCPU {
+			direction = "down"
+		}
+
+		metrics.cpu.WithLabelValues(direction).Add(abs.VCPU.AsFloat64())
+	}
+
+	// Add memory
+	if abs.Mem != 0 {
+		direction := "up"
+		if target.Mem < current.Mem {
+			direction = "down"
+		}
+
+		// Avoid floating-point inaccuracy.
+		byteTotal := r.vm.Mem.SlotSize.Value() * int64(abs.Mem)
+		mib := int64(1 << 20)
+		floatMB := float64(byteTotal/mib) + float64(byteTotal%mib)/float64(mib)
+
+		metrics.mem.WithLabelValues(direction).Add(floatMB)
+	}
 }
 
 // validateInformant checks that the Runner's informant server is present AND active (i.e. not

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -215,6 +215,15 @@ func (r Resources) Mul(factor uint16) Resources {
 	}
 }
 
+// AbsDiff returns a new Resources with each field F as the absolute value of the difference between
+// r.F and cmp.F
+func (r Resources) AbsDiff(cmp Resources) Resources {
+	return Resources{
+		VCPU: util.AbsDiff(r.VCPU, cmp.VCPU),
+		Mem:  util.AbsDiff(r.Mem, cmp.Mem),
+	}
+}
+
 // Increase returns a MoreResources with each field F true when r.F > old.F.
 func (r Resources) IncreaseFrom(old Resources) MoreResources {
 	return MoreResources{

--- a/pkg/util/arith.go
+++ b/pkg/util/arith.go
@@ -34,6 +34,15 @@ func Min[T constraints.Ordered](x, y T) T {
 	}
 }
 
+// AbsDiff returns the absolute value of the difference between x and y
+func AbsDiff[T constraints.Unsigned](x, y T) T {
+	if x > y {
+		return x - y
+	} else {
+		return y - x
+	}
+}
+
 // AtomicInt represents the shared interface provided by various atomic.<NAME> integers
 //
 // This interface type is primarily used by AtomicMax.


### PR DESCRIPTION
Broadly, this PR primarily adds metrics that focus on the change in resources -- both "requested" changes (to: scheduler, informant, NeonVM) and "approved" changes (from: scheduler, informant).

The CPU and memory changes are separate metrics. Memory is in units of Mibibytes. Upscaling vs downscaling is represented by the "direction" label, which is either "up" or "down".

There's also the addition of NeonVM request counts and the associated result.

In total, the new metrics are:

* `autoscaling_agent_scheduler_plugin_{requested,approved}_{cpu,mem}_change_total`
* `autoscaling_agent_informant_{requested,approved}_{cpu,mem}_change_total`
* `autoscaling_agent_neonvm_requested_{cpu,mem}_change_total`
* `autoscaling_agent_neonvm_outbound_requests_total`

So, 11 new metrics in total.

---

This PR is part 1 of 3, for upcoming metrics additions. The next pieces are:

* Gauges for per-node utilization in the scheduler
  - Blocked on cleaning up node info when nodes are removed, plus some extra questions on how metrics should be handled there.
* Timing histograms/etc for how long it takes for a desired scaling to become reality (i.e. duration between autoscaler-agent realizing it should scale and that scaling coming into effect in the VM)
  - Blocked on an `agent.Runner` refactor that would allow us to track this in the first place.