### PR TITLE
plugin: Standardize+improve plugin method logging

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -869,11 +869,11 @@ func (e *AutoscaleEnforcer) Reserve(
 			}
 
 			cpuVerdict := fmt.Sprintf(
-				"need %v CPU (%v -> %v raw), %v of %v used, so %v available (%s)",
+				"need %v (%v -> %v raw), %v of %v used, so %v available (%s)",
 				addCpu, &oldNodeRes.RawCPU, &newNodeRes.RawCPU, node.vCPU.Reserved, node.totalReservableCPU(), node.remainingReservableCPU(), cpuShortVerdict,
 			)
 			memVerdict := fmt.Sprintf(
-				"need %v CPU (%v -> %v raw), %v of %v used, so %v available (%s)",
+				"need %v (%v -> %v raw), %v of %v used, so %v available (%s)",
 				addMem, &oldNodeRes.RawMemory, &newNodeRes.RawMemory, node.memSlots.Reserved, node.totalReservableMemSlots(), node.remainingReservableMemSlots(), memShortVerdict,
 			)
 
@@ -951,8 +951,14 @@ func (e *AutoscaleEnforcer) Reserve(
 			memShortVerdict = "OK"
 		}
 
-		cpuVerdict := fmt.Sprintf("need %v vCPU, have %v available (%s)", vmInfo.Cpu.Use, node.remainingReservableCPU(), cpuShortVerdict)
-		memVerdict := fmt.Sprintf("need %v mem slots, have %v available (%s)", vmInfo.Mem.Use, node.remainingReservableMemSlots(), memShortVerdict)
+		cpuVerdict := fmt.Sprintf(
+			"need %v, %v of %v used, so %v available (%s)",
+			vmInfo.Cpu.Use, node.vCPU.Reserved, node.totalReservableCPU(), node.remainingReservableCPU(), cpuShortVerdict,
+		)
+		memVerdict := fmt.Sprintf(
+			"need %v, %v of %v used, so %v available (%s)",
+			vmInfo.Mem.Use, node.memSlots.Reserved, node.totalReservableMemSlots(), node.remainingReservableMemSlots(), memShortVerdict,
+		)
 
 		logger.Error(
 			"Can't reserve VM pod (not enough resources)",

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -473,7 +473,10 @@ func (e *AutoscaleEnforcer) Filter(
 	otherResources.MarginCPU = node.otherResources.MarginCPU
 	otherResources.MarginMemory = node.otherResources.MarginMemory
 
-	// As we process all pods, we should record all the pods that either aren't
+	// As we process all pods, we should record all the pods that aren't present in both nodeInfo
+	// and e.state's maps, so that we can log any inconsistencies instead of silently using
+	// *potentially* bad data. Some differences are expected, but on the whole this extra
+	// information should be helpful.
 	missedPods := make(map[util.NamespacedName]struct{})
 	for name := range node.pods {
 		missedPods[name] = struct{}{}


### PR DESCRIPTION
Some ongoing issues on staging due to inconsistencies between the Filter and Reserve steps are proving hard to debug because there's just a bit too little information available. For example, the Filter step shows the node totals, whereas a failed Reserve step shows the incremental change.