### PR TITLE
plugin: Fix missing `continue` when skipping completed pods

### DIFF
--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -1055,6 +1055,7 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context, logger *zap.Lo
 			continue
 		} else if util.PodCompleted(pod) {
 			logSkip("Pod is in its final, complete state (phase = %q), so will not use any resources", pod.Status.Phase)
+			continue
 		}
 
 		vmInfo, err := api.ExtractVmInfo(logger, vm)
@@ -1167,6 +1168,7 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context, logger *zap.Lo
 
 		if util.PodCompleted(pod) {
 			logSkip("Pod is in its final, complete state (phase = %q), so will not use any resources", pod.Status.Phase)
+			continue
 		}
 
 		if _, ok := p.state.podMap[podName]; ok {


### PR DESCRIPTION
ref https://neondb.slack.com/archives/C03F5SM1N02/p1687222026730729?thread_ts=1687205072.505319&cid=C03F5SM1N02

Kind of a silly bug, that really could have been caught by tests, but oh well.

Given it's currently impacting prod, I'll backport this onto v0.10.1, so that (a) we're not waiting on cutting tomorrow's release to fix it, and (b) we're not tying other things into this.