### PR TITLE
plugin: Handle bypassed Reserve due to k8s bug

### DIFF
--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -732,11 +732,6 @@ func (e *AutoscaleEnforcer) handlePodStarted(logger *zap.Logger, pod *corev1.Pod
 		zap.String("node", nodeName),
 	)
 
-	if pod.Spec.SchedulerName == e.state.conf.SchedulerName {
-		logger.Info("Got non-VM pod start event for pod assigned to this scheduler; nothing to do")
-		return
-	}
-
 	logger.Info("Handling non-VM pod start event")
 
 	podResources, err := extractPodOtherPodResourceState(pod)
@@ -751,6 +746,8 @@ func (e *AutoscaleEnforcer) handlePodStarted(logger *zap.Logger, pod *corev1.Pod
 	if _, ok := e.state.otherPods[podName]; ok {
 		logger.Info("Pod is already known") // will happen during startup
 		return
+	} else if pod.Spec.SchedulerName == e.state.conf.SchedulerName {
+		logger.Error("Got non-VM pod start event for unknown pod assigned to this scheduler")
 	}
 
 	// Pod is not known - let's get information about the node!


### PR DESCRIPTION
ref https://neondb.slack.com/archives/C03F5SM1N02/p1690131944251759?thread_ts=1690130256.724109&cid=C03F5SM1N02

Basically, we noticed a bug(?) in the core k8s scheduler where a pod went through Reserve, Bind failed, got Unreserve'd, and then re-bound to the node without consulting Reserve again. While the core scheduler shouldn't do that to the plugin, fixing that is a lot more effort than just gracefully handling it ourselves.

**Tasks**

- [x] Handle for non-VM pods
- [ ] Handle for VM pods