### PR TITLE
plugin: Track all pods, remove 'System' resources, ignore overprovisioning pods

### DIFF
--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -27,8 +27,8 @@ data:
     {
       "memBlockSize": "1Gi",
       "nodeDefaults": {
-        "cpu": { "watermark": 0.7, "system": "500m" },
-        "memory": { "watermark": 0.7, "system": "0.5Gi" },
+        "cpu": { "watermark": 0.7 },
+        "memory": { "watermark": 0.7 },
         "computeUnit": { "vCPUs": 0.25, "mem": 1 }
       },
       "nodeOverrides": [],

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -385,6 +385,12 @@ func (e *AutoscaleEnforcer) Filter(
 	logger := e.logger.With(zap.String("method", "Filter"), zap.String("node", nodeName), util.PodNameFields(pod))
 	logger.Info("Handling Filter request")
 
+	if e.state.conf.ignoredNamespace(pod.Namespace) {
+		// Generally, we shouldn't be getting plugin requests for resources that are ignored.
+		logger.Warn("Ignoring Filter request for pod in ignored namespace")
+		return
+	}
+
 	vmInfo, err := getVmInfo(logger, e.vmStore, pod)
 	if err != nil {
 		logger.Error("Error getting VM info for Pod", zap.Error(err))
@@ -656,6 +662,12 @@ func (e *AutoscaleEnforcer) Reserve(
 
 	logger.Info("Handling Reserve request")
 
+	if e.state.conf.ignoredNamespace(pod.Namespace) {
+		// Generally, we shouldn't be getting plugin requests for resources that are ignored.
+		logger.Warn("Ignoring Reserve request for pod in ignored namespace")
+		return nil // success; allow the Pod onto the node.
+	}
+
 	vmInfo, err := getVmInfo(logger, e.vmStore, pod)
 	if err != nil {
 		logger.Error("Error getting VM info for pod", zap.Error(err))
@@ -875,6 +887,12 @@ func (e *AutoscaleEnforcer) Unreserve(
 
 	logger := e.logger.With(zap.String("method", "Unreserve"), zap.String("node", nodeName), util.PodNameFields(pod))
 	logger.Info("Handling Unreserve request")
+
+	if e.state.conf.ignoredNamespace(pod.Namespace) {
+		// Generally, we shouldn't be getting plugin requests for resources that are ignored.
+		logger.Warn("Ignoring Unreserve request for pod in ignored namespace")
+		return
+	}
 
 	e.state.lock.Lock()
 	defer e.state.lock.Unlock()

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -132,6 +132,9 @@ func makeAutoscaleEnforcerPlugin(
 		},
 	}
 	pwc := podWatchCallbacks{
+		submitPodStarted: func(logger *zap.Logger, pod *corev1.Pod) {
+			pushToQueue(logger, func() { p.handlePodStarted(hlogger, pod) })
+		},
 		submitVMDeletion: func(logger *zap.Logger, pod util.NamespacedName) {
 			pushToQueue(logger, func() { p.handleVMDeletion(hlogger, pod) })
 		},

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -1338,7 +1338,10 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context, logger *zap.Lo
 			skippedVms += 1
 		}
 
-		if pod.Spec.NodeName == "" {
+		if p.state.conf.ignoredNamespace(pod.Namespace) {
+			logSkip("VM is in ignored namespace")
+			continue
+		} else if pod.Spec.NodeName == "" {
 			logSkip("VM pod's Spec.NodeName = \"\" (maybe it hasn't been scheduled yet?)")
 			continue
 		}
@@ -1468,6 +1471,9 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context, logger *zap.Lo
 		}
 
 		if _, ok := p.state.podMap[podName]; ok {
+			continue
+		} else if p.state.conf.ignoredNamespace(pod.Namespace) {
+			logSkip("non-VM pod is in ignored namespace")
 			continue
 		}
 

--- a/pkg/plugin/trans.go
+++ b/pkg/plugin/trans.go
@@ -85,7 +85,7 @@ func (s verdictSet) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 //
 // A pretty-formatted summary of the outcome is returned as the verdict, for logging.
 func (r resourceTransition[T]) handleRequested(requested T, startingMigration bool, onlyThousands bool) (verdict string) {
-	totalReservable := r.node.Total - r.node.System
+	totalReservable := r.node.Total
 	// note: it's possible to temporarily have reserved > totalReservable, after loading state or
 	// config change; we have to use SaturatingSub here to account for that.
 	remainingReservable := util.SaturatingSub(totalReservable, r.oldNode.reserved)


### PR DESCRIPTION
Resolves #384. Pre-req ish for #397.

- [x] Track all pods
- [x] Remove 'System' resources
- [x] Ignore overprovisioning pods

Not yet sure whether this should be merged via rebase, or squashed. These changes all _basically_ need to be grouped together because they're mutually dependent, even though they're logically separate.