### PR TITLE
neonvm/controller: Better label/annotation propagation

### DIFF
--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -736,7 +736,7 @@ func (r *VirtualMachineReconciler) podForVirtualMachine(
 // labelsForVirtualMachine returns the labels for selecting the resources
 // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 func labelsForVirtualMachine(virtualmachine *vmv1.VirtualMachine) map[string]string {
-	l := map[string]string{}
+	l := make(map[string]string, len(virtualmachine.Labels)+3)
 	for k, v := range virtualmachine.Labels {
 		l[k] = v
 	}
@@ -753,7 +753,7 @@ func annotationsForVirtualMachine(virtualmachine *vmv1.VirtualMachine) map[strin
 		"kubectl.kubernetes.io/last-applied-configuration": true,
 	}
 
-	a := map[string]string{}
+	a := make(map[string]string, len(virtualmachine.Annotations)+1)
 	for k, v := range virtualmachine.Annotations {
 		if !ignored[k] {
 			a[k] = v

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -736,10 +736,11 @@ func (r *VirtualMachineReconciler) podForVirtualMachine(
 // labelsForVirtualMachine returns the labels for selecting the resources
 // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 func labelsForVirtualMachine(virtualmachine *vmv1.VirtualMachine) map[string]string {
-	l := virtualmachine.Labels
-	if l == nil {
-		l = map[string]string{}
+	l := map[string]string{}
+	for k, v := range virtualmachine.Labels {
+		l[k] = v
 	}
+
 	l["app.kubernetes.io/name"] = "NeonVM"
 	l[vmv1.VirtualMachineNameLabel] = virtualmachine.Name
 	l[vmv1.RunnerPodVersionLabel] = fmt.Sprintf("%d", api.RunnerProtoV1)
@@ -747,10 +748,18 @@ func labelsForVirtualMachine(virtualmachine *vmv1.VirtualMachine) map[string]str
 }
 
 func annotationsForVirtualMachine(virtualmachine *vmv1.VirtualMachine) map[string]string {
-	a := virtualmachine.Annotations
-	if a == nil {
-		a = map[string]string{}
+	// use bool here so `if ignored[key] { ... }` works
+	ignored := map[string]bool{
+		"kubectl.kubernetes.io/last-applied-configuration": true,
 	}
+
+	a := map[string]string{}
+	for k, v := range virtualmachine.Annotations {
+		if !ignored[k] {
+			a[k] = v
+		}
+	}
+
 	a[vmv1.VirtualMachineUsageAnnotation] = extractVirtualMachineUsageJSON(virtualmachine.Spec)
 	return a
 }


### PR DESCRIPTION
In particular, we don't want to propagate the annotation kubectl.kubernetes.io/last-applied-configuration to the runner pod, but the preexisting code also modified the VM's labels/annotations, which maybe is not what's desired.

This PR is split off from some commits in #279, because it's actually not related. ref https://github.com/neondatabase/autoscaling/pull/279#issuecomment-1597844234