### PR TITLE
plugin: Calculate "remaining reservable" resources via SaturatingSub

### DIFF
--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -384,13 +384,13 @@ func (s *nodeState) totalReservableMemSlots() uint16 {
 
 // remainingReservableCPU returns the remaining CPU that can be allocated to VM pods
 func (s *nodeState) remainingReservableCPU() vmapi.MilliCPU {
-	return s.totalReservableCPU() - s.vCPU.Reserved
+	return util.SaturatingSub(s.totalReservableCPU(), s.vCPU.Reserved)
 }
 
 // remainingReservableMemSlots returns the remaining number of memory slots that can be allocated to
 // VM pods
 func (s *nodeState) remainingReservableMemSlots() uint16 {
-	return s.totalReservableMemSlots() - s.memSlots.Reserved
+	return util.SaturatingSub(s.totalReservableMemSlots(), s.memSlots.Reserved)
 }
 
 // tooMuchPressure is used to signal whether the node should start migrating pods out in order to


### PR DESCRIPTION
Earlier in its life, the plugin used to assume that `Reserved` was always less than or equal to the `Total` resources; this is... no longer true, and hasn't been for a while - although I suspect it hasn't impacted things very much.