### PR TITLE
plugin: Fix Score scale usage: mul, not div

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -727,7 +727,7 @@ func (e *AutoscaleEnforcer) Score(
 			score = y1 + (1-y1)/(1-xp)*(1-fraction)
 		}
 
-		score /= scale
+		score *= scale
 
 		return score, framework.MinNodeScore + int64(float64(scoreLen)*score)
 	}


### PR DESCRIPTION
`scale` is a value between 0 and 1, so we want to multiply by it, instead of dividing by it - otherwise we can end up with scores outside the required bounds.

Logs from staging during the failed deploy earlier:

```
{"level":"info","ts":1692211124.9558136,"logger":"autoscale-scheduler.plugin","caller":"plugin/plugin.go:739","msg":"Scored pod placement for node","method":"Score","node":"ip-10-6-26-248.us-east-2.compute.internal","pod":{"namespace":"default","name":"compute-little-river-47144208-7cffdcb994-s4zp6"},"score":802,"verdict":{"cpu":"5.845 remaining reservable of 7.91 total => fraction=0.26106194690265494, scale=0.08266276517922458 => score=(8.022520361813768 :: 802)","mem":"18 remaining reservable of 29 total => fraction=0.3793103448275862, scale=0.07859078590785908 => score=(9.378567181926277 :: 937)"}}
E0816 18:38:44.956024       1 schedule_one.go:131] "Error selecting node for pod" err="applying score defaultWeights on Score plugins: plugin \"AutoscaleEnforcer\" returns an invalid score 802, it should in the range of [0, 100] after normalizing" pod="default/compute-little-river-47144208-7cffdcb994-s4zp6"
```