### PR TITLE
plugin: Emit k8s Event on failed ExtractVmInfo

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -178,12 +178,15 @@ func makeAutoscaleEnforcerPlugin(
 	p.nodeStore = watch.NewIndexedStore(nodeStore, watch.NewFlatNameIndex[corev1.Node]())
 
 	logger.Info("Starting pod watcher")
-	if err := p.watchPodEvents(ctx, logger, watchMetrics, pwc); err != nil {
+	podStore, err := p.watchPodEvents(ctx, logger, watchMetrics, pwc)
+	if err != nil {
 		return nil, fmt.Errorf("Error starting pod watcher: %w", err)
 	}
 
+	podIndex := watch.NewIndexedStore(podStore, watch.NewNameIndex[corev1.Pod]())
+
 	logger.Info("Starting VM watcher")
-	vmStore, err := p.watchVMEvents(ctx, logger, watchMetrics, vwc)
+	vmStore, err := p.watchVMEvents(ctx, logger, watchMetrics, vwc, podIndex)
 	if err != nil {
 		return nil, fmt.Errorf("Error starting VM watcher: %w", err)
 	}

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -82,10 +82,10 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 	parentLogger *zap.Logger,
 	metrics watch.Metrics,
 	callbacks podWatchCallbacks,
-) error {
+) (*watch.Store[corev1.Pod], error) {
 	logger := parentLogger.Named("pod-watch")
 
-	_, err := watch.Watch(
+	return watch.Watch(
 		ctx,
 		logger.Named("watch"),
 		e.handle.ClientSet().CoreV1().Pods(corev1.NamespaceAll),
@@ -190,7 +190,6 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 			},
 		},
 	)
-	return err
 }
 
 // tryMigrationOwnerReference returns the name of the owning migration, if this pod *is* owned by a
@@ -269,6 +268,7 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 	parentLogger *zap.Logger,
 	metrics watch.Metrics,
 	callbacks vmWatchCallbacks,
+	podIndex watch.IndexedStore[corev1.Pod, *watch.NameIndex[corev1.Pod]],
 ) (*watch.Store[vmapi.VirtualMachine], error) {
 	logger := parentLogger.Named("vm-watch")
 
@@ -300,10 +300,21 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 
 				newInfo, err := api.ExtractVmInfo(logger, newVM)
 				if err != nil {
+					// Try to get the runner pod associated with the VM, if we can, but don't worry
+					// about it if we can't.
+					var runnerPod *corev1.Pod
+					if podName := newVM.Status.PodName; podName != "" {
+						// NB: index.Get returns nil if not found, so we only have a non-nil
+						// runnerPod if it's currently known.
+						runnerPod, _ = podIndex.GetIndexed(func(index *watch.NameIndex[corev1.Pod]) (*corev1.Pod, bool) {
+							return index.Get(newVM.Namespace, podName)
+						})
+					}
+
 					logger.Error("Failed to extract VM info in update for new VM", util.VMNameFields(newVM), zap.Error(err))
 					e.handle.EventRecorder().Eventf(
 						newVM,            // regarding
-						nil,              // related
+						runnerPod,        // related
 						"Warning",        // eventtype
 						"ExtractVmInfo",  // reason
 						"HandleVmUpdate", // action

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -298,14 +298,23 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 					return
 				}
 
-				oldInfo, err := api.ExtractVmInfo(logger, oldVM)
-				if err != nil {
-					logger.Error("Failed to extract VM info in update for old VM", util.VMNameFields(oldVM), zap.Error(err))
-					return
-				}
 				newInfo, err := api.ExtractVmInfo(logger, newVM)
 				if err != nil {
 					logger.Error("Failed to extract VM info in update for new VM", util.VMNameFields(newVM), zap.Error(err))
+					e.handle.EventRecorder().Eventf(
+						newVM,            // regarding
+						nil,              // related
+						"Warning",        // eventtype
+						"ExtractVmInfo",  // reason
+						"HandleVmUpdate", // action
+						"Failed to extract autoscaling info about VM: %s", // note
+						err,
+					)
+					return
+				}
+				oldInfo, err := api.ExtractVmInfo(logger, oldVM)
+				if err != nil {
+					logger.Error("Failed to extract VM info in update for old VM", util.VMNameFields(oldVM), zap.Error(err))
 					return
 				}
 


### PR DESCRIPTION
This should make observability for invalid autoscaling annotations / labels much better; previously, this information was only really visible in the logs.

Tested this locally by modifying `vm-deploy.yaml` and it seems to work as expected.

cc @cicdteam for any advice on events here.