### PR TITLE
add panic=-1 to kernel command line

### DIFF
--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -46,7 +46,7 @@ const (
 	QEMU_BIN      = "qemu-system-x86_64"
 	QEMU_IMG_BIN  = "qemu-img"
 	kernelPath    = "/vm/kernel/vmlinuz"
-	kernelCmdline = "init=/neonvm/bin/init memhp_default_state=online_movable console=ttyS1 loglevel=7 root=/dev/vda rw"
+	kernelCmdline = "panic=-1 init=/neonvm/bin/init memhp_default_state=online_movable console=ttyS1 loglevel=7 root=/dev/vda rw"
 
 	rootDiskPath    = "/vm/images/rootdisk.qcow2"
 	runtimeDiskPath = "/vm/images/runtime.iso"


### PR DESCRIPTION
From linux kernel docs:

```
        panic=          [KNL] Kernel behaviour on panic: delay <timeout>
                        timeout > 0: seconds before rebooting
                        timeout = 0: wait forever
                        timeout < 0: reboot immediately
                        Format: <timeout>
```

adding `panic=-1` to kernel command line should prevent  VM from freezing when the kernel receives a panic event.

resolve #446 
