### PR TITLE
util/watch, agent/billing: Don't record events if VM watch is failing

### DIFF
--- a/pkg/util/watch/watch.go
+++ b/pkg/util/watch/watch.go
@@ -354,6 +354,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 					retryAfter := config.RetryRelistAfter.Random()
 					logger.Info("Retrying relist after delay", zap.Duration("delay", retryAfter))
 
+					store.failing.Store(true)
 					config.Metrics.failing()
 
 					select {
@@ -369,6 +370,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 					}
 				}
 
+				store.failing.Store(false)
 				config.Metrics.unfailing()
 
 				// err == nil, process relistList
@@ -450,6 +452,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 					retryAfter := config.RetryWatchAfter.Random()
 					logger.Info("Retrying re-watch after delay", zap.Duration("delay", retryAfter))
 
+					store.failing.Store(true)
 					config.Metrics.failing()
 
 					select {
@@ -466,6 +469,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 				}
 
 				// err == nil
+				store.failing.Store(false)
 				config.Metrics.unfailing()
 				break newWatcher
 			}
@@ -554,6 +558,7 @@ type Store[T any] struct {
 
 	stopSignal util.SignalSender[struct{}]
 	stopped    atomic.Bool
+	failing    atomic.Bool
 }
 
 // Relist triggers re-listing the WatchStore, returning a channel that will be closed once the
@@ -573,6 +578,10 @@ func (w *Store[T]) Relist() <-chan struct{} {
 func (w *Store[T]) Stop() {
 	w.stopSignal.Send(struct{}{})
 	w.stopped.Store(true)
+}
+
+func (w *Store[T]) Failing() bool {
+	return w.failing.Load()
 }
 
 func (w *Store[T]) Stopped() bool {


### PR DESCRIPTION
On the `util/watch` side: This adds a new Failing() method that complements the existing Stopped() method, similarly matching the metrics we expose.

On the `agent/billing` side: If the watch is failing, we just pretend that there's no VMs, and log a suitable error.

Realized this needed to be implemented because today we had a [k8s API server switchover](https://neondb.slack.com/archives/C039YKBRZB4/p1690313460648149) in prod-us-west-2-eta, and all the Watch instances separately failed for 1s at different times. If it had been longer (or if relisting took a long time), and we had VMs there, we would have used stale data for our billing events.