### PR TITLE
vm-builder: add flag to enable informant/monitor at VM startup and remove cgexec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ docker-build-scheduler: ## Build docker image for (autoscaling) scheduler
 
 .PHONY: docker-build-examples
 docker-build-examples: vm-informant bin/vm-builder ## Build docker images for testing VMs
-	./bin/vm-builder -src postgres:15-bullseye -dst $(E2E_TESTS_VM_IMG)
+	./bin/vm-builder -src postgres:15-bullseye -dst $(E2E_TESTS_VM_IMG) -enable-informant
 
 .PHONY: docker-build-pg14-disk-test
 docker-build-pg14-disk-test: vm-informant bin/vm-builder-generic ## Build a VM image for testing

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ docker-build-scheduler: ## Build docker image for (autoscaling) scheduler
 
 .PHONY: docker-build-examples
 docker-build-examples: vm-informant bin/vm-builder ## Build docker images for testing VMs
-	./bin/vm-builder -src postgres:15-bullseye -dst $(E2E_TESTS_VM_IMG) -enable-informant
+	./bin/vm-builder -src postgres:15-bullseye -dst $(E2E_TESTS_VM_IMG) -enable-informant -enable-monitor
 
 .PHONY: docker-build-pg14-disk-test
 docker-build-pg14-disk-test: vm-informant bin/vm-builder-generic ## Build a VM image for testing

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -22,8 +22,6 @@ import (
 
 // vm-builder --src alpine:3.16 --dst vm-alpine:dev --file vm-alpine.qcow2
 
-var entrypointPrefix = []string{"/usr/bin/cgexec", "-g", "memory:neon-postgres"}
-
 const (
 	dockerfileVmBuilder = `
 FROM {{.InformantImage}} as informant
@@ -521,7 +519,7 @@ func main() {
 	}
 
 	tmplArgs := TemplatesContext{
-		Entrypoint:      append(entrypointPrefix, imageSpec.Config.Entrypoint...),
+		Entrypoint:      imageSpec.Config.Entrypoint,
 		Cmd:             imageSpec.Config.Cmd,
 		Env:             imageSpec.Config.Env,
 		RootDiskImage:   *srcImage,

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -248,8 +248,12 @@ fi
 ::respawn:/neonvm/bin/acpid -f -c /neonvm/acpi
 ::respawn:/neonvm/bin/vector -c /neonvm/config/vector.yaml --config-dir /etc/vector
 ::respawn:/neonvm/bin/vmstart
+{{if .EnableMonitor}}
 ::respawn:su -p vm-informant -c 'RUST_LOG=info /usr/local/bin/vm-monitor --cgroup=neon-postgres{{if .FileCache}} --pgconnstr="host=localhost port=5432 dbname=postgres user=cloud_admin sslmode=disable"{{end}}'
+{{end}}
+{{if .EnableInformant}}
 ::respawn:su -p vm-informant -c '/usr/local/bin/vm-informant'
+{{end}}
 ::respawn:su -p nobody -c '/usr/local/bin/pgbouncer /etc/pgbouncer.ini'
 ::respawn:su -p nobody -c 'DATA_SOURCE_NAME="user=cloud_admin sslmode=disable dbname=postgres" /bin/postgres_exporter --auto-discover-databases --exclude-databases=template0,template1'
 ttyS0::respawn:/neonvm/bin/agetty --8bits --local-line --noissue --noclear --noreset --host console --login-program /neonvm/bin/login --login-pause --autologin root 115200 ttyS0 linux
@@ -364,16 +368,18 @@ var (
 	VMInformant string
 	VMMonitor   string
 
-	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.16`)
-	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
-	size      = flag.String("size", "1G", `Size for disk image: --size=1G`)
-	outFile   = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
-	quiet     = flag.Bool("quiet", false, `Show less output from the docker build process`)
-	forcePull = flag.Bool("pull", false, `Pull src image even if already present locally`)
-	informant = flag.String("informant", VMInformant, `vm-informant docker image`)
-	monitor   = flag.String("monitor", VMMonitor, `vm-monitor docker image`)
-	fileCache = flag.Bool("enable-file-cache", false, `enables the vm-informant's file cache integration`)
-	version   = flag.Bool("version", false, `Print vm-builder version`)
+	srcImage        = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.16`)
+	dstImage        = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
+	size            = flag.String("size", "1G", `Size for disk image: --size=1G`)
+	outFile         = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
+	quiet           = flag.Bool("quiet", false, `Show less output from the docker build process`)
+	forcePull       = flag.Bool("pull", false, `Pull src image even if already present locally`)
+	informant       = flag.String("informant", VMInformant, `vm-informant docker image`)
+	monitor         = flag.String("monitor", VMMonitor, `vm-monitor docker image`)
+	enableMonitor   = flag.Bool("enable-monitor", false, `start the vm-monitor during VM startup`)
+	enableInformant = flag.Bool("enable-informant", false, `start the vm-informant during VM startup`)
+	fileCache       = flag.Bool("enable-file-cache", false, `enables the vm-informant's file cache integration`)
+	version         = flag.Bool("version", false, `Print vm-builder version`)
 )
 
 type dockerMessage struct {
@@ -424,14 +430,16 @@ func AddTemplatedFileToTar(tw *tar.Writer, tmplArgs any, filename string, tmplSt
 }
 
 type TemplatesContext struct {
-	User           string
-	Entrypoint     []string
-	Cmd            []string
-	Env            []string
-	RootDiskImage  string
-	InformantImage string
-	MonitorImage   string
-	FileCache      bool
+	User            string
+	Entrypoint      []string
+	Cmd             []string
+	Env             []string
+	RootDiskImage   string
+	InformantImage  string
+	MonitorImage    string
+	FileCache       bool
+	EnableMonitor   bool
+	EnableInformant bool
 }
 
 func main() {
@@ -513,13 +521,15 @@ func main() {
 	}
 
 	tmplArgs := TemplatesContext{
-		Entrypoint:     append(entrypointPrefix, imageSpec.Config.Entrypoint...),
-		Cmd:            imageSpec.Config.Cmd,
-		Env:            imageSpec.Config.Env,
-		RootDiskImage:  *srcImage,
-		InformantImage: *informant,
-		MonitorImage:   *monitor,
-		FileCache:      *fileCache,
+		Entrypoint:      append(entrypointPrefix, imageSpec.Config.Entrypoint...),
+		Cmd:             imageSpec.Config.Cmd,
+		Env:             imageSpec.Config.Env,
+		RootDiskImage:   *srcImage,
+		InformantImage:  *informant,
+		MonitorImage:    *monitor,
+		FileCache:       *fileCache,
+		EnableMonitor:   *enableMonitor,
+		EnableInformant: *enableInformant,
 	}
 
 	if len(imageSpec.Config.User) != 0 {


### PR DESCRIPTION
This change enables more flexibility rolling out the monitor. We can keep using the monitor during `e2e` tests, while not enabling it for release builds.

This PR also removes cgexec. This functionality will be delegated to `compute_ctl`.