### PR TITLE
agent: Fix Runner panic when scaling bounds decrease

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1301,10 +1301,12 @@ func (r *Runner) getStateForVMUpdate(logger *zap.Logger, updateReason VMUpdateRe
 
 	// Check that the VM's current usage is <= lastApproved
 	if vmUsing := r.vm.Using(); vmUsing.HasFieldGreaterThan(*r.lastApproved) {
-		panic(fmt.Errorf(
-			"invalid state: r.vm has resources greater than r.lastApproved (%+v vs %+v)",
-			vmUsing, *r.lastApproved,
-		))
+		// ref <https://github.com/neondatabase/autoscaling/issues/234>
+		logger.Warn(
+			"r.vm has resources greater than r.lastApproved. This should only happen when scaling bounds change",
+			zap.Object("using", vmUsing),
+			zap.Object("lastApproved", *r.lastApproved),
+		)
 	}
 
 	config := r.global.config.Scaling.DefaultConfig


### PR DESCRIPTION
Fixes #234. This affects pools, and *should* be fine without it, because the Runner will auto-restart and *should* be ok after that, but it's worth fixing anyways.

~~(In the meantime, I'll validate that #234 will self-resolve after restart; otherwise this fix will block our VM pool improvements)~~

#234 _does_ self-resolve after restart; we should be ok.