### PR TITLE
agent: Track runner state metrics as it goes

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -486,12 +486,12 @@ func (s *lockedPodStatus) update(global *agentState, with func(podStatus) podSta
 	// Update the metrics:
 	if s.state != "" {
 		oldIsEndpoint := strconv.FormatBool(s.endpointID != "")
-		global.metrics.runnersCount.WithLabelValues(oldIsEndpoint, string(s.state)).Add(-1)
+		global.metrics.runnersCount.WithLabelValues(oldIsEndpoint, string(s.state)).Dec()
 	}
 
 	if newStatus.state != "" {
 		newIsEndpoint := strconv.FormatBool(newStatus.endpointID != "")
-		global.metrics.runnersCount.WithLabelValues(newIsEndpoint, string(newStatus.state)).Add(1)
+		global.metrics.runnersCount.WithLabelValues(newIsEndpoint, string(newStatus.state)).Inc()
 	}
 
 	s.podStatus = newStatus

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -695,9 +695,10 @@ func (s *InformantServer) handleID(ctx context.Context, _ *zap.Logger, body *str
 	// currently enabled. This allows us to detect cases where the informant is not currently
 	// communicating back to the agent - OR when the informant never /resume'd the agent.
 	if s.mode == InformantServerRunning {
-		s.runner.setStatus(func(s *podStatus) {
+		s.runner.status.update(s.runner.global, func(s podStatus) podStatus {
 			now := time.Now()
 			s.lastSuccessfulInformantComm = &now
+			return s
 		})
 	}
 

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -20,6 +20,7 @@ type PromMetrics struct {
 	neonvmRequestsOutbound *prometheus.CounterVec
 	neonvmRequestedChange  resourceChangePair
 
+	runnersCount       *prometheus.CounterVec
 	runnerFatalErrors  prometheus.Counter
 	runnerThreadPanics prometheus.Counter
 	runnerStarts       prometheus.Counter
@@ -35,6 +36,15 @@ const (
 	directionLabel    = "direction"
 	directionValueInc = "inc"
 	directionValueDec = "dec"
+)
+
+type runnerMetricState string
+
+const (
+	runnerMetricStateOk       runnerMetricState = "ok"
+	runnerMetricStateStuck    runnerMetricState = "stuck"
+	runnerMetricStateErrored  runnerMetricState = "errored"
+	runnerMetricStatePanicked runnerMetricState = "panicked"
 )
 
 func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Registry) {
@@ -168,6 +178,14 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 		},
 
 		// ---- RUNNER LIFECYCLE ----
+		runnersCount: util.RegisterMetric(reg, prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "autoscaling_agent_runners_current",
+				Help: "Number of per-VM runners, with associated metadata",
+			},
+			// NB: is_endpoint ∈ ("true", "false"), state ∈ runnerMetricState = ("ok", "stuck", "errored", "panicked")
+			[]string{"is_endpoint", "state"},
+		)),
 		runnerFatalErrors: util.RegisterMetric(reg, prometheus.NewCounter(
 			prometheus.CounterOpts{
 				Name: "autoscaling_agent_runner_fatal_errors_total",
@@ -213,115 +231,6 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 			m.WithLabelValues(directionValueDec).Add(0.0)
 		}
 	}
-
-	// the remaining metrics are computed at scrape time by prom:
-	// register them directly.
-	reg.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Name: "autoscaling_errored_vm_runners_current",
-			Help: "Number of VMs whose per-VM runner has panicked (and not restarted)",
-		},
-		func() float64 {
-			globalstate.lock.Lock()
-			defer globalstate.lock.Unlock()
-
-			count := 0
-
-			for _, p := range globalstate.pods {
-				func() {
-					p.status.mu.Lock()
-					defer p.status.mu.Unlock()
-
-					if p.status.endState != nil && p.status.endState.ExitKind == podStatusExitErrored {
-						count += 1
-					}
-				}()
-			}
-
-			return float64(count)
-		},
-	))
-
-	reg.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Name: "autoscaling_panicked_vm_runners_current",
-			Help: "Number of VMs whose per-VM runner has panicked (and not restarted)",
-		},
-		func() float64 {
-			globalstate.lock.Lock()
-			defer globalstate.lock.Unlock()
-
-			count := 0
-
-			for _, p := range globalstate.pods {
-				func() {
-					p.status.mu.Lock()
-					defer p.status.mu.Unlock()
-
-					if p.status.endState != nil && p.status.endState.ExitKind == podStatusExitPanicked {
-						count += 1
-					}
-				}()
-			}
-
-			return float64(count)
-		},
-	))
-
-	reg.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Name: "autoscaling_agent_tracked_vms_current",
-			Help: "Number of autoscaling-enabled non-migrating VMs on the autoscaler-agent's node",
-		},
-		func() float64 {
-			globalstate.lock.Lock()
-			defer globalstate.lock.Unlock()
-
-			return float64(len(globalstate.pods))
-		},
-	))
-
-	reg.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Name: "autoscaling_vms_unsuccessful_communication_with_informant_current",
-			Help: "Number of VMs whose vm-informants aren't successfully communicating with the autoscaler-agent",
-		},
-		func() float64 {
-			globalstate.lock.Lock()
-			defer globalstate.lock.Unlock()
-
-			count := 0
-
-			for _, p := range globalstate.pods {
-				if p.status.informantIsUnhealthy(globalstate.config, unhealthyAny) {
-					count++
-				}
-			}
-
-			return float64(count)
-		},
-	))
-
-	reg.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{
-			Name: "autoscaling_billed_vms_unsuccessful_communication_with_informant_current",
-			Help: "Number of VMs *getting billed* whose vm-informants aren't successfully communicating with the autoscaler-agent",
-		},
-		func() float64 {
-			globalstate.lock.Lock()
-			defer globalstate.lock.Unlock()
-
-			count := 0
-
-			for _, p := range globalstate.pods {
-				if p.status.informantIsUnhealthy(globalstate.config, unhealthyEndpoint) {
-					count++
-				}
-			}
-
-			return float64(count)
-		},
-	))
 
 	return metrics, reg
 }

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -20,7 +20,7 @@ type PromMetrics struct {
 	neonvmRequestsOutbound *prometheus.CounterVec
 	neonvmRequestedChange  resourceChangePair
 
-	runnersCount       *prometheus.CounterVec
+	runnersCount       *prometheus.GaugeVec
 	runnerFatalErrors  prometheus.Counter
 	runnerThreadPanics prometheus.Counter
 	runnerStarts       prometheus.Counter
@@ -178,8 +178,8 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 		},
 
 		// ---- RUNNER LIFECYCLE ----
-		runnersCount: util.RegisterMetric(reg, prometheus.NewCounterVec(
-			prometheus.CounterOpts{
+		runnersCount: util.RegisterMetric(reg, prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
 				Name: "autoscaling_agent_runners_current",
 				Help: "Number of per-VM runners, with associated metadata",
 			},


### PR DESCRIPTION
... instead of the previous method of calculating them as needed at scrape time.

There's some ongoing issues with metrics collection on staging, maybe this will help with it.

Resolves #198.

~~Haven't tested it or anything, still need to self-review.~~

## This PR makes breaking changes to metrics

All the following metrics are removed:

- `autoscaling_errored_vm_runners_current`
- `autoscaling_panicked_vm_runners_current`
- `autoscaling_agent_tracked_vms_current`
- `autoscaling_vms_unsuccessful_communication_with_informant_current`
- `autoscaling_billed_vms_unsuccessful_communication_with_informant_current`

... replaced by:

- `autoscaling_agent_runners_current`

with the previous metrics replaced with combinations of labels on the new one.