### PR TITLE
plugin: Fix nodeConfig.ScorePeak JSON name (was scoreMidpoint)

### DIFF
--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -32,7 +32,7 @@ data:
         "computeUnit": { "vCPUs": 0.25, "mem": 1 },
         "minUsageScore": 0.5,
         "maxUsageScore": 0,
-        "scoreMidpoint": 0.8
+        "scorePeak": 0.8
       },
       "nodeOverrides": [],
       "schedulerName": "autoscale-scheduler",

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -103,7 +103,7 @@ type nodeConfig struct {
 	// sloping down on either side towards MinUsageScore at 0 and MaxUsageScore at 1.
 	//
 	// This corresponds to xₚ in the desmos link.
-	ScorePeak float64 `json:"scoreMidpoint"`
+	ScorePeak float64 `json:"scorePeak"`
 }
 
 // resourceConfig configures the amount of a particular resource we're willing to allocate to VMs,


### PR DESCRIPTION
Missed this while working on #476.