### PR TITLE
plugin: Expose "ignored_namespace" label for method call metrics

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -341,9 +341,11 @@ func (e *AutoscaleEnforcer) PreFilter(
 	state *framework.CycleState,
 	pod *corev1.Pod,
 ) (_ *framework.PreFilterResult, status *framework.Status) {
-	e.metrics.pluginCalls.WithLabelValues("PreFilter").Inc()
+	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
+
+	e.metrics.IncMethodCall("PreFilter", ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("PreFilter", status)
+		e.metrics.IncFailIfNotSuccess("PreFilter", ignored, status)
 	}()
 
 	return nil, nil
@@ -369,9 +371,11 @@ func (e *AutoscaleEnforcer) PostFilter(
 	pod *corev1.Pod,
 	filteredNodeStatusMap framework.NodeToStatusMap,
 ) (_ *framework.PostFilterResult, status *framework.Status) {
-	e.metrics.pluginCalls.WithLabelValues("PostFilter").Inc()
+	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
+
+	e.metrics.IncMethodCall("PostFilter", ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("PostFilter", status)
+		e.metrics.IncFailIfNotSuccess("PostFilter", ignored, status)
 	}()
 
 	logger := e.logger.With(zap.String("method", "Filter"), util.PodNameFields(pod))
@@ -389,9 +393,11 @@ func (e *AutoscaleEnforcer) Filter(
 	pod *corev1.Pod,
 	nodeInfo *framework.NodeInfo,
 ) (status *framework.Status) {
-	e.metrics.pluginCalls.WithLabelValues("Filter").Inc()
+	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
+
+	e.metrics.IncMethodCall("Filter", ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("Filter", status)
+		e.metrics.IncFailIfNotSuccess("Filter", ignored, status)
 	}()
 
 	nodeName := nodeInfo.Node().Name // TODO: nodes also have namespaces? are they used at all?
@@ -399,7 +405,7 @@ func (e *AutoscaleEnforcer) Filter(
 	logger := e.logger.With(zap.String("method", "Filter"), zap.String("node", nodeName), util.PodNameFields(pod))
 	logger.Info("Handling Filter request")
 
-	if e.state.conf.ignoredNamespace(pod.Namespace) {
+	if ignored {
 		logger.Warn("Received Filter request for pod in ignored namespace, continuing anyways.")
 	}
 
@@ -616,9 +622,11 @@ func (e *AutoscaleEnforcer) Score(
 	pod *corev1.Pod,
 	nodeName string,
 ) (_ int64, status *framework.Status) {
-	e.metrics.pluginCalls.WithLabelValues("Score").Inc()
+	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
+
+	e.metrics.IncMethodCall("Score", ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("Score", status)
+		e.metrics.IncFailIfNotSuccess("Score", ignored, status)
 	}()
 
 	logger := e.logger.With(zap.String("method", "Score"), zap.String("node", nodeName), util.PodNameFields(pod))
@@ -691,9 +699,11 @@ func (e *AutoscaleEnforcer) Reserve(
 	pod *corev1.Pod,
 	nodeName string,
 ) (status *framework.Status) {
-	e.metrics.pluginCalls.WithLabelValues("Reserve").Inc()
+	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
+
+	e.metrics.IncMethodCall("Reserve", ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("Reserve", status)
+		e.metrics.IncFailIfNotSuccess("Reserve", ignored, status)
 	}()
 
 	pName := util.GetNamespacedName(pod)
@@ -704,7 +714,7 @@ func (e *AutoscaleEnforcer) Reserve(
 
 	logger.Info("Handling Reserve request")
 
-	if e.state.conf.ignoredNamespace(pod.Namespace) {
+	if ignored {
 		// Generally, we shouldn't be getting plugin requests for resources that are ignored.
 		logger.Warn("Ignoring Reserve request for pod in ignored namespace")
 		return nil // success; allow the Pod onto the node.
@@ -923,14 +933,15 @@ func (e *AutoscaleEnforcer) Unreserve(
 	pod *corev1.Pod,
 	nodeName string,
 ) {
-	e.metrics.pluginCalls.WithLabelValues("Unreserve").Inc()
+	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
+	e.metrics.IncMethodCall("Unreserve", ignored)
 
 	podName := util.GetNamespacedName(pod)
 
 	logger := e.logger.With(zap.String("method", "Unreserve"), zap.String("node", nodeName), util.PodNameFields(pod))
 	logger.Info("Handling Unreserve request")
 
-	if e.state.conf.ignoredNamespace(pod.Namespace) {
+	if ignored {
 		// Generally, we shouldn't be getting plugin requests for resources that are ignored.
 		logger.Warn("Ignoring Unreserve request for pod in ignored namespace")
 		return

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -3,6 +3,8 @@ package plugin
 // defines prometheus metrics and provides the server, via (*AutoscaleEnforcer).startPrometheusServer()
 
 import (
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 
@@ -42,14 +44,14 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 				Name: "autoscaling_plugin_extension_calls_total",
 				Help: "Number of calls to scheduler plugin extension points",
 			},
-			[]string{"method"},
+			[]string{"method", "ignored_namespace"},
 		)),
 		pluginCallFails: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "autoscaling_plugin_extension_call_fails_total",
 				Help: "Number of unsuccessful calls to scheduler plugin extension points",
 			},
-			[]string{"method", "status"},
+			[]string{"method", "ignored_namespace", "status"},
 		)),
 		resourceRequests: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -110,7 +112,11 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 	return reg
 }
 
-func (m *PromMetrics) IncFailIfNotSuccess(method string, status *framework.Status) {
+func (m *PromMetrics) IncMethodCall(method string, ignored bool) {
+	m.pluginCalls.WithLabelValues(method, strconv.FormatBool(ignored)).Inc()
+}
+
+func (m *PromMetrics) IncFailIfNotSuccess(method string, ignored bool, status *framework.Status) {
 	if !status.IsSuccess() {
 		return
 	}

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -121,5 +121,5 @@ func (m *PromMetrics) IncFailIfNotSuccess(method string, ignored bool, status *f
 		return
 	}
 
-	m.pluginCallFails.WithLabelValues(method, status.Code().String())
+	m.pluginCallFails.WithLabelValues(method, strconv.FormatBool(ignored), status.Code().String())
 }


### PR DESCRIPTION
Without this, our alerting could get messed up by the overprovisioning pods, which are expected to frequently fail certain methods, like Filter.