### PR TITLE
downgrade k8s.io/apiextensions-apiserver to match others

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -182,7 +182,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.26.1 // indirect
+	k8s.io/apiextensions-apiserver v0.25.11 // indirect
 	k8s.io/cloud-provider v0.0.0 // indirect
 	k8s.io/component-base v0.25.11 // indirect
 	k8s.io/component-helpers v0.25.11 // indirect


### PR DESCRIPTION
I'm not sure why making manual changes to "// indirect" dependencies wouldn't be erased by `go mod tidy`, but I guess this works? It's... a little weird TBH, maybe something to do with the replace directives?

cc @bayandin / @tychoish if you have ideas