### PR TITLE
plugin: Fix queue event skips

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -211,14 +211,13 @@ func makeAutoscaleEnforcerPlugin(
 
 	go func() {
 		for {
-			callback, err := queue.Wait(ctx)
+			callback, err := queue.Wait(ctx) // NB: Wait pulls from the front of the queue
 			if err != nil {
 				logger.Info("Stopped waiting on pod/VM queue", zap.Error(err))
 				break
 			}
 
 			callback()
-			queue.Remove()
 		}
 	}()
 


### PR DESCRIPTION
Noticed because of state inconsistencies in prod; `Wait()` also pulls from the queue.

**NB: This should be backported / hotfixed onto v0.13.5.**