### PR TITLE
vm-builder: add additional fields to vm-monitor conn str

### DIFF
--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -248,7 +248,7 @@ fi
 ::respawn:/neonvm/bin/acpid -f -c /neonvm/acpi
 ::respawn:/neonvm/bin/vector -c /neonvm/config/vector.yaml --config-dir /etc/vector
 ::respawn:/neonvm/bin/vmstart
-::respawn:su -p vm-informant -c 'RUST_LOG=info /usr/local/bin/vm-monitor --cgroup=neon-postgres{{if .FileCache}} --pgconnstr="dbname=postgres user=cloud_admin sslmode=disable"{{end}}'
+::respawn:su -p vm-informant -c 'RUST_LOG=info /usr/local/bin/vm-monitor --cgroup=neon-postgres{{if .FileCache}} --pgconnstr="host=localhost port=5432 dbname=postgres user=cloud_admin sslmode=disable"{{end}}'
 ::respawn:su -p vm-informant -c '/usr/local/bin/vm-informant'
 ::respawn:su -p nobody -c '/usr/local/bin/pgbouncer /etc/pgbouncer.ini'
 ::respawn:su -p nobody -c 'DATA_SOURCE_NAME="user=cloud_admin sslmode=disable dbname=postgres" /bin/postgres_exporter --auto-discover-databases --exclude-databases=template0,template1'


### PR DESCRIPTION
The informant did not need these fields because they were assumed by default by the pq go sql driver.

https://neondb.slack.com/archives/C03TN5G758R/p1691694313375769