### PR TITLE
plugin: randomize plugin scores

### DIFF
--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -41,5 +41,6 @@ data:
         "timeoutSeconds": 5
       },
       "migrationDeletionRetrySeconds": 5,
-      "doMigration": false
+      "doMigration": false,
+      "randomizeScores": true
     }

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -41,6 +41,10 @@ type Config struct {
 	// version handled.
 	SchedulerName string `json:"schedulerName"`
 
+	// RandomizeScores, if true, will cause the scheduler to score a node with a random number in
+	// the range [minScore + 1, trueScore], instead of the trueScore
+	RandomizeScores bool `json:"randomizeScores"`
+
 	// MigrationDeletionRetrySeconds gives the duration, in seconds, we should wait between retrying
 	// a failed attempt to delete a VirtualMachineMigration that's finished.
 	MigrationDeletionRetrySeconds uint `json:"migrationDeletionRetrySeconds"`

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -773,11 +773,6 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 	logger := e.logger.With(zap.String("method", "NormalizeScore"), util.PodNameFields(pod))
 	logger.Info("Handling NormalizeScore request")
 
-	if !e.state.conf.RandomizeScores {
-		logger.Info("randomizeScores not set, skipping randomizations")
-		return
-	}
-
 	for _, node := range scores {
 		nodeScore := node.Score
 		nodeName := node.Name
@@ -812,7 +807,11 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 // ScoreExtensions is required for framework.ScorePlugin, and can return nil if it's not used.
 // However, we do use it, to randomize scores.
 func (e *AutoscaleEnforcer) ScoreExtensions() framework.ScoreExtensions {
-	return e
+	if e.state.conf.RandomizeScores {
+		return e
+	} else {
+		return nil
+	}
 }
 
 // Reserve signals to our plugin that a particular pod will (probably) be bound to a node, giving us

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -61,7 +61,6 @@ var _ framework.PreFilterPlugin = (*AutoscaleEnforcer)(nil)
 var _ framework.PostFilterPlugin = (*AutoscaleEnforcer)(nil)
 var _ framework.FilterPlugin = (*AutoscaleEnforcer)(nil)
 var _ framework.ScorePlugin = (*AutoscaleEnforcer)(nil)
-var _ framework.ScoreExtensions = (*AutoscaleEnforcer)(nil)
 var _ framework.ReservePlugin = (*AutoscaleEnforcer)(nil)
 
 func NewAutoscaleEnforcerPlugin(ctx context.Context, logger *zap.Logger, config *Config) func(runtime.Object, framework.Handle) (framework.Plugin, error) {
@@ -780,10 +779,7 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 
 		// rand.Intn will panic if we pass in 0
 		if nodeScore == 0 {
-			logger.Info(
-				fmt.Sprintf("Ignoring node %s as it was assigned a score of 0", nodeName),
-				zap.String("node", nodeName),
-			)
+			logger.Info("Ignoring node as it was assigned a score of 0", zap.String("node", nodeName))
 			continue
 		}
 
@@ -798,8 +794,8 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 		newScore := int64(rand.Intn(int(nodeScore+1-minScore))) + minScore
 		logger.Info(
 			fmt.Sprintf(
-				"Randomly chose score %d from range [minScore=%d, trueScore=%d]",
-				newScore, minScore, nodeScore,
+				"Randomly choosing from range [minScore=%d, trueScore=%d]",
+				minScore, nodeScore,
 			),
 			zap.String("node", nodeName),
 			zap.Int64("score", newScore),

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -775,7 +775,6 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 	logger.Info("Handling NormalizeScore request")
 
 	for _, node := range scores {
-		// logger := e.logger.With(zap.String("method", "Score"), zap.String("node", nodeName), util.PodNameFields(pod))
 		nodeScore := node.Score
 		nodeName := node.Name
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -774,7 +774,7 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 
 		// This is different from framework.MinNodeScore. We use framework.MinNodeScore
 		// to indicate that a pod should not be placed on a node. Thus, the lowest
-        // actual score we assign a node is thus framework.MinNodeScore + 1
+		// actual score we assign a node is thus framework.MinNodeScore + 1
 		minScore := framework.MinNodeScore + 1
 
 		// We want to pick a score in the range [minScore, score], so use

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -773,6 +773,11 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 	logger := e.logger.With(zap.String("method", "NormalizeScore"), util.PodNameFields(pod))
 	logger.Info("Handling NormalizeScore request")
 
+	if !e.state.conf.RandomizeScores {
+		logger.Info("randomizeScores not set, skipping randomizations")
+		return
+	}
+
 	for _, node := range scores {
 		nodeScore := node.Score
 		nodeName := node.Name

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -798,12 +798,11 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 		// range [0, n)
 		newScore := int64(rand.Intn(int(nodeScore+1-minScore))) + minScore
 		logger.Info(
-			fmt.Sprintf(
-				"Randomly choosing from range [minScore=%d, trueScore=%d]",
-				minScore, nodeScore,
-			),
+			"Randomly choosing newScore from range [minScore, trueScore]",
 			zap.String("node", nodeName),
-			zap.Int64("score", newScore),
+			zap.Int64("newScore", newScore),
+			zap.Int64("minScore", minScore),
+			zap.Int64("trueScore", nodeScore),
 		)
 		node.Score = newScore
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -756,7 +756,7 @@ func (e *AutoscaleEnforcer) Score(
 	return score, nil
 }
 
-// NormalizeScore weights scores uniformly in the range [minScore, trueScore], were
+// NormalizeScore weights scores uniformly in the range [minScore, trueScore], where
 // minScore is framework.MinNodeScore + 1.
 func (e *AutoscaleEnforcer) NormalizeScore(
 	ctx context.Context,
@@ -773,7 +773,7 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 		}
 
 		// This is different from framework.MinNodeScore. We use framework.MinNodeScore
-		// to indicate that a pod should not be placed on a node. Thus, the lowest
+		// to indicate that a pod should not be placed on a node. The lowest
 		// actual score we assign a node is thus framework.MinNodeScore + 1
 		minScore := framework.MinNodeScore + 1
 


### PR DESCRIPTION
Randomizes scores in the range `[minScore + 1, trueScore]` to "soften" scaling decisions and make the system less fragile. Resolves #412.
