### PR TITLE
agent/informant: Do health checks even when suspended

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -940,7 +940,13 @@ func (s *InformantServer) HealthCheck(ctx context.Context, logger *zap.Logger) (
 		defer s.runner.lock.Unlock()
 		return s.valid()
 	}()
-	if err != nil {
+	// NB: we want to continue to perform health checks even if the informant server is not properly
+	// available for *normal* use.
+	//
+	// We only need to check for InformantServerSuspendedError because
+	// InformantServerUnconfirmedError will be handled by the retryRegister loop in
+	// serveInformantLoop.
+	if err != nil && !errors.Is(err, InformantServerSuspendedError) {
 		return nil, err
 	}
 


### PR DESCRIPTION
The health checks are meant to serve as a means of restablishing connections if something goes wrong, so that we can have naive "all errors are fatal" approach in the informant (which allows it to be simpler - a good thing).

However, in prod I saw a new VM (so: recent informant, that supports health checks) stop communicating, and narrowed it down to a failure to "/resume" the autoscaler-agent. When that happened, neither component sent any more requests because it was waiting for the other. [In the agent's logs](https://neonprod.grafana.net/explore?left=%7B%22datasource%22:%22grafanacloud-logs%22,%22queries%22:%5B%7B%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22grafanacloud-logs%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bcontainer%3D%5C%22autoscaler-agent%5C%22,%20cluster%3D%5C%22prod-ap-southeast-1-epsilon%5C%22%7D%20%7C%3D%20%5C%22ep-quiet-shadow-772008%5C%22%22,%22queryType%22:%22range%22,%22refId%22:%22A%22%7D%5D,%22range%22:%7B%22from%22:%221687131348857%22,%22to%22:%221687131396304%22%7D%7D&orgId=1), there were repeated messages like:

    Informant health check failed: Informant server is currently suspended

So a reasonable fix for this should be to just be less strict about when we do health checks. (refer to the added comment for why we only need to handle "suspended" and not also "unconfirmed")