### PR TITLE
plugin: Fix agent-handler log keys explosion

### DIFF
--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -58,7 +58,7 @@ func (e *AutoscaleEnforcer) startPermitHandler(ctx context.Context, logger *zap.
 			return
 		}
 
-		logger = logger.With(zap.Object("pod", req.Pod))
+		logger := logger.With(zap.Object("pod", req.Pod))
 		logger.Info(
 			"Received autoscaler-agent request",
 			zap.String("client", r.RemoteAddr), zap.Any("request", req),


### PR DESCRIPTION
Currently preventing any `agent-handler` logs from appearing on staging, with the logs ending a few hours after it was released at ~150kb / line.

Requires a backport onto v0.10.0 to hotfix before it gets to prod