### PR TITLE
plugin: Fix scoring to use current resources

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -676,8 +676,8 @@ func (e *AutoscaleEnforcer) Score(
 		return score, nil
 	}
 
-	totalMilliCpu := int64(node.totalReservableCPU())
-	totalMem := int64(node.totalReservableMemSlots())
+	totalMilliCpu := int64(node.remainingReservableCPU())
+	totalMem := int64(node.remainingReservableMemSlots())
 	maxTotalMilliCpu := int64(e.state.maxTotalReservableCPU)
 	maxTotalMem := int64(e.state.maxTotalReservableMemSlots)
 


### PR DESCRIPTION
The new behavior is what was originally intended, and should fix an issue that we're observing in prod (currently it just scores based on *size*, not *available resources*, which is... bad).