### PR TITLE
plugin/watch: Remove redundant error wrapping

### DIFF
--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -5,7 +5,6 @@ package plugin
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -108,11 +107,7 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 			},
 		},
 	)
-	if err != nil {
-		return fmt.Errorf("Error watching pod deletions: %w", err)
-	}
-
-	return nil
+	return err
 }
 
 // tryMigrationOwnerReference returns the name of the owning migration, if this pod *is* owned by a


### PR DESCRIPTION
This is already being handled by the caller, here:

https://github.com/neondatabase/autoscaling/blob/d574fbbb05d6f949510c70009ae7bfd3f83d73a5/pkg/plugin/plugin.go#L152