### PR TITLE
release workflow: Add whereabouts.yaml asset

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,3 +178,4 @@ jobs:
             rendered_manifests/neonvm.yaml
             rendered_manifests/multus.yaml
             rendered_manifests/multus-eks.yaml
+            rendered_manifests/whereabouts.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,6 +142,7 @@ jobs:
             cd ${GITHUB_WORKSPACE}/deploy/agent && kustomize edit set image autoscaler-agent=${{ env.AGENT_IMAGE }}:${{ steps.get_vcs_info.outputs.version }}
             cd ${GITHUB_WORKSPACE}
             mkdir -p rendered_manifests
+            kustomize build neonvm/config/default-vxlan/whereabouts > rendered_manifests/whereabouts.yaml
             kustomize build neonvm/config/default-vxlan/multus-eks > rendered_manifests/multus-eks.yaml
             kustomize build neonvm/config/default-vxlan/multus > rendered_manifests/multus.yaml
             kustomize build neonvm/config/default-vxlan > rendered_manifests/neonvm.yaml


### PR DESCRIPTION
Noticed that whereabouts.yaml was missing while working on releasing v0.11.0 — AFAICT it was extracted from multus-eks.yaml and never added to the release workflow?

Not immediately blocking the release (I just used `make render-release` and took the yaml from there), but would be good to fix.