### PR TITLE
plugin: Handle VM 'Buffer' on delete

### DIFF
--- a/pkg/plugin/trans.go
+++ b/pkg/plugin/trans.go
@@ -228,12 +228,23 @@ func (r resourceTransition[T]) handleDeleted(currentlyMigrating bool) (verdict s
 		r.node.PressureAccountedFor -= r.pod.Reserved + r.pod.CapacityPressure
 	}
 
-	fmtString := "pod had %d; node reserved %d -> %d, " +
+	var podBuffer string
+	var oldNodeBuffer string
+	var newNodeBuffer string
+	if r.pod.Buffer != 0 {
+		r.node.Buffer -= r.pod.Buffer
+
+		podBuffer = fmt.Sprintf(" [buffer %d]", r.pod.Buffer)
+		oldNodeBuffer = fmt.Sprintf(" [buffer %d]", r.oldNode.buffer)
+		newNodeBuffer = fmt.Sprintf(" [buffer %d]", r.node.Buffer)
+	}
+
+	fmtString := "pod had %d%s; node reserved %d%s -> %d%s, " +
 		"node capacityPressure %d -> %d (%d -> %d spoken for)"
 	verdict = fmt.Sprintf(
 		fmtString,
-		// pod had %d; node reserved %d -> %d
-		r.pod.Reserved, r.oldNode.reserved, r.node.Reserved,
+		// pod had %d%s; node reserved %d%s -> %d%s
+		r.pod.Reserved, podBuffer, r.oldNode.reserved, oldNodeBuffer, r.node.Reserved, newNodeBuffer,
 		// node capacityPressure %d -> %d (%d -> %d spoken for)
 		r.oldNode.capacityPressure, r.node.CapacityPressure, r.oldNode.pressureAccountedFor, r.node.PressureAccountedFor,
 	)


### PR DESCRIPTION
Noticed this because 'Buffer' was high in prod-eu-central-1-gamma after the scheduler restarted, realized it was because a VM was deleted before the autoscaler-agent checked in about it, and the VM's Buffer wasn't appropriately removed from the Node's total.

AFAICT this wasn't actually affecting any scheduling decisions (because Buffer is included in Reserved, and Reserved *is* appropriately unset when a VM is deleted), but it's worth fixing anyways so that our monitoring is cleaner.