### PR TITLE
agent: Reset `Runner` endState on restart

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -308,6 +308,7 @@ func (s *agentState) TriggerRestartIfNecessary(runnerCtx context.Context, logger
 		pod.runner = runner
 
 		pod.status.previousEndStates = append(pod.status.previousEndStates, *pod.status.endState)
+		pod.status.endState = nil
 		pod.status.startTime = time.Now()
 
 		runnerLogger := s.loggerForRunner(pod.status.vmInfo.NamespacedName(), podName)


### PR DESCRIPTION
Otherwise we'll incorrectly think that currently running `Runner`s are still panicked/errored, after they've already successfully restarted.