### PR TITLE
agent/metrics: Add "endpoint" for agent→informant request metrics

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -602,7 +602,7 @@ func doInformantRequest[Q any, R any](
 ) (_ *R, statusCode int, _ error) {
 	result := "<internal error>"
 	defer func() {
-		s.runner.global.metrics.informantRequestsOutbound.WithLabelValues(result).Inc()
+		s.runner.global.metrics.informantRequestsOutbound.WithLabelValues(path, result).Inc()
 	}()
 
 	reqBody, err := json.Marshal(reqData)

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -98,7 +98,7 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 				Name: "autoscaling_agent_informant_outbound_requests_total",
 				Help: "Number of attempted HTTP requests to vm-informants by autoscaler-agents",
 			},
-			[]string{"code"},
+			[]string{"endpoint", "code"},
 		)),
 		informantRequestsInbound: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{


### PR DESCRIPTION
We have it for informant → agent metrics, but not the other way around.