### PR TITLE
agent: Fix endpointAssignedAt for VMs added with endpoint

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -154,7 +154,7 @@ func (s *agentState) handleVMEventAdded(
 			previousEndStates:  nil,
 			vmInfo:             event.vmInfo,
 			endpointID:         event.endpointID,
-			endpointAssignedAt: nil,
+			endpointAssignedAt: &now,
 			state:              "", // Explicitly set state to empty so that the initial state update does no decrement
 			stateUpdatedAt:     now,
 


### PR DESCRIPTION
For some reason, had this in my shell history from 2023-07-26 but nowhere to be found in any local branches. Oof.

This, in combination with some new usage from #459 was causing crash-looping on staging.