### PR TITLE
informant/filecache: Close DB connections

### DIFF
--- a/pkg/informant/filecache.go
+++ b/pkg/informant/filecache.go
@@ -127,6 +127,7 @@ func (s *FileCacheState) GetFileCacheSize(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("Error connecting to postgres: %w", err)
 	}
+	defer db.Close()
 
 	// The file cache GUC variable is in MiB, but the conversion with pg_size_bytes means that the
 	// end result we get is in bytes.
@@ -144,6 +145,7 @@ func (s *FileCacheState) SetFileCacheSize(ctx context.Context, logger *zap.Logge
 	if err != nil {
 		return 0, fmt.Errorf("Error connecting to postgres: %w", err)
 	}
+	defer db.Close()
 
 	logger.Info("Fetching maximum file cache size")
 


### PR DESCRIPTION
Realistically a better solution _should_ be to just connect at startup and keep the connection open, but that's a larger change, and this is at least clearly correct.

ref https://neondb.slack.com/archives/C03H1K0PGKH/p1688139786575229

IMO this should be backported + hotfix released as a single-commit change, so that we can get it out sooner.