### PR TITLE
plugin: Fix buffer underflow, include Buffer in more logs

### DIFF
--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -1420,7 +1420,9 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context, logger *zap.Lo
 		oldNodeMemBuffer := ns.memSlots.Buffer
 
 		ns.vCPU.Reserved += ps.vCPU.Reserved
+		ns.vCPU.Buffer += ps.vCPU.Buffer
 		ns.memSlots.Reserved += ps.memSlots.Reserved
+		ns.memSlots.Buffer += ps.memSlots.Buffer
 
 		cpuVerdict := fmt.Sprintf(
 			"pod = %v/%v (node %v -> %v / %v, %v -> %v buffer)",

--- a/pkg/plugin/trans.go
+++ b/pkg/plugin/trans.go
@@ -184,15 +184,20 @@ func (r resourceTransition[T]) handleRequested(requested T, startingMigration bo
 	}
 
 	fmtString := "Register %d%s -> %d%s (pressure %d -> %d); " +
-		"node reserved %d -> %d (of %d), " +
+		"node reserved %d%s -> %d%s (of %d), " +
 		"node capacityPressure %d -> %d (%d -> %d spoken for)"
 
-	var buffer string
+	var podBuffer string
+	var oldNodeBuffer string
+	var newNodeBuffer string
 	if r.pod.Buffer != 0 {
-		buffer = fmt.Sprintf(" (buffer %d)", r.pod.Buffer)
+		podBuffer = fmt.Sprintf(" [buffer %d]", r.pod.Buffer)
+		oldNodeBuffer = fmt.Sprintf(" [buffer %d]", r.oldNode.buffer)
 
 		r.node.Buffer -= r.pod.Buffer
 		r.pod.Buffer = 0
+
+		newNodeBuffer = fmt.Sprintf(" [buffer %d]", r.node.Buffer)
 	}
 
 	var wanted string
@@ -203,9 +208,9 @@ func (r resourceTransition[T]) handleRequested(requested T, startingMigration bo
 	verdict = fmt.Sprintf(
 		fmtString,
 		// Register %d%s -> %d%s (pressure %d -> %d)
-		r.oldPod.reserved, buffer, r.pod.Reserved, wanted, r.oldPod.capacityPressure, r.pod.CapacityPressure,
-		// node reserved %d -> %d (of %d)
-		r.oldNode.reserved, r.node.Reserved, totalReservable,
+		r.oldPod.reserved, podBuffer, r.pod.Reserved, wanted, r.oldPod.capacityPressure, r.pod.CapacityPressure,
+		// node reserved %d%s -> %d%s (of %d)
+		r.oldNode.reserved, oldNodeBuffer, r.node.Reserved, newNodeBuffer, totalReservable,
 		// node capacityPressure %d -> %d (%d -> %d spoken for)
 		r.oldNode.capacityPressure, r.node.CapacityPressure, r.oldNode.pressureAccountedFor, r.node.PressureAccountedFor,
 	)
@@ -261,14 +266,19 @@ func (r resourceTransition[T]) handleAutoscalingDisabled() (verdict string) {
 	r.node.CapacityPressure -= r.pod.CapacityPressure
 	r.pod.CapacityPressure = 0
 
+	var nodeBufferChange string
+	if r.oldPod.buffer != 0 {
+		nodeBufferChange = fmt.Sprintf(" [buffer %d -> %d]", r.oldNode.buffer, r.node.Buffer)
+	}
+
 	fmtString := "pod had buffer %d, capacityPressure %d; " +
-		"node reserved %d -> %d, capacityPressure %d -> %d"
+		"node reserved %d -> %d%s, capacityPressure %d -> %d"
 	verdict = fmt.Sprintf(
 		fmtString,
 		// pod had buffer %d, capacityPressure %d;
 		r.oldPod.buffer, r.oldPod.capacityPressure,
-		// node reserved %d -> %d, capacityPressure %d -> %d
-		r.oldNode.reserved, r.node.Reserved, r.oldNode.capacityPressure, r.node.CapacityPressure,
+		// node reserved %d -> %d%s, capacityPressure %d -> %d
+		r.oldNode.reserved, r.node.Reserved, nodeBufferChange, r.oldNode.capacityPressure, r.node.CapacityPressure,
 	)
 	return verdict
 }


### PR DESCRIPTION
ref https://neondb.slack.com/archives/C03F5SM1N02/p1689711148704229

This PR should be merged via rebase _and_ backported onto v0.12.2, so that we can try it out in isolation from the changes by #423.