### PR TITLE
plugin: Penalize underfull nodes during Score

### DIFF
--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -27,8 +27,8 @@ data:
     {
       "memBlockSize": "1Gi",
       "nodeDefaults": {
-        "cpu": { "watermark": 0.7 },
-        "memory": { "watermark": 0.7 },
+        "cpu": { "watermark": 0.9 },
+        "memory": { "watermark": 0.9 },
         "computeUnit": { "vCPUs": 0.25, "mem": 1 }
       },
       "nodeOverrides": [],

--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -29,7 +29,10 @@ data:
       "nodeDefaults": {
         "cpu": { "watermark": 0.9 },
         "memory": { "watermark": 0.9 },
-        "computeUnit": { "vCPUs": 0.25, "mem": 1 }
+        "computeUnit": { "vCPUs": 0.25, "mem": 1 },
+        "minUsageScore": 0.5,
+        "maxUsageScore": 0,
+        "scoreMidpoint": 0.8
       },
       "nodeOverrides": [],
       "schedulerName": "autoscale-scheduler",

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -99,10 +99,10 @@ type nodeConfig struct {
 	//
 	// This corresponds to y₁ in the desmos link above.
 	MaxUsageScore float64 `json:"maxUsageScore"`
-	// ScorePeak gives the fraction at which the "midpoint" should be -- or, in other words, it
-	// gives a notion of a "target" usage.
+	// ScorePeak gives the fraction at which the "target" or highest score should be, with the score
+	// sloping down on either side towards MinUsageScore at 0 and MaxUsageScore at 1.
 	//
-	// The midpoint has the maximum score attached to it, and corresponds to xₚ in the desmos link.
+	// This corresponds to xₚ in the desmos link.
 	ScorePeak float64 `json:"scoreMidpoint"`
 }
 

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -185,6 +185,14 @@ func (c *nodeConfig) validate() (string, error) {
 		return "computeUnit", err
 	}
 
+	if c.MinUsageScore < 0 || c.MinUsageScore > 1 {
+		return "minUsageScore", errors.New("value must be between 0 and 1, inclusive")
+	} else if c.MaxUsageScore < 0 || c.MaxUsageScore > 1 {
+		return "maxUsageScore", errors.New("value must be between 0 and 1, inclusive")
+	} else if c.ScorePeak < 0 || c.ScorePeak > 1 {
+		return "scorePeak", errors.New("value must be between 0 and 1, inclusive")
+	}
+
 	return "", nil
 }
 

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -82,6 +82,28 @@ type nodeConfig struct {
 	Cpu         resourceConfig `json:"cpu"`
 	Memory      resourceConfig `json:"memory"`
 	ComputeUnit api.Resources  `json:"computeUnit"`
+
+	// Details about node scoring:
+	// See also: https://www.desmos.com/calculator/wg8s0yn63s
+	// In the desmos, the value f(x,s) gives the score (from 0 to 1) of a node that's x amount full
+	// (where x is a fraction from 0 to 1), with a total size that is equal to the maximum size node
+	// times s (i.e. s (or: "scale") gives the ratio between this nodes's size and the biggest one).
+
+	// MinUsageScore gives the ratio of the score at the minimum usage (i.e. 0) relative to the
+	// score at the midpoint, which will have the maximum.
+	//
+	// This corresponds to y₀ in the desmos link above.
+	MinUsageScore float64 `json:"minUsageScore"`
+	// MaxUsageScore gives the ratio of the score at the maximum usage (i.e. full) relative to the
+	// score at the midpoint, which will have the maximum.
+	//
+	// This corresponds to y₁ in the desmos link above.
+	MaxUsageScore float64 `json:"maxUsageScore"`
+	// ScoreMidpoint gives the fraction full at which the "midpoint" should be -- or, in other
+	// words, it gives a notion of a "target" usage.
+	//
+	// The midpoint has the maximum score attached to it, and corresponds to xₚ in the desmos link.
+	ScoreMidpoint float64 `json:"scoreMidpoint"`
 }
 
 // resourceConfig configures the amount of a particular resource we're willing to allocate to VMs,

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -99,11 +99,11 @@ type nodeConfig struct {
 	//
 	// This corresponds to y₁ in the desmos link above.
 	MaxUsageScore float64 `json:"maxUsageScore"`
-	// ScoreMidpoint gives the fraction full at which the "midpoint" should be -- or, in other
+	// ScorePeak gives the fraction full at which the "midpoint" should be -- or, in other
 	// words, it gives a notion of a "target" usage.
 	//
 	// The midpoint has the maximum score attached to it, and corresponds to xₚ in the desmos link.
-	ScoreMidpoint float64 `json:"scoreMidpoint"`
+	ScorePeak float64 `json:"scoreMidpoint"`
 }
 
 // resourceConfig configures the amount of a particular resource we're willing to allocate to VMs,

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -99,8 +99,8 @@ type nodeConfig struct {
 	//
 	// This corresponds to y₁ in the desmos link above.
 	MaxUsageScore float64 `json:"maxUsageScore"`
-	// ScorePeak gives the fraction full at which the "midpoint" should be -- or, in other
-	// words, it gives a notion of a "target" usage.
+	// ScorePeak gives the fraction at which the "midpoint" should be -- or, in other words, it
+	// gives a notion of a "target" usage.
 	//
 	// The midpoint has the maximum score attached to it, and corresponds to xₚ in the desmos link.
 	ScorePeak float64 `json:"scoreMidpoint"`

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -718,12 +718,12 @@ func (e *AutoscaleEnforcer) Score(
 	calculateScore := func(fraction, scale float64) (float64, int64) {
 		y0 := nodeConf.MinUsageScore
 		y1 := nodeConf.MaxUsageScore
-		xp := nodeConf.ScoreMidpoint
+		xp := nodeConf.ScorePeak
 
-		score := float64(1) // if fraction == nodeConf.ScoreMidpoint
-		if fraction < nodeConf.ScoreMidpoint {
+		score := float64(1) // if fraction == nodeConf.ScorePeak
+		if fraction < nodeConf.ScorePeak {
 			score = y0 + (1-y0)/xp*fraction
-		} else if fraction > nodeConf.ScoreMidpoint {
+		} else if fraction > nodeConf.ScorePeak {
 			score = y1 + (1-y1)/(1-xp)*(1-fraction)
 		}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -702,23 +702,52 @@ func (e *AutoscaleEnforcer) Score(
 		return score, nil
 	}
 
-	remainingCPU := node.remainingReservableCPU()
-	remainingMem := node.remainingReservableMemSlots()
-	totalCPU := e.state.maxTotalReservableCPU
-	totalMem := e.state.maxTotalReservableMemSlots
+	cpuRemaining := node.remainingReservableCPU()
+	cpuTotal := node.totalReservableCPU()
+	memRemaining := node.remainingReservableMemSlots()
+	memTotal := node.totalReservableMemSlots()
 
-	// The ordering of multiplying before dividing is intentional; it allows us to get an exact
-	// result, because scoreLen and total will both be small (i.e. their product fits within an int64)
-	cpuScore := framework.MinNodeScore + scoreLen*int64(remainingCPU)/int64(totalCPU)
-	memScore := framework.MinNodeScore + scoreLen*int64(remainingMem)/int64(totalMem)
+	cpuFraction := 1 - cpuRemaining.AsFloat64()/cpuTotal.AsFloat64()
+	memFraction := 1 - float64(memRemaining)/float64(memTotal)
+	cpuScale := node.totalReservableCPU().AsFloat64() / e.state.maxTotalReservableCPU.AsFloat64()
+	memScale := float64(node.totalReservableMemSlots()) / float64(e.state.maxTotalReservableMemSlots)
 
-	score := util.Min(cpuScore, memScore)
+	nodeConf := e.state.conf.forNode(nodeName)
+
+	// Refer to the comments in nodeConfig for more. Also, see: https://www.desmos.com/calculator/wg8s0yn63s
+	calculateScore := func(fraction, scale float64) (float64, int64) {
+		y0 := nodeConf.MinUsageScore
+		y1 := nodeConf.MaxUsageScore
+		xp := nodeConf.ScoreMidpoint
+
+		score := float64(1) // if fraction == nodeConf.ScoreMidpoint
+		if fraction < nodeConf.ScoreMidpoint {
+			score = y0 + (1-y0)/xp*fraction
+		} else if fraction > nodeConf.ScoreMidpoint {
+			score = y1 + (1-y1)/(1-xp)*(1-fraction)
+		}
+
+		score /= scale
+
+		return score, framework.MinNodeScore + int64(float64(scoreLen)*score)
+	}
+
+	cpuFScore, cpuIScore := calculateScore(cpuFraction, cpuScale)
+	memFScore, memIScore := calculateScore(memFraction, memScale)
+
+	score := util.Min(cpuIScore, memIScore)
 	logger.Info(
 		"Scored pod placement for node",
 		zap.Int64("score", score),
 		zap.Object("verdict", verdictSet{
-			cpu: fmt.Sprintf("%d remaining reservable of %d total => score is %d", remainingCPU, totalCPU, cpuScore),
-			mem: fmt.Sprintf("%d remaining reservable of %d total => score is %d", remainingMem, totalMem, memScore),
+			cpu: fmt.Sprintf(
+				"%d remaining reservable of %d total => fraction=%g, scale=%g => score=(%g :: %d)",
+				cpuRemaining, cpuTotal, cpuFraction, cpuScale, cpuFScore, cpuIScore,
+			),
+			mem: fmt.Sprintf(
+				"%d remaining reservable of %d total => fraction=%g, scale=%g => score=(%g :: %d)",
+				memRemaining, memTotal, memFraction, memScale, memFScore, memIScore,
+			),
 		}),
 	)
 


### PR DESCRIPTION
us-west-2 is currently at ~30-35% cluster-wide utilization, so I'm figuring that #411 should be handled sooner rather than later.

Implemented this after some brainstorming with @fprasx in a call earlier today.

Should resolve #411.