### PR TITLE
agent: Fix LA-based scaling being 4x too small

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -1354,8 +1354,9 @@ func (s *atomicUpdateState) desiredVMState(allowDecrease bool) api.Resources {
 	// For CPU:
 	// Goal compute unit is at the point where (CPUs) × (LoadAverageFractionTarget) == (load
 	// average),
-	// which we can get by dividing LA by LAFT.
-	cpuGoalCU := uint32(math.Round(float64(s.metrics.LoadAverage1Min) / s.config.LoadAverageFractionTarget))
+	// which we can get by dividing LA by LAFT, and then dividing by the number of CPUs per CU
+	goalCPUs := float64(s.metrics.LoadAverage1Min) / s.config.LoadAverageFractionTarget
+	cpuGoalCU := uint32(math.Round(goalCPUs / s.computeUnit.VCPU.AsFloat64()))
 
 	// For Mem:
 	// Goal compute unit is at the point where (Mem) * (MemoryUsageFractionTarget) == (Mem Usage)


### PR DESCRIPTION
When we switched compute units from (1 CPU, 4 GiB) to (1/4 CPU, 1 GiB), the previous behavior of assuming that 1 CPU = 1 CU became a regression, causing us to significantly underestimate the actual amount of CPU needed to match a given load average.

Noticed this while looking at this VM: https://neonprod.grafana.net/goto/_RIiDPC4R?orgId=1
(using memory as a proxy for CU × 4, because reading "desired CPUs" is somewhat non-trivial)