### PR TITLE
agent/metrics: Initialize runnersCount label pairings to 0

### DIFF
--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -232,5 +232,16 @@ func makePrometheusParts(globalstate *agentState) (PromMetrics, *prometheus.Regi
 		}
 	}
 
+	runnerStates := []runnerMetricState{
+		runnerMetricStateOk,
+		runnerMetricStateStuck,
+		runnerMetricStateErrored,
+		runnerMetricStatePanicked,
+	}
+	for _, s := range runnerStates {
+		metrics.runnersCount.WithLabelValues("true", string(s)).Set(0.0)
+		metrics.runnersCount.WithLabelValues("false", string(s)).Set(0.0)
+	}
+
 	return metrics, reg
 }


### PR DESCRIPTION
For some of these (e.g. "errored" or "panicked" states), we're not expecting to have many of them, so it's better to explicitly have zero, rather than "no data".