### PR TITLE
agent: Improve "billed stuck" metric

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -140,11 +140,12 @@ func (s *agentState) handleVMEventAdded(
 	runnerCtx, cancelRunnerContext := context.WithCancel(ctx)
 
 	status := &podStatus{
-		mu:                sync.Mutex{},
-		endState:          nil,
-		previousEndStates: nil,
-		vmInfo:            event.vmInfo,
-		endpointID:        event.endpointID,
+		mu:                 sync.Mutex{},
+		endState:           nil,
+		previousEndStates:  nil,
+		vmInfo:             event.vmInfo,
+		endpointID:         event.endpointID,
+		endpointAssignedAt: nil,
 
 		startTime:                   time.Now(),
 		lastSuccessfulInformantComm: nil,
@@ -404,6 +405,7 @@ type podStatus struct {
 	// endpointID, if non-empty, stores the ID of the endpoint associated with the VM
 	endpointID string
 
+	// NB: this value, once non-nil, is never changed.
 	endpointAssignedAt *time.Time
 }
 
@@ -488,9 +490,10 @@ func (s *podStatus) dump() podStatusDump {
 		PreviousEndStates: previousEndStates,
 
 		// FIXME: api.VmInfo contains a resource.Quantity - is that safe to copy by value?
-		VMInfo:     s.vmInfo,
-		EndpointID: s.endpointID,
-		StartTime:  s.startTime,
+		VMInfo:             s.vmInfo,
+		EndpointID:         s.endpointID,
+		EndpointAssignedAt: s.endpointAssignedAt, // ok to share the pointer, because it's not updated
+		StartTime:          s.startTime,
 
 		LastSuccessfulInformantComm: s.lastSuccessfulInformantComm,
 	}

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -293,7 +293,7 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 			count := 0
 
 			for _, p := range globalstate.pods {
-				if p.status.informantIsUnhealthy(globalstate.config) {
+				if p.status.informantIsUnhealthy(globalstate.config, unhealthyAny) {
 					count++
 				}
 			}
@@ -314,7 +314,7 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 			count := 0
 
 			for _, p := range globalstate.pods {
-				if p.status.endpointID != "" && p.status.informantIsUnhealthy(globalstate.config) {
+				if p.status.informantIsUnhealthy(globalstate.config, unhealthyEndpoint) {
 					count++
 				}
 			}


### PR DESCRIPTION
With the way that the informant currently works, all pooled VMs are marked as "autoscaling stuck". Because of that, there's the occasional VM that is detected as "autoscaling stuck" *after* it's assigned an endpoint, but before the agent has tried to reconnect to its informant.

If we track the "billed autoscaling stuck" metric with a grace period extending from the time at which the VM was assigned the endpoint, we should have enough wiggle room to make the metrics more consistent.