### PR TITLE
plugin: Include node group in node resource metrics

### DIFF
--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -47,7 +47,7 @@ type Config struct {
 
 	// K8sNodeGroupLabel, if provided, gives the label to use when recording k8s node groups in the
 	// metrics (like for autoscaling_plugin_node_{cpu,mem}_resources_current)
-	K8sNodeGroupLabel string `json:"nodeGroupLabel"`
+	K8sNodeGroupLabel string `json:"k8sNodeGroupLabel"`
 
 	// DumpState, if provided, enables a server to dump internal state
 	DumpState *dumpStateConfig `json:"dumpState"`

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -45,6 +45,10 @@ type Config struct {
 	// re-enable it.
 	DoMigration *bool `json:"doMigration"`
 
+	// K8sNodeGroupLabel, if provided, gives the label to use when recording k8s node groups in the
+	// metrics (like for autoscaling_plugin_node_{cpu,mem}_resources_current)
+	K8sNodeGroupLabel string `json:"nodeGroupLabel"`
+
 	// DumpState, if provided, enables a server to dump internal state
 	DumpState *dumpStateConfig `json:"dumpState"`
 

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -120,6 +120,7 @@ type pointerString string
 type nodeStateDump struct {
 	Obj       pointerString                                   `json:"obj"`
 	Name      string                                          `json:"name"`
+	NodeGroup string                                          `json:"nodeGroup"`
 	VCPU      nodeResourceState[vmapi.MilliCPU]               `json:"vCPU"`
 	MemSlots  nodeResourceState[uint16]                       `json:"memSlots"`
 	Pods      []keyed[util.NamespacedName, podStateDump]      `json:"pods"`
@@ -225,6 +226,7 @@ func (s *nodeState) dump() nodeStateDump {
 	return nodeStateDump{
 		Obj:       makePointerString(s),
 		Name:      s.name,
+		NodeGroup: s.nodeGroup,
 		VCPU:      s.vCPU,
 		MemSlots:  s.memSlots,
 		Pods:      pods,

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -66,14 +66,14 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 				Name: "autoscaling_plugin_node_cpu_resources_current",
 				Help: "Current amount of CPU for 'nodeResourceState' fields",
 			},
-			[]string{"node", "field"},
+			[]string{"node", "node_group", "field"},
 		)),
 		nodeMemResources: util.RegisterMetric(reg, prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "autoscaling_plugin_node_mem_resources_current",
 				Help: "Current amount of memory (in bytes) for 'nodeResourceState' fields",
 			},
-			[]string{"node", "field"},
+			[]string{"node", "node_group", "field"},
 		)),
 	}
 


### PR DESCRIPTION
One of the features we're actually sorely missing with our current node-level resource usage metrics is the ability to aggregate them by node group.

Per-node group information, rather than per-cluster is more likely to be a useful signal (because various node groups being over/under provisioned typically won't affect the others).

This PR adds a new config field to set the node group label: `k8sNodeGroupLabel`. For EKS, this label is `eks.amazonaws.com/nodegroup`.