### PR TITLE
plugin/metrics: Add availability zone label to node metrics

### DIFF
--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -55,6 +55,10 @@ type Config struct {
 	// metrics (like for autoscaling_plugin_node_{cpu,mem}_resources_current)
 	K8sNodeGroupLabel string `json:"k8sNodeGroupLabel"`
 
+	// K8sAvailabilityZoneLabel, if provided, gives the label to use when recording nodes'
+	// availability zones in the metrics (like for autoscaling_plugin_node_{cpu,mem}_resources_current)
+	K8sAvailabilityZoneLabel string `json:"k8sAvailabilityZoneLabel"`
+
 	// IgnoreNamespaces, if provided, gives a list of namespaces that the plugin should completely
 	// ignore, as if pods from those namespaces do not exist.
 	//

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -120,14 +120,15 @@ type podNameAndPointer struct {
 type pointerString string
 
 type nodeStateDump struct {
-	Obj       pointerString                                   `json:"obj"`
-	Name      string                                          `json:"name"`
-	NodeGroup string                                          `json:"nodeGroup"`
-	VCPU      nodeResourceState[vmapi.MilliCPU]               `json:"vCPU"`
-	MemSlots  nodeResourceState[uint16]                       `json:"memSlots"`
-	Pods      []keyed[util.NamespacedName, podStateDump]      `json:"pods"`
-	OtherPods []keyed[util.NamespacedName, otherPodStateDump] `json:"otherPods"`
-	Mq        []*podNameAndPointer                            `json:"mq"`
+	Obj              pointerString                                   `json:"obj"`
+	Name             string                                          `json:"name"`
+	NodeGroup        string                                          `json:"nodeGroup"`
+	AvailabilityZone string                                          `json:"availabilityZone"`
+	VCPU             nodeResourceState[vmapi.MilliCPU]               `json:"vCPU"`
+	MemSlots         nodeResourceState[uint16]                       `json:"memSlots"`
+	Pods             []keyed[util.NamespacedName, podStateDump]      `json:"pods"`
+	OtherPods        []keyed[util.NamespacedName, otherPodStateDump] `json:"otherPods"`
+	Mq               []*podNameAndPointer                            `json:"mq"`
 }
 
 type podStateDump struct {
@@ -233,14 +234,15 @@ func (s *nodeState) dump() nodeStateDump {
 	}
 
 	return nodeStateDump{
-		Obj:       makePointerString(s),
-		Name:      s.name,
-		NodeGroup: s.nodeGroup,
-		VCPU:      s.vCPU,
-		MemSlots:  s.memSlots,
-		Pods:      pods,
-		OtherPods: otherPods,
-		Mq:        mq,
+		Obj:              makePointerString(s),
+		Name:             s.name,
+		NodeGroup:        s.nodeGroup,
+		AvailabilityZone: s.availabilityZone,
+		VCPU:             s.vCPU,
+		MemSlots:         s.memSlots,
+		Pods:             pods,
+		OtherPods:        otherPods,
+		Mq:               mq,
 	}
 }
 

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -72,14 +72,14 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 				Name: "autoscaling_plugin_node_cpu_resources_current",
 				Help: "Current amount of CPU for 'nodeResourceState' fields",
 			},
-			[]string{"node", "node_group", "field"},
+			[]string{"node", "node_group", "availability_zone", "field"},
 		)),
 		nodeMemResources: util.RegisterMetric(reg, prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "autoscaling_plugin_node_mem_resources_current",
 				Help: "Current amount of memory (in bytes) for 'nodeResourceState' fields",
 			},
-			[]string{"node", "node_group", "field"},
+			[]string{"node", "node_group", "availability_zone", "field"},
 		)),
 		migrationCreations: util.RegisterMetric(reg, prometheus.NewCounter(
 			prometheus.CounterOpts{

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -64,6 +64,9 @@ type nodeState struct {
 	// nodeGroup, if present, gives the node group that this node belongs to.
 	nodeGroup string
 
+	// availabilityZone, if present, gives the availability zone that this node is in.
+	availabilityZone string
+
 	// vCPU tracks the state of vCPU resources -- what's available and how
 	vCPU nodeResourceState[vmapi.MilliCPU]
 	// memSlots tracks the state of memory slots -- what's available and how
@@ -103,15 +106,21 @@ func (s *nodeResourceState[T]) fields() []nodeResourceStateField[T] {
 }
 
 func (s *nodeState) updateMetrics(metrics PromMetrics, memSlotSizeBytes uint64) {
-	s.vCPU.updateMetrics(metrics.nodeCPUResources, s.name, s.nodeGroup, vmapi.MilliCPU.AsFloat64)
-	s.memSlots.updateMetrics(metrics.nodeMemResources, s.name, s.nodeGroup, func(memSlots uint16) float64 {
+	s.vCPU.updateMetrics(metrics.nodeCPUResources, s.name, s.nodeGroup, s.availabilityZone, vmapi.MilliCPU.AsFloat64)
+	s.memSlots.updateMetrics(metrics.nodeMemResources, s.name, s.nodeGroup, s.availabilityZone, func(memSlots uint16) float64 {
 		return float64(uint64(memSlots) * memSlotSizeBytes) // convert memSlots -> bytes
 	})
 }
 
-func (s *nodeResourceState[T]) updateMetrics(metric *prometheus.GaugeVec, nodeName, nodeGroup string, convert func(T) float64) {
+func (s *nodeResourceState[T]) updateMetrics(
+	metric *prometheus.GaugeVec,
+	nodeName string,
+	nodeGroup string,
+	availabilityZone string,
+	convert func(T) float64,
+) {
 	for _, f := range s.fields() {
-		metric.WithLabelValues(nodeName, nodeGroup, f.valueName).Set(convert(f.value))
+		metric.WithLabelValues(nodeName, nodeGroup, availabilityZone, f.valueName).Set(convert(f.value))
 	}
 }
 
@@ -121,7 +130,7 @@ func (s *nodeState) removeMetrics(metrics PromMetrics) {
 
 	for _, g := range gauges {
 		for _, f := range fields {
-			g.DeleteLabelValues(s.name, s.nodeGroup, f.valueName)
+			g.DeleteLabelValues(s.name, s.nodeGroup, s.availabilityZone, f.valueName)
 		}
 	}
 }
@@ -617,13 +626,23 @@ func buildInitialNodeState(logger *zap.Logger, node *corev1.Node, conf *Config) 
 		}
 	}
 
+	var availabilityZone string
+	if conf.K8sAvailabilityZoneLabel != "" {
+		var ok bool
+		availabilityZone, ok = node.Labels[conf.K8sAvailabilityZoneLabel]
+		if !ok {
+			logger.Warn("Node does not have availability zone label", zap.String("label", conf.K8sAvailabilityZoneLabel))
+		}
+	}
+
 	n := &nodeState{
-		name:      node.Name,
-		nodeGroup: nodeGroup,
-		vCPU:      vCPU,
-		memSlots:  memSlots,
-		pods:      make(map[util.NamespacedName]*podState),
-		otherPods: make(map[util.NamespacedName]*otherPodState),
+		name:             node.Name,
+		nodeGroup:        nodeGroup,
+		availabilityZone: availabilityZone,
+		vCPU:             vCPU,
+		memSlots:         memSlots,
+		pods:             make(map[util.NamespacedName]*podState),
+		otherPods:        make(map[util.NamespacedName]*otherPodState),
 		otherResources: nodeOtherResourceState{
 			RawCPU:           resource.Quantity{},
 			RawMemory:        resource.Quantity{},


### PR DESCRIPTION
It'd be useful for the "node resource usage" dashboard here: https://neonprod.grafana.net/d/c3799a0a-78e2-4cee-90d7-aef35f52858b

(Specifically, I'd like to be able to just look at a particular availability zone, or even just see which AZ each node belongs to, without having to cross-reference k8s.)