### PR TITLE
agent: harden dispatcher concurrency

### DIFF
--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -105,6 +105,7 @@ func NewDispatcher(logger *zap.Logger, addr string, parent *InformantServer) (di
 		logger:            logger.Named("dispatcher"),
 		protoVersion:      version.Version,
 		server:            parent,
+		lock:              &sync.Mutex{},
 	}
 	return disp, nil
 }

--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -86,15 +86,15 @@ func NewDispatcher(logger *zap.Logger, addr string, parent *InformantServer) (di
 		},
 	)
 	if err != nil {
-		return &Dispatcher{}, fmt.Errorf("error sending protocol range to monitor: %w", err)
+		return nil, fmt.Errorf("error sending protocol range to monitor: %w", err)
 	}
 	var version api.MonitorProtocolResponse
 	err = wsjson.Read(ctx, c, &version)
 	if err != nil {
-		return &Dispatcher{}, fmt.Errorf("error reading monitor response during protocol handshake: %w", err)
+		return nil, fmt.Errorf("error reading monitor response during protocol handshake: %w", err)
 	}
 	if version.Error != nil {
-		return &Dispatcher{}, fmt.Errorf("monitor returned error during protocol handshake: %q", *version.Error)
+		return nil, fmt.Errorf("monitor returned error during protocol handshake: %q", *version.Error)
 	}
 	logger.Info("negotiated protocol version with monitor", zap.String("version", version.Version.String()))
 

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -425,7 +425,7 @@ func (s *InformantServer) RegisterWithInformant(ctx context.Context, logger *zap
 		)
 		// pre-declare disp so that err get's assigned to err from enclosing scope,
 		// overwriting original request error.
-		var disp Dispatcher
+		var disp *Dispatcher
 		disp, err = NewDispatcher(logger, addr, s)
 		// If the error is not nil, it will get handled below
 		if err == nil {
@@ -437,7 +437,7 @@ func (s *InformantServer) RegisterWithInformant(ctx context.Context, logger *zap
 
 				connectedToMonitor = true
 				s.informantIsMonitor = true
-				s.dispatcher = &disp
+				s.dispatcher = disp
 				s.mode = InformantServerRunning
 				s.updatedInformant.Send()
 				if s.runner.server == s {


### PR DESCRIPTION
This addresses a few possible race conditions in the dispatcher. One is related to a read-modify-write operation not being done atomically, and another is related to unsynchronized access to a hash map. See individual commits for more details.