### PR TITLE
plugin: Fix leak by actually consuming queue

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -207,13 +207,15 @@ func makeAutoscaleEnforcerPlugin(
 	}
 
 	go func() {
-		iter := queue.Iterator()
-		for iter.Next(ctx) {
-			callback := iter.Value()
+		for {
+			callback, err := queue.Wait(ctx)
+			if err != nil {
+				logger.Info("Stopped waiting on pod/VM queue", zap.Error(err))
+				break
+			}
+
 			callback()
-		}
-		if err := iter.Close(); err != nil {
-			logger.Info("Stopped waiting on pod/VM queue", zap.Error(err))
+			queue.Remove()
 		}
 	}()
 


### PR DESCRIPTION
Fixes #409, validated locally, etc. Turns out `pubsub.Queue[...].Iterator()` doesn't actually consume the queue, it just visits everything in it.

Bug was originally introduced by #160, commit 2795b50ab7582dff2fa24442e24db41a01e47d14, but we didn't notice before because of (a) other memory leakage (see #248) and (b) the size of the items in the queue were all small before #399, which started passing through whole K8s `Pod` objects.

**NB: This should be backported onto v0.13.0, or released alongside recent commits as v0.13.1**