### PR TITLE
plugin: Fix behavior of ignored namespaces during Filter

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -467,6 +467,36 @@ func (e *AutoscaleEnforcer) Filter(
 			otherResources = oldRes.addPod(&e.state.conf.MemSlotSize, otherPodState.resources)
 			totalNodeVCPU += otherResources.ReservedCPU - oldRes.ReservedCPU
 			totalNodeMem += otherResources.ReservedMemSlots - oldRes.ReservedMemSlots
+		} else {
+			name := util.GetNamespacedName(podInfo.Pod)
+
+			if !e.state.conf.ignoredNamespace(podInfo.Pod.Namespace) {
+				// FIXME: this gets us duplicated "pod" fields. Not great. But we're using
+				// logger.With pretty pervasively, and it's hard to avoid this while using that.
+				// For now, we can get around this by including the pod name in an error.
+				logger.Error(
+					"Unknown-but-not-ignored Pod in Filter node's pods",
+					zap.Object("pod", name),
+					zap.Error(fmt.Errorf("Pod %v is unknown but not ignored", name)),
+				)
+			}
+
+			// We *also* need to count pods in ignored namespaces
+			resources, err := extractPodOtherPodResourceState(podInfo.Pod)
+			if err != nil {
+				// FIXME: Same duplicate "pod" field issue as above; same temporary solution.
+				logger.Error(
+					"Error extracting resource state for non-VM Pod",
+					zap.Object("pod", name),
+					zap.Error(fmt.Errorf("Error extracting resource state for %v: %w", name, err)),
+				)
+				continue
+			}
+
+			oldRes := otherResources
+			otherResources = oldRes.addPod(&e.state.conf.MemSlotSize, resources)
+			totalNodeVCPU += otherResources.ReservedCPU - oldRes.ReservedCPU
+			totalNodeMem += otherResources.ReservedMemSlots - oldRes.ReservedMemSlots
 		}
 	}
 


### PR DESCRIPTION
The intention behind that piece of #399 was that pods from ignored namespaces (particularly: `overprovisioning`) should be included *only* in the Filter calculations, so that it gets used to trigger eviction for those pods, but NOT migrations.

However, the current behavior (before this PR) just ignores all pods that weren't previously known, so the ignored namespaces were *still* getting ignored during filter. That's fixed here (missed it in #399).