### PR TITLE
plugin: Migration handling reliability improvements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,8 +49,8 @@ linters-settings:
     exclude:
       - '^net/http\.(Client|Server)'
       - '^net\.TCPAddr$'
-      # metav1.{CreateOptions,GetOptions,ListOptions,WatchOptions,PatchOptions}
-      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.(Create|Get|List|Watch|Patch)Options$'
+      # metav1.{CreateOptions,GetOptions,ListOptions,WatchOptions,PatchOptions,DeleteOptions}
+      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.(Create|Get|List|Watch|Patch|Delete)Options$'
       - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.ObjectMeta$'
       - '^k8s\.io/apimachinery/pkg/api/resource\.Quantity$'
       - '^github.com/prometheus/client_golang/prometheus(/.*)?\.\w+Opts$'

--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -37,5 +37,6 @@ data:
         "port": 10298,
         "timeoutSeconds": 5
       },
+      "migrationDeletionRetrySeconds": 5,
       "doMigration": false
     }

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -39,6 +39,10 @@ type Config struct {
 	// version handled.
 	SchedulerName string `json:"schedulerName"`
 
+	// MigrationDeletionRetrySeconds gives the duration, in seconds, we should wait between retrying
+	// a failed attempt to delete a VirtualMachineMigration that's finished.
+	MigrationDeletionRetrySeconds uint `json:"migrationDeletionRetrySeconds"`
+
 	// DoMigration, if provided, allows VM migration to be disabled
 	//
 	// This flag is intended to be temporary, just until NeonVM supports mgirations and we can
@@ -113,6 +117,10 @@ func (c *Config) validate() (string, error) {
 		if path, err := c.DumpState.validate(); err != nil {
 			return fmt.Sprintf("dumpState.%s", path), err
 		}
+	}
+
+	if c.MigrationDeletionRetrySeconds == 0 {
+		return "migrationDeletionRetrySeconds", errors.New("value must be > 0")
 	}
 
 	return "", nil

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -99,6 +99,8 @@ type keyed[K any, V any] struct {
 }
 
 type pluginStateDump struct {
+	OngoingMigrationDeletions []keyed[util.NamespacedName, int] `json:"ongoingMigrationDeletions"`
+
 	Nodes []keyed[string, nodeStateDump] `json:"nodes"`
 
 	VMPods    []podNameAndPointer `json:"vmPods"`
@@ -189,7 +191,14 @@ func (s *pluginState) dump(ctx context.Context) (*pluginStateDump, error) {
 		return kvx.Key < kvy.Key
 	})
 
+	ongoingMigrationDeletions := make([]keyed[util.NamespacedName, int], 0, len(s.ongoingMigrationDeletions))
+	for k, count := range s.ongoingMigrationDeletions {
+		ongoingMigrationDeletions = append(ongoingMigrationDeletions, keyed[util.NamespacedName, int]{Key: k, Value: count})
+	}
+	sortSliceByPodName(ongoingMigrationDeletions, func(kv keyed[util.NamespacedName, int]) util.NamespacedName { return kv.Key })
+
 	return &pluginStateDump{
+		OngoingMigrationDeletions:  ongoingMigrationDeletions,
 		Nodes:                      nodes,
 		VMPods:                     vmPods,
 		OtherPods:                  otherPods,

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -100,8 +100,9 @@ func makeAutoscaleEnforcerPlugin(
 		vmClient: vmClient,
 		// remaining fields are set by p.readClusterState and p.makePrometheusRegistry
 		state: pluginState{ //nolint:exhaustruct // see above.
-			lock: util.NewChanMutex(),
-			conf: config,
+			lock:                      util.NewChanMutex(),
+			ongoingMigrationDeletions: make(map[util.NamespacedName]int),
+			conf:                      config,
 		},
 		metrics:   PromMetrics{},      //nolint:exhaustruct // set by makePrometheusRegistry
 		vmStore:   IndexedVMStore{},   //nolint:exhaustruct // set below
@@ -154,6 +155,13 @@ func makeAutoscaleEnforcerPlugin(
 			pushToQueue(logger, func() { p.handleNonAutoscalingUsageChange(hlogger, vm, podName) })
 		},
 	}
+	mwc := migrationWatchCallbacks{
+		submitMigrationFinished: func(vmm *vmapi.VirtualMachineMigration) {
+			// When cleaning up migrations, we don't want to process those events synchronously.
+			// So instead, we'll spawn a goroutine to delete the completed migration.
+			go p.cleanupMigration(hlogger, vmm)
+		},
+	}
 
 	watchMetrics := watch.NewMetrics("autoscaling_plugin_watchers")
 
@@ -174,6 +182,11 @@ func makeAutoscaleEnforcerPlugin(
 	vmStore, err := p.watchVMEvents(ctx, logger, watchMetrics, vwc)
 	if err != nil {
 		return nil, fmt.Errorf("Error starting VM watcher: %w", err)
+	}
+
+	logger.Info("Starting VM Migration watcher")
+	if _, err := p.watchMigrationEvents(ctx, logger, watchMetrics, mwc); err != nil {
+		return nil, fmt.Errorf("Error starting VM Migration watcher: %w", err)
 	}
 
 	p.vmStore = watch.NewIndexedStore(vmStore, watch.NewNameIndex[vmapi.VirtualMachine]())

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -25,6 +25,7 @@ import (
 
 const Name = "AutoscaleEnforcer"
 const LabelVM = vmapi.VirtualMachineNameLabel
+const LabelPluginCreatedMigration = "autoscaling.neon.tech/created-by-scheduler"
 const ConfigMapNamespace = "kube-system"
 const ConfigMapName = "scheduler-plugin-config"
 const ConfigMapKey = "autoscaler-enforcer-config.json"

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -18,6 +18,10 @@ type PromMetrics struct {
 	validResourceRequests *prometheus.CounterVec
 	nodeCPUResources      *prometheus.GaugeVec
 	nodeMemResources      *prometheus.GaugeVec
+	migrationCreations    prometheus.Counter
+	migrationDeletions    *prometheus.CounterVec
+	migrationCreateFails  prometheus.Counter
+	migrationDeleteFails  *prometheus.CounterVec
 }
 
 func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
@@ -74,6 +78,32 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 				Help: "Current amount of memory (in bytes) for 'nodeResourceState' fields",
 			},
 			[]string{"node", "field"},
+		)),
+		migrationCreations: util.RegisterMetric(reg, prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "autoscaling_plugin_migrations_created_total",
+				Help: "Number of successful VirtualMachineMigration Create requests by the plugin",
+			},
+		)),
+		migrationDeletions: util.RegisterMetric(reg, prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "autoscaling_plugin_migrations_deleted_total",
+				Help: "Number of successful VirtualMachineMigration Delete requests by the plugin",
+			},
+			[]string{"phase"},
+		)),
+		migrationCreateFails: util.RegisterMetric(reg, prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "autoscaling_plugin_migration_create_fails_total",
+				Help: "Number of failed VirtualMachineMigration Create requests by the plugin",
+			},
+		)),
+		migrationDeleteFails: util.RegisterMetric(reg, prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "autoscaling_plugin_migration_delete_fails_total",
+				Help: "Number of failed VirtualMachineMigration Delete requests by the plugin",
+			},
+			[]string{"phase"},
 		)),
 	}
 

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -180,7 +180,7 @@ func (e *AutoscaleEnforcer) handleAgentRequest(
 
 	var migrateDecision *api.MigrateResponse
 	if mustMigrate {
-		created, err := e.state.startMigration(context.Background(), logger, pod, e.vmClient)
+		created, err := e.startMigration(context.Background(), logger, pod)
 		if err != nil {
 			return nil, 500, fmt.Errorf("Error starting migration for pod %v: %w", pod.name, err)
 		}

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -1146,6 +1146,12 @@ func (e *AutoscaleEnforcer) startMigration(ctx context.Context, logger *zap.Logg
 		return false, fmt.Errorf("Error checking if migration exists: %w", err)
 	}
 
+	gitVersion := util.GetBuildInfo().GitInfo
+	// FIXME: make this not depend on GetBuildInfo() internals.
+	if gitVersion == "<unknown>" {
+		gitVersion = "unknown"
+	}
+
 	vmm := &vmapi.VirtualMachineMigration{
 		ObjectMeta: metav1.ObjectMeta{
 			// TODO: it's maybe possible for this to run into name length limits? Unclear what we
@@ -1158,7 +1164,7 @@ func (e *AutoscaleEnforcer) startMigration(ctx context.Context, logger *zap.Logg
 				//
 				// See also:
 				// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
-				LabelPluginCreatedMigration: util.GetBuildInfo().GitInfo,
+				LabelPluginCreatedMigration: gitVersion,
 			},
 		},
 		Spec: vmapi.VirtualMachineMigrationSpec{

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -19,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-	vmclient "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
 
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
@@ -32,6 +31,8 @@ import (
 // Accessing the individual fields MUST be done while holding a lock.
 type pluginState struct {
 	lock util.ChanMutex
+
+	ongoingMigrationDeletions map[util.NamespacedName]int
 
 	podMap  map[util.NamespacedName]*podState
 	nodeMap map[string]*nodeState
@@ -986,6 +987,101 @@ func (e *AutoscaleEnforcer) handleNonAutoscalingUsageChange(logger *zap.Logger, 
 	)
 }
 
+// NB: expected to be run in its own thread.
+func (e *AutoscaleEnforcer) cleanupMigration(logger *zap.Logger, vmm *vmapi.VirtualMachineMigration) {
+	vmmName := util.GetNamespacedName(vmm)
+
+	logger = logger.With(
+		// note: use the "virtualmachinemigration" key here for just the name, because it mirrors
+		// what we log in startMigration.
+		zap.Object("virtualmachinemigration", vmmName),
+		// also include the VM, for better association.
+		zap.Object("virtualmachine", util.NamespacedName{
+			Name:      vmm.Spec.VmName,
+			Namespace: vmm.Namespace,
+		}),
+	)
+	// Failed migrations should be noisy. Everything to do with cleaning up a failed migration
+	// should be logged at "Warn" or higher.
+	var logInfo func(string, ...zap.Field)
+	if vmm.Status.Phase == vmapi.VmmSucceeded {
+		logInfo = logger.Info
+	} else {
+		logInfo = logger.Warn
+	}
+	logInfo(
+		"Going to delete VirtualMachineMigration",
+		// Explicitly include "phase" here because we have metrics for it.
+		zap.String("phase", string(vmm.Status.Phase)),
+		// ... and then log the rest of the information about the migration:
+		zap.Any("spec", vmm.Spec),
+		zap.Any("status", vmm.Status),
+	)
+
+	// mark the operation as ongoing
+	func() {
+		e.state.lock.Lock()
+		defer e.state.lock.Unlock()
+
+		newCount := e.state.ongoingMigrationDeletions[vmmName] + 1
+		if newCount != 1 {
+			// context included by logger
+			logger.Error(
+				"More than one ongoing deletion for VirtualMachineMigration",
+				zap.Int("count", newCount),
+			)
+		}
+		e.state.ongoingMigrationDeletions[vmmName] = newCount
+	}()
+	// ... and remember to clean up when we're done:
+	defer func() {
+		e.state.lock.Lock()
+		defer e.state.lock.Unlock()
+
+		newCount := e.state.ongoingMigrationDeletions[vmmName] - 1
+		if newCount == 0 {
+			delete(e.state.ongoingMigrationDeletions, vmmName)
+		} else {
+			// context included by logger
+			logger.Error(
+				"More than one ongoing deletion for VirtualMachineMigration",
+				zap.Int("count", newCount),
+			)
+			e.state.ongoingMigrationDeletions[vmmName] = newCount
+		}
+	}()
+
+	// Continually retry the operation, until we're successful (or the VM doesn't exist anymore)
+
+	retryWait := time.Second * time.Duration(e.state.conf.MigrationDeletionRetrySeconds)
+
+	for {
+		logInfo("Attempting to delete VirtualMachineMigration")
+		err := e.vmClient.NeonvmV1().
+			VirtualMachineMigrations(vmmName.Namespace).
+			Delete(context.TODO(), vmmName.Name, metav1.DeleteOptions{})
+		if err == nil /* NB! This condition is inverted! */ {
+			logInfo("Successfully deleted VirtualMachineMigration")
+			e.metrics.migrationDeletions.WithLabelValues(string(vmm.Status.Phase)).Inc()
+			return
+		} else if apierrors.IsNotFound(err) {
+			logger.Warn("Deletion was handled for us; VirtualMachineMigration no longer exists")
+			return
+		}
+
+		logger.Error(
+			"Failed to delete VirtualMachineMigration, will try again after delay",
+			zap.Duration("delay", retryWait),
+			zap.Error(err),
+		)
+		e.metrics.migrationDeleteFails.WithLabelValues(string(vmm.Status.Phase)).Inc()
+
+		// retry after a delay
+		time.Sleep(retryWait)
+		continue
+	}
+}
+
 func (s *podState) isBetterMigrationTarget(other *podState) bool {
 	// TODO: this deprioritizes VMs whose metrics we can't collect. Maybe we don't want that?
 	if s.metrics == nil || other.metrics == nil {
@@ -1000,14 +1096,14 @@ func (s *podState) isBetterMigrationTarget(other *podState) bool {
 // send requests to the API server
 //
 // A lock will ALWAYS be held on return from this function.
-func (s *pluginState) startMigration(ctx context.Context, logger *zap.Logger, pod *podState, vmClient *vmclient.Clientset) (created bool, _ error) {
+func (e *AutoscaleEnforcer) startMigration(ctx context.Context, logger *zap.Logger, pod *podState) (created bool, _ error) {
 	if pod.currentlyMigrating() {
 		return false, fmt.Errorf("Pod is already migrating")
 	}
 
 	// Unlock to make the API request(s), then make sure we're locked on return.
-	s.lock.Unlock()
-	defer s.lock.Lock()
+	e.state.lock.Unlock()
+	defer e.state.lock.Lock()
 
 	vmmName := util.NamespacedName{
 		Name:      fmt.Sprintf("schedplugin-%s", pod.vmName.Name),
@@ -1024,7 +1120,7 @@ func (s *pluginState) startMigration(ctx context.Context, logger *zap.Logger, po
 	// We technically don't *need* this additional request here (because we can check the return
 	// from the Create request with apierrors.IsAlreadyExists). However: the benefit we get from
 	// this is that the logs are significantly clearer.
-	_, err := vmClient.NeonvmV1().
+	_, err := e.vmClient.NeonvmV1().
 		VirtualMachineMigrations(pod.name.Namespace).
 		Get(ctx, vmmName.Name, metav1.GetOptions{})
 	if err == nil {
@@ -1059,12 +1155,14 @@ func (s *pluginState) startMigration(ctx context.Context, logger *zap.Logger, po
 	}
 
 	logger.Info("Migration doesn't already exist, creating one for VM", zap.Any("spec", vmm.Spec))
-	_, err = vmClient.NeonvmV1().VirtualMachineMigrations(pod.name.Namespace).Create(ctx, vmm, metav1.CreateOptions{})
+	_, err = e.vmClient.NeonvmV1().VirtualMachineMigrations(pod.name.Namespace).Create(ctx, vmm, metav1.CreateOptions{})
 	if err != nil {
+		e.metrics.migrationCreateFails.Inc()
 		// log here, while the logger's fields are in scope
 		logger.Error("Unexpected error doing Create request for new migration", zap.Error(err))
 		return false, fmt.Errorf("Error creating migration: %w", err)
 	}
+	e.metrics.migrationCreations.Inc()
 	logger.Info("VM migration request successful")
 
 	return true, nil

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -1139,6 +1139,14 @@ func (e *AutoscaleEnforcer) startMigration(ctx context.Context, logger *zap.Logg
 			// should do if that happens.
 			Name:      vmmName.Name,
 			Namespace: pod.name.Namespace,
+			Labels: map[string]string{
+				// NB: There's requirements on what constitutes a valid label. Thankfully, the
+				// output of `git describe` always will.
+				//
+				// See also:
+				// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+				LabelPluginCreatedMigration: util.GetBuildInfo().GitInfo,
+			},
 		},
 		Spec: vmapi.VirtualMachineMigrationSpec{
 			VmName: pod.vmName.Name,

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -329,7 +329,14 @@ func (e *AutoscaleEnforcer) watchMigrationEvents(
 			Items: func(list *vmapi.VirtualMachineMigrationList) []vmapi.VirtualMachineMigration { return list.Items },
 		},
 		watch.InitModeSync,
-		metav1.ListOptions{},
+		metav1.ListOptions{
+			// NB: Including just the label itself means that we select for objects that *have* the
+			// label, without caring about the actual value.
+			//
+			// See also:
+			// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement
+			LabelSelector: LabelPluginCreatedMigration,
+		},
 		watch.HandlerFuncs[*vmapi.VirtualMachineMigration]{
 			UpdateFunc: func(oldObj, newObj *vmapi.VirtualMachineMigration) {
 				shouldDelete := newObj.Status.Phase != oldObj.Status.Phase &&

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -303,6 +303,15 @@ type migrationWatchCallbacks struct {
 	submitMigrationFinished func(*vmapi.VirtualMachineMigration)
 }
 
+// watchMigrationEvents *only* looks at migrations that were created by the scheduler plugin (or a
+// previous version of it).
+//
+// We use this to trigger cleaning up migrations once they're finished, because they don't
+// auto-delete, and our deterministic naming means that each we won't be able to create a new
+// migration for the same VM until the old one's gone.
+//
+// Tracking whether a migration was created by the scheduler plugin is done by adding the label
+// 'autoscaling.neon.tech/created-by-scheduler' to every migration we create.
 func (e *AutoscaleEnforcer) watchMigrationEvents(
 	ctx context.Context,
 	parentLogger *zap.Logger,

--- a/pkg/util/buildinfo.go
+++ b/pkg/util/buildinfo.go
@@ -33,6 +33,8 @@ func GetBuildInfo() BuildInfo {
 		}
 	}
 
+	// FIXME: the "<unknown>" string is depended upon by the plugin's VirtualMachineMigration
+	// creation process. We should expose something better here.
 	gitInfo := BuildGitInfo
 	if BuildGitInfo == "" {
 		gitInfo = "<unknown>"


### PR DESCRIPTION
Like all good things, this PR comes in three parts:

1. If the plugin decides to trigger a migration, it no longer returns a non-nil `PluginResponse.Migrate` if the VirtualMachineMigration already existed.
    - This had the potential to cause spurious failures where the autoscaler-agent permanently shuts off communication because _it_ was told that the scheduler is going to migrate it, but actually the migration had already completed.
2. The plugin now automatically cleans up completed migrations.
    - To make this work, all migrations now have the `autoscaling.neon.tech/created-by-scheduler` label.
3. The plugin now exposes metrics about migration creation and deletion. These are:
    - `autoscaling_plugin_migrations_created_total`
    - `autoscaling_plugin_migrations_deleted_total`
    - `autoscaling_plugin_migration_create_fails_total`
    - `autoscaling_plugin_migration_delete_fails_total`