### PR TITLE
billing, agent/billing: Log IdempotencyKey of events

### DIFF
--- a/pkg/agent/billing/billing.go
+++ b/pkg/agent/billing/billing.go
@@ -268,8 +268,8 @@ func (s *metricsState) drainAppendToBatch(logger *zap.Logger, conf *Config, batc
 
 		batch.Add(logAddedEvent(logger, batch.Enrich(billing.IncrementalEvent{
 			MetricName:     conf.CPUMetricName,
-			Type:           "", // set by billing.Enrich
-			IdempotencyKey: "", // set by billing.Enrich
+			Type:           "", // set by batch.Enrich
+			IdempotencyKey: "", // set by batch.Enrich
 			EndpointID:     key.endpointID,
 			// TODO: maybe we should store start/stop time in the vmMetricsHistory object itself?
 			// That way we can be aligned to collection, rather than pushing.
@@ -279,8 +279,8 @@ func (s *metricsState) drainAppendToBatch(logger *zap.Logger, conf *Config, batc
 		})))
 		batch.Add(logAddedEvent(logger, batch.Enrich(billing.IncrementalEvent{
 			MetricName:     conf.ActiveTimeMetricName,
-			Type:           "", // set by billing.Enrich
-			IdempotencyKey: "", // set by billing.Enrich
+			Type:           "", // set by batch.Enrich
+			IdempotencyKey: "", // set by batch.Enrich
 			EndpointID:     key.endpointID,
 			StartTime:      s.pushWindowStart,
 			StopTime:       now,

--- a/pkg/agent/billing/billing.go
+++ b/pkg/agent/billing/billing.go
@@ -96,7 +96,7 @@ func RunBillingMetricsCollector(
 	}
 
 	state.collect(conf, store, metrics)
-	batch := billing.NewBatch[billing.IncrementalEvent](client)
+	batch := billing.NewBatch[*billing.IncrementalEvent](client)
 
 	for {
 		select {
@@ -122,7 +122,7 @@ func RunBillingMetricsCollector(
 			//
 			// Don't reset metrics.batchSizeCurrent because it stores the *most recent* batch size.
 			// (The "current" suffix refers to the fact the metric is a gague, not a counter)
-			batch = billing.NewBatch[billing.IncrementalEvent](client)
+			batch = billing.NewBatch[*billing.IncrementalEvent](client)
 		case <-backgroundCtx.Done():
 			// If we're being shut down, push the latests events we have before returning.
 			logger.Info("Creating final billing batch")
@@ -248,7 +248,7 @@ func (s *metricsTimeSlice) tryMerge(next metricsTimeSlice) bool {
 	return merged
 }
 
-func logAddedEvent(logger *zap.Logger, event billing.IncrementalEvent) billing.IncrementalEvent {
+func logAddedEvent(logger *zap.Logger, event *billing.IncrementalEvent) *billing.IncrementalEvent {
 	logger.Info(
 		"Adding event to batch",
 		zap.String("IdempotencyKey", event.IdempotencyKey),
@@ -260,13 +260,13 @@ func logAddedEvent(logger *zap.Logger, event billing.IncrementalEvent) billing.I
 }
 
 // drainAppendToBatch clears the current history, adding it as events to the batch
-func (s *metricsState) drainAppendToBatch(logger *zap.Logger, conf *Config, batch *billing.Batch[billing.IncrementalEvent]) {
+func (s *metricsState) drainAppendToBatch(logger *zap.Logger, conf *Config, batch *billing.Batch[*billing.IncrementalEvent]) {
 	now := time.Now()
 
 	for key, history := range s.historical {
 		history.finalizeCurrentTimeSlice()
 
-		batch.Add(logAddedEvent(logger, batch.Enrich(billing.IncrementalEvent{
+		batch.Add(logAddedEvent(logger, batch.Enrich(&billing.IncrementalEvent{
 			MetricName:     conf.CPUMetricName,
 			Type:           "", // set by batch.Enrich
 			IdempotencyKey: "", // set by batch.Enrich
@@ -277,7 +277,7 @@ func (s *metricsState) drainAppendToBatch(logger *zap.Logger, conf *Config, batc
 			StopTime:  now,
 			Value:     int(math.Round(history.total.cpu)),
 		})))
-		batch.Add(logAddedEvent(logger, batch.Enrich(billing.IncrementalEvent{
+		batch.Add(logAddedEvent(logger, batch.Enrich(&billing.IncrementalEvent{
 			MetricName:     conf.ActiveTimeMetricName,
 			Type:           "", // set by batch.Enrich
 			IdempotencyKey: "", // set by batch.Enrich
@@ -292,7 +292,7 @@ func (s *metricsState) drainAppendToBatch(logger *zap.Logger, conf *Config, batc
 	s.historical = make(map[metricsKey]vmMetricsHistory)
 }
 
-func pushBillingEvents(conf *Config, batch *billing.Batch[billing.IncrementalEvent]) error {
+func pushBillingEvents(conf *Config, batch *billing.Batch[*billing.IncrementalEvent]) error {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*time.Duration(conf.PushTimeoutSeconds))
 	defer cancel()
 

--- a/pkg/billing/model.go
+++ b/pkg/billing/model.go
@@ -28,8 +28,8 @@ type eventMethods[Self any] interface {
 }
 
 var (
-	_ eventMethods[AbsoluteEvent]    = AbsoluteEvent{}
-	_ eventMethods[IncrementalEvent] = IncrementalEvent{}
+	_ eventMethods[AbsoluteEvent]    = AbsoluteEvent{}    //nolint:exhaustruct // just checking they impl the interface
+	_ eventMethods[IncrementalEvent] = IncrementalEvent{} //nolint:exhaustruct // just checking they impl the interface
 )
 
 type AbsoluteEvent struct {
@@ -53,21 +53,21 @@ type IncrementalEvent struct {
 }
 
 // typeSetter implements eventMethods
-func (AbsoluteEvent) typeSetter() func(*AbsoluteEvent) {
+func (AbsoluteEvent) typeSetter() func(*AbsoluteEvent) { //nolint:unused // linter is incorrect
 	return func(e *AbsoluteEvent) { e.Type = "absolute" }
 }
 
 // idempotencyKeyGetter implements eventMethods
-func (AbsoluteEvent) idempotencyKeyGetter() func(*AbsoluteEvent) *string {
+func (AbsoluteEvent) idempotencyKeyGetter() func(*AbsoluteEvent) *string { //nolint:unused // linter is incorrect
 	return func(e *AbsoluteEvent) *string { return &e.IdempotencyKey }
 }
 
 // typeSetter implements eventMethods
-func (IncrementalEvent) typeSetter() func(*IncrementalEvent) {
+func (IncrementalEvent) typeSetter() func(*IncrementalEvent) { //nolint:unused // linter is incorrect
 	return func(e *IncrementalEvent) { e.Type = "incremental" }
 }
 
 // idempotencyKeyGetter implements eventMethods
-func (IncrementalEvent) idempotencyKeyGetter() func(*IncrementalEvent) *string {
+func (IncrementalEvent) idempotencyKeyGetter() func(*IncrementalEvent) *string { //nolint:unused // linter is incorrect
 	return func(e *IncrementalEvent) *string { return &e.IdempotencyKey }
 }

--- a/pkg/billing/model.go
+++ b/pkg/billing/model.go
@@ -42,16 +42,6 @@ type AbsoluteEvent struct {
 	Value          int       `json:"value"`
 }
 
-type IncrementalEvent struct {
-	IdempotencyKey string    `json:"idempotency_key"`
-	MetricName     string    `json:"metric"`
-	Type           string    `json:"type"`
-	EndpointID     string    `json:"endpoint_id"`
-	StartTime      time.Time `json:"start_time"`
-	StopTime       time.Time `json:"stop_time"`
-	Value          int       `json:"value"`
-}
-
 // typeSetter implements eventMethods
 func (AbsoluteEvent) typeSetter() func(*AbsoluteEvent) { //nolint:unused // linter is incorrect
 	return func(e *AbsoluteEvent) { e.Type = "absolute" }
@@ -60,6 +50,16 @@ func (AbsoluteEvent) typeSetter() func(*AbsoluteEvent) { //nolint:unused // lint
 // idempotencyKeyGetter implements eventMethods
 func (AbsoluteEvent) idempotencyKeyGetter() func(*AbsoluteEvent) *string { //nolint:unused // linter is incorrect
 	return func(e *AbsoluteEvent) *string { return &e.IdempotencyKey }
+}
+
+type IncrementalEvent struct {
+	IdempotencyKey string    `json:"idempotency_key"`
+	MetricName     string    `json:"metric"`
+	Type           string    `json:"type"`
+	EndpointID     string    `json:"endpoint_id"`
+	StartTime      time.Time `json:"start_time"`
+	StopTime       time.Time `json:"stop_time"`
+	Value          int       `json:"value"`
 }
 
 // typeSetter implements eventMethods

--- a/pkg/billing/model.go
+++ b/pkg/billing/model.go
@@ -7,6 +7,7 @@ import (
 type Event[Self any] interface {
 	AbsoluteEvent | IncrementalEvent
 
+	// yeah this is weird; the comment on eventMethods explains what's going on.
 	eventMethods[Self]
 }
 

--- a/pkg/billing/model.go
+++ b/pkg/billing/model.go
@@ -1,7 +1,10 @@
 package billing
 
 import (
+	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type AbsoluteEvent struct {
@@ -22,4 +25,45 @@ type IncrementalEvent struct {
 	StartTime      time.Time `json:"start_time"`
 	StopTime       time.Time `json:"stop_time"`
 	Value          int       `json:"value"`
+}
+
+type enrichable interface {
+	setEventType()
+	idempotencyKey() *string
+}
+
+// Enrich sets the event's Type and IdempotencyKey fields, so that users of this API don't need to
+// manually set them
+//
+// Enrich is already called by (*Batch).Add, but this is used in the autoscaler-agent's billing
+// implementation, which manually calls Enrich in order to log the IdempotencyKey for each event.
+func Enrich[E enrichable](batch *Batch, event E) E {
+	event.setEventType()
+
+	key := event.idempotencyKey()
+	if *key == "" {
+		*key = fmt.Sprintf("Host<%s>:ID<%s>:T<%s>", batch.c.hostname, uuid.NewString(), time.Now().Format(time.RFC3339))
+	}
+
+	return event
+}
+
+// setEventType implements enrichable
+func (e *AbsoluteEvent) setEventType() {
+	e.Type = "absolute"
+}
+
+// idempotencyKey implements enrichable
+func (e *AbsoluteEvent) idempotencyKey() *string {
+	return &e.IdempotencyKey
+}
+
+// setEventType implements enrichable
+func (e *IncrementalEvent) setEventType() {
+	e.Type = "incremental"
+}
+
+// idempotencyKey implements enrichable
+func (e *IncrementalEvent) idempotencyKey() *string {
+	return &e.IdempotencyKey
 }


### PR DESCRIPTION
In order to make this work on the agent's side, idempotency key generation needed to be *somewhat* exposed, so this PR adds the `Enrich` function, which handles the common "filling out the other fields" tasks for each event.

By abstracting this interface, we also remove the need for separate `(*Batch).AddAbsoluteEvent` vs `(*Batch).AddIncrementalEvent` methods, so now we just have a single `(*Batch).Add` method that just calls `Enrich`.