### PR TITLE
agent: Fix NeonVM downscaling not showing up in metrics

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1486,7 +1486,7 @@ func (r *Runner) doVMUpdate(
 		}
 	}
 
-	r.recordResourceChange(downscaled, target, r.global.metrics.neonvmRequestedChange)
+	r.recordResourceChange(current, target, r.global.metrics.neonvmRequestedChange)
 
 	// Make the NeonVM request
 	patches := []util.JSONPatch{{


### PR DESCRIPTION
Basically, because we were recording the change from 'downscaled' to 'target', rather than 'current' to 'target', any time we sent a NeonVM request to downscale, we'd record the change as doing nothing.

**NB: This may be worth backporting?** It's a pretty simple fix, and it's maybe worth it to not have our metrics broken.