### PR TITLE
agent/metrics: Fix runner state metrics deletion handling

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -506,12 +506,14 @@ func (s *lockedPodStatus) update(global *agentState, with func(podStatus) podSta
 	}
 
 	// Update the metrics:
-	if !s.deleted {
+	// Note: s.state is initialized to the empty string to signify that it's not yet represented in
+	// the metrics.
+	if !s.deleted && s.state != "" {
 		oldIsEndpoint := strconv.FormatBool(s.endpointID != "")
 		global.metrics.runnersCount.WithLabelValues(oldIsEndpoint, string(s.state)).Dec()
 	}
 
-	if !newStatus.deleted {
+	if !newStatus.deleted && newStatus.state != "" {
 		newIsEndpoint := strconv.FormatBool(newStatus.endpointID != "")
 		global.metrics.runnersCount.WithLabelValues(newIsEndpoint, string(newStatus.state)).Inc()
 	}

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -120,7 +120,12 @@ func (s *agentState) handleEvent(ctx context.Context, logger *zap.Logger, event 
 	switch event.kind {
 	case vmEventDeleted:
 		state.stop()
-		delete(s.pods, podName)
+		// mark the status as deleted, so that it gets removed from metrics.
+		state.status.update(s, func(stat podStatus) podStatus {
+			stat.deleted = true
+			delete(s.pods, podName) // Do the removal while synchronized, because we can :)
+			return stat
+		})
 	case vmEventUpdated:
 		state.status.update(s, func(stat podStatus) podStatus {
 			now := time.Now()
@@ -150,6 +155,7 @@ func (s *agentState) handleVMEventAdded(
 	status := &lockedPodStatus{
 		mu: sync.Mutex{},
 		podStatus: podStatus{
+			deleted:            false,
 			endState:           nil,
 			previousEndStates:  nil,
 			vmInfo:             event.vmInfo,
@@ -409,6 +415,9 @@ type lockedPodStatus struct {
 type podStatus struct {
 	startTime time.Time
 
+	// if true, the corresponding podState is no longer included in the global pod map
+	deleted bool
+
 	// if non-nil, the runner is finished
 	endState          *podStatusEndState
 	previousEndStates []podStatusEndState
@@ -473,10 +482,13 @@ func (s *lockedPodStatus) update(global *agentState, with func(podStatus) podSta
 
 	// Calculate the new state:
 	var newState runnerMetricState
-	if s.endState != nil {
+	if s.deleted {
+		// If deleted, don't change anything.
+	} else if s.endState != nil {
 		switch s.endState.ExitKind {
 		case podStatusExitCanceled:
-			newState = runnerMetricState("") // signal for later that we should remove the value.
+			// If canceled, don't change the state.
+			newState = s.state
 		case podStatusExitErrored:
 			newState = runnerMetricStateErrored
 		case podStatusExitPanicked:
@@ -488,16 +500,18 @@ func (s *lockedPodStatus) update(global *agentState, with func(podStatus) podSta
 		newState = runnerMetricStateOk
 	}
 
-	newStatus.state = newState
-	newStatus.stateUpdatedAt = now
+	if !newStatus.deleted {
+		newStatus.state = newState
+		newStatus.stateUpdatedAt = now
+	}
 
 	// Update the metrics:
-	if s.state != "" {
+	if !s.deleted {
 		oldIsEndpoint := strconv.FormatBool(s.endpointID != "")
 		global.metrics.runnersCount.WithLabelValues(oldIsEndpoint, string(s.state)).Dec()
 	}
 
-	if newStatus.state != "" {
+	if !newStatus.deleted {
 		newIsEndpoint := strconv.FormatBool(newStatus.endpointID != "")
 		global.metrics.runnersCount.WithLabelValues(newIsEndpoint, string(newStatus.state)).Inc()
 	}


### PR DESCRIPTION
Honestly not sure whether this will fix #470, but hopefully it should.

At the very least, without this PR, we'd definitely have incorrect behavior if a Runner ended with fatal error / panic, but was deleted before restarting. Beyond that, I don't know.