### PR TITLE
Add timeouts on a few CI workflow steps.

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -65,8 +65,11 @@ jobs:
       - run: make ${{ matrix.cluster }}-setup
 
       - run: make deploy
+        timeout-minutes: 10
       - run: make example-vms
+        timeout-minutes: 10
       - run: make e2e
+        timeout-minutes: 15
 
       - name: Get k8s logs and events
         if: always()


### PR DESCRIPTION
My PR got stuck on the "make deploy" step, and kept running for hours until it was cancelled. That was surely a bug in my PR, but if such bugs happen, there's no need to wait for so long. All these steps finish in < 5 minutes on the CI currently, so these timeouts are quite conservative.