### PR TITLE
plugin: Handle Filter request in ignored namespaces

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -388,9 +388,7 @@ func (e *AutoscaleEnforcer) Filter(
 	logger.Info("Handling Filter request")
 
 	if e.state.conf.ignoredNamespace(pod.Namespace) {
-		// Generally, we shouldn't be getting plugin requests for resources that are ignored.
-		logger.Warn("Ignoring Filter request for pod in ignored namespace")
-		return
+		logger.Warn("Received Filter request for pod in ignored namespace, continuing anyways.")
 	}
 
 	vmInfo, err := getVmInfo(logger, e.vmStore, pod)


### PR DESCRIPTION
In combination with #416, it *may* be necessary to have the overprovisioning pods go through our scheduler as well in order to stay evicted. If that's the case, they'll need to go through the normal Filter flow as well so they can be rejected (so cluster-autoscaler can do its thing).