### PR TITLE
neonvm/controller: Deduplicate QMP query logic

### DIFF
--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -409,7 +409,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 			virtualmachine.Status.Node = vmRunner.Spec.NodeName
 
 			// get CPU details from QEMU and update status
-			cpuSlotsPlugged, _, err := QmpGetCpus(virtualmachine)
+			cpuSlotsPlugged, _, err := QmpGetCpus(QmpAddr(virtualmachine))
 			if err != nil {
 				log.Error(err, "Failed to get CPU details from VirtualMachine", "VirtualMachine", virtualmachine.Name)
 				return err
@@ -452,7 +452,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 			}
 
 			// get Memory details from hypervisor and update VM status
-			memorySize, err := QmpGetMemorySize(virtualmachine)
+			memorySize, err := QmpGetMemorySize(QmpAddr(virtualmachine))
 			if err != nil {
 				log.Error(err, "Failed to get Memory details from VirtualMachine", "VirtualMachine", virtualmachine.Name)
 				return err
@@ -513,7 +513,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 
 		// do hotplug/unplug CPU
 		// firstly get current state from QEMU
-		cpuSlotsPlugged, _, err := QmpGetCpus(virtualmachine)
+		cpuSlotsPlugged, _, err := QmpGetCpus(QmpAddr(virtualmachine))
 		if err != nil {
 			log.Error(err, "Failed to get CPU details from VirtualMachine", "VirtualMachine", virtualmachine.Name)
 			return err
@@ -524,7 +524,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		if specCPU > pluggedCPU {
 			// going to plug one CPU
 			log.Info("Plug one more CPU into VM")
-			if err := QmpPlugCpu(virtualmachine); err != nil {
+			if err := QmpPlugCpu(QmpAddr(virtualmachine)); err != nil {
 				return err
 			}
 			r.Recorder.Event(virtualmachine, "Normal", "ScaleUp",
@@ -533,7 +533,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		} else if specCPU < pluggedCPU {
 			// going to unplug one CPU
 			log.Info("Unplug one CPU from VM")
-			if err := QmpUnplugCpu(virtualmachine); err != nil {
+			if err := QmpUnplugCpu(QmpAddr(virtualmachine)); err != nil {
 				return err
 			}
 			r.Recorder.Event(virtualmachine, "Normal", "ScaleDown",
@@ -546,7 +546,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 
 		// do hotplug/unplug Memory
 		// firstly get current state from QEMU
-		memoryDevices, err := QmpQueryMemoryDevices(virtualmachine)
+		memoryDevices, err := QmpQueryMemoryDevices(QmpAddr(virtualmachine))
 		memoryPluggedSlots := *virtualmachine.Spec.Guest.MemorySlots.Min + int32(len(memoryDevices))
 		if err != nil {
 			log.Error(err, "Failed to get Memory details from VirtualMachine", "VirtualMachine", virtualmachine.Name)
@@ -565,7 +565,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		} else if *virtualmachine.Spec.Guest.MemorySlots.Use < memoryPluggedSlots {
 			// going to unplug one Memory Slot
 			log.Info("Unplug one Memory module from VM")
-			if err := QmpUnplugMemory(virtualmachine); err != nil {
+			if err := QmpUnplugMemory(QmpAddr(virtualmachine)); err != nil {
 				// special case !
 				// error means VM hadn't memory devices available for unplug
 				// need set .memorySlots.Use back to real value

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -371,7 +371,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 		}
 
 		// retrieve migration statistics
-		migrationInfo, err := QmpGetMigrationInfo(vm)
+		migrationInfo, err := QmpGetMigrationInfo(QmpAddr(vm))
 		if err != nil {
 			log.Error(err, "Failed to get migration info")
 			return ctrl.Result{}, err
@@ -475,7 +475,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 		// seems migration still going on, just update status with migration progress once per second
 		time.Sleep(time.Second)
 		// re-retrieve migration statistics
-		migrationInfo, err = QmpGetMigrationInfo(vm)
+		migrationInfo, err = QmpGetMigrationInfo(QmpAddr(vm))
 		if err != nil {
 			log.Error(err, "Failed to re-get migration info")
 			return ctrl.Result{}, err
@@ -576,7 +576,7 @@ func (r *VirtualMachineMigrationReconciler) doFinalizerOperationsForVirtualMachi
 
 		// try to cancel migration
 		log.Info("Canceling migration")
-		if err := QmpCancelMigration(vm); err != nil {
+		if err := QmpCancelMigration(QmpAddr(vm)); err != nil {
 			// inform about error but not return error to avoid stuckness in reconciliation cycle
 			log.Error(err, "Migration canceling failed")
 		}


### PR DESCRIPTION
The general idea here is to make all of the functions take only the information they need - so if they only need the address to connect to, don't give them the whole VirtualMachine object. This allows us to remove some functions that had duplicated logic depending on whether there was a VM as input or the IP + port.

To compensate and provide *some* remaining ease of use, there's a new QmpAddr function that gets the address of a VM's QMP listener. Because of how go handles returning multiple values (and passing that along into another function), we can just directly call functions with the output of QmpAddr, like:

```go
QmpQueryMemoryDevices(QmpAddr(vm))
```

even though QmpAddr returns (string, int32) as the (IP, port) combo.