### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-template.md
@@ -1,0 +1,46 @@
+---
+name: Bug template
+about: Template that will help you to submit a visible and actionable bug report.
+title: 'Bug: '
+labels: t/bug
+assignees: ''
+
+---
+
+## Environment
+
+<!--
+e.g. local development, staging, production
+-->
+
+## Steps to reproduce
+
+<!--
+If you can, try to reproduce the bug. If e.g. this occurred in production under
+rare circumstances, indicate as such. Any related events can be included in the
+later "Actual result" section.
+
+If this occurred while you were testing, but you don't have logs for it, say
+what kind of testing you were doing! Provide any scripts / commands that were
+relevant.
+-->
+
+## Expected result
+
+<!--
+What did you expect to happen?
+
+Try to avoid vague statements like "operation should succeed". Instead, say more
+specifically what the success should look like (e.g. "VM should scale up").
+-->
+
+## Actual result
+
+<!--
+Remember to include logs, graphs, and other supporting information to show
+how/why things did not function as expected.
+-->
+
+## Other logs, links
+
+- ...

--- a/.github/ISSUE_TEMPLATE/epic-template.md
+++ b/.github/ISSUE_TEMPLATE/epic-template.md
@@ -1,0 +1,51 @@
+---
+name: Epic Template
+about: A set of related tasks contributing towards specific outcome, comprising of
+  more than 1 week of work.
+title: 'Epic: '
+labels: t/Epic
+assignees: ''
+
+---
+
+## Motivation
+
+<!--
+Why is this worthwhile?
+
+Provide any relevant context, either written here or with links to slack, other issues, etc.
+-->
+
+## DoD
+
+<!--
+DoD = "definition of done".
+
+Put any ideas you have for how the changes should look *externally* - i.e. to a
+user of the system or component that needs changing. For each idea, give the
+DoD: "what external changes need to be made for the feature to be complete?"
+-->
+
+
+## Implementation ideas
+
+<!--
+If you have ideas about how the feature could be implemented, please share!
+
+If not, leave this section here so that it can be filled in by others.
+-->
+
+TODO
+
+
+## Tasks
+
+```[tasklist]
+- [ ] ...
+- [ ] List tasks as they're created for this Epic
+```
+
+
+## Other related tasks, Epics, and links
+
+-

--- a/.github/ISSUE_TEMPLATE/feature-request-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-template.md
@@ -1,0 +1,37 @@
+---
+name: Feature request template
+about: Template that will help you to submit a visible and actionable feature request.
+title: 'Feature: '
+labels: t/feature
+assignees: ''
+
+---
+
+## Problem description / Motivation
+
+<!--
+Feature requests are for when something isn't a bug (because there's nothing
+*unexpected* per se), but there's still room for improvement.
+
+This area is the most important part! Sometimes we think one solution is best,
+but gradually realize that another is simpler. This is only possible if the
+problem description is clear about what is *actually* required.
+-->
+
+## Feature idea(s) / DoD
+
+<!--
+DoD = "definition of done".
+
+Put any ideas you have for how the changes should look *externally* - i.e. to a
+user of the system or component that needs changing. For each idea, give the
+DoD: "what external changes need to be made for the feature to be complete?"
+-->
+
+## Implementation ideas
+
+<!--
+If you have ideas about how the feature could be implemented, please share!
+
+If not, feel free to remove this section.
+-->


### PR DESCRIPTION
Noticed we didn't have any, figured we should.

~~Not quite done yet:~~

- [x] Bug template
- [x] Feature template
- [x] Epic template

Requested review from anyone I thought might care about these. Feel free to comment as much or as little as you'd like.

Broadly the templates are adapted from the cloud repo, with some minor rearrangements to structure.