### PR TITLE
e2e: Set strategy.fail-fast: false (keep running if other fails)

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   e2e-tests:
     strategy:
+      fail-fast: false
       matrix:
         cluster:
           - k3d


### PR DESCRIPTION
We have various sources of flakiness (some avoidable, after fixing bugs, and some unavoidable), and given the success rate of e2e tests, I suspect the default fail-fast behavior is probably using our CI runners less efficiently than if we turned it off.