### PR TITLE
plugin: Add PostFilter-based "filter cycle" metrics

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -299,15 +299,15 @@ func (e *AutoscaleEnforcer) PostFilter(
 		return nil, nil
 	}
 
-	allNotSuccessful := true
+	hasSuccess := false
 	for _, status := range filteredNodeStatusMap {
 		if status.IsSuccess() {
-			allNotSuccessful = false
+			hasSuccess = true
 			break
 		}
 	}
 
-	if allNotSuccessful {
+	if !hasSuccess {
 		podName := fmt.Sprint(util.GetNamespacedName(pod))
 		e.metrics.fullFilterRejections.WithLabelValues(podName).Inc()
 	} else {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -301,7 +301,7 @@ func (e *AutoscaleEnforcer) PostFilter(
 
 	allNotSuccessful := true
 	for _, status := range filteredNodeStatusMap {
-		if !status.IsSuccess() {
+		if status.IsSuccess() {
 			allNotSuccessful = false
 			break
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -309,9 +309,9 @@ func (e *AutoscaleEnforcer) PostFilter(
 
 	if !hasSuccess {
 		podName := fmt.Sprint(util.GetNamespacedName(pod))
-		e.metrics.fullFilterRejections.WithLabelValues(podName).Inc()
+		e.metrics.filterCycleRejections.WithLabelValues(podName).Inc()
 	} else {
-		e.metrics.fullFilterSuccesses.Inc()
+		e.metrics.filterCycleSuccesses.Inc()
 	}
 
 	return nil, nil // PostFilterResult is optional, nil Status is success.

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -11,6 +11,8 @@ import (
 
 type PromMetrics struct {
 	pluginCalls           *prometheus.CounterVec
+	fullFilterSuccesses   prometheus.Counter
+	fullFilterRejections  *prometheus.CounterVec
 	resourceRequests      *prometheus.CounterVec
 	validResourceRequests *prometheus.CounterVec
 }
@@ -34,6 +36,19 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 				Help: "Number of calls to scheduler plugin extension points",
 			},
 			[]string{"method"},
+		)),
+		fullFilterSuccesses: util.RegisterMetric(reg, prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "autoscaling_plugin_full_filter_successes_total",
+				Help: "Number of successful Filter stages for any pod",
+			},
+		)),
+		fullFilterRejections: util.RegisterMetric(reg, prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "autoscaling_plugin_full_filter_rejections_total",
+				Help: "For each pod, number of times rejected by *all* Filter evaluations",
+			},
+			[]string{"pod_name"},
 		)),
 		resourceRequests: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -11,8 +11,8 @@ import (
 
 type PromMetrics struct {
 	pluginCalls           *prometheus.CounterVec
-	fullFilterSuccesses   prometheus.Counter
-	fullFilterRejections  *prometheus.CounterVec
+	filterCycleSuccesses  prometheus.Counter
+	filterCycleRejections *prometheus.CounterVec
 	resourceRequests      *prometheus.CounterVec
 	validResourceRequests *prometheus.CounterVec
 }
@@ -37,15 +37,15 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 			},
 			[]string{"method"},
 		)),
-		fullFilterSuccesses: util.RegisterMetric(reg, prometheus.NewCounter(
+		filterCycleSuccesses: util.RegisterMetric(reg, prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "autoscaling_plugin_full_filter_successes_total",
+				Name: "autoscaling_plugin_filter_cycle_successes_total",
 				Help: "Number of successful Filter stages for any pod",
 			},
 		)),
-		fullFilterRejections: util.RegisterMetric(reg, prometheus.NewCounterVec(
+		filterCycleRejections: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "autoscaling_plugin_full_filter_rejections_total",
+				Name: "autoscaling_plugin_filter_cycle_rejections_total",
 				Help: "For each pod, number of times rejected by *all* Filter evaluations",
 			},
 			[]string{"pod_name"},


### PR DESCRIPTION
This should allow us to add alerts for cases where the scheduler plugin is misbehaving, allowing us to detect issues before they escalate into a larger outage.

This adds two new metrics to the scheduler:

* `autoscaling_plugin_filter_cycle_successes_total`
* `autoscaling_plugin_filter_cycle_rejections_total`

**NB: Builds on #345, pre-req for #347**