### PR TITLE
agent: inherit context from caller instead of using bg

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -449,9 +449,8 @@ func (s *InformantServer) RegisterWithInformant(ctx context.Context, logger *zap
 							},
 						},
 					}
-					// TODO: fix context/logger stuff
 					s.runner.spawnBackgroundWorker(
-						context.Background(),
+						ctx,
 						disp.logger,
 						"dispatcher message handler",
 						func(context.Context, *zap.Logger) { disp.run() },


### PR DESCRIPTION
Fixes a bug in dispatcher creation where we start a new context instead of using the outer informant server context. It seems like this is a causing a panic to not be propagated fully, and thus goroutines are being leaked.

> I think #486 is not related to the goroutine leakage (because healthchecks are a separate goroutine, and all the goroutines were stuck trying to lock the request lock for health checks, so AFAICT it was just because of the issue behind #488)
