### PR TITLE
agent: Record endpoints for `Runner`s

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -121,6 +121,7 @@ func (s *agentState) handleEvent(ctx context.Context, logger *zap.Logger, event 
 		defer state.status.mu.Unlock()
 
 		state.status.vmInfo = event.vmInfo
+		state.status.endpointID = event.endpointID
 		state.vmInfoUpdated.Send()
 	case vmEventAdded:
 		s.handleVMEventAdded(ctx, event, podName)
@@ -141,6 +142,7 @@ func (s *agentState) handleVMEventAdded(
 		endState:          nil,
 		previousEndStates: nil,
 		vmInfo:            event.vmInfo,
+		endpointID:        event.endpointID,
 
 		startTime:                   time.Now(),
 		lastSuccessfulInformantComm: nil,
@@ -396,6 +398,9 @@ type podStatus struct {
 	// There is also a similar field inside the Runner itself, but it's better to store this out
 	// here, where we don't have to rely on the Runner being well-behaved w.r.t. locking.
 	vmInfo api.VmInfo
+
+	// endpointID, if non-empty, stores the ID of the endpoint associated with the VM
+	endpointID string
 }
 
 type podStatusDump struct {
@@ -407,6 +412,8 @@ type podStatusDump struct {
 	LastSuccessfulInformantComm *time.Time `json:"lastSuccessfulInformantComm"`
 
 	VMInfo api.VmInfo `json:"vmInfo"`
+
+	EndpointID string `json:"endpointID"`
 }
 
 type podStatusEndState struct {
@@ -457,8 +464,9 @@ func (s *podStatus) dump() podStatusDump {
 		PreviousEndStates: previousEndStates,
 
 		// FIXME: api.VmInfo contains a resource.Quantity - is that safe to copy by value?
-		VMInfo:    s.vmInfo,
-		StartTime: s.startTime,
+		VMInfo:     s.vmInfo,
+		EndpointID: s.endpointID,
+		StartTime:  s.startTime,
 
 		LastSuccessfulInformantComm: s.lastSuccessfulInformantComm,
 	}


### PR DESCRIPTION
With upcoming compute pool changes, we're going to end up with a lot of VMs where the informant is unable to start up - because the initial file cache connection will fail until postgres is alive, which only happens once the pooled VM is bound to a particular endpoint.

So on staging, we currently report a lot of "autoscaling stuck" VMs, when in reality these are just part of the pool. Having a separate value for the number of these stuck VMs that are actually running something will ensure our metrics continue to be useful.

And also, in passing this through so that we can make a metric out of it, it's worth storing & logging the endpoint ID, so that the information is more easily available (without having to cross-reference the console DB)