### PR TITLE
agent/informant: Update lastSuccessfulInformantComm for monitor comms

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -1203,7 +1203,23 @@ func (s *InformantServer) MonitorHealthCheck(ctx context.Context, logger *zap.Lo
 	}
 
 	_, err = s.awaitMonitorResponse(ctx, rx)
-	return err
+	if err != nil {
+		return err
+	}
+
+	s.runner.lock.Lock()
+	defer s.runner.lock.Unlock()
+
+	// Update our record of the last successful time we heard from the monitor, if the "server"
+	// is currently enabled. This allows us to detect cases where the communication has broken
+	// down.
+	s.runner.status.update(s.runner.global, func(s podStatus) podStatus {
+		now := time.Now()
+		s.lastSuccessfulInformantComm = &now
+		return s
+	})
+
+	return nil
 }
 
 // MonitorUpscale is the equivalent of (*InformantServer).Upscale for

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -1210,9 +1210,8 @@ func (s *InformantServer) MonitorHealthCheck(ctx context.Context, logger *zap.Lo
 	s.runner.lock.Lock()
 	defer s.runner.lock.Unlock()
 
-	// Update our record of the last successful time we heard from the monitor, if the "server"
-	// is currently enabled. This allows us to detect cases where the communication has broken
-	// down.
+	// Update our record of the last successful time we heard from the monitor. This allows us to
+	// detect cases where the communication has broken down.
 	s.runner.status.update(s.runner.global, func(s podStatus) podStatus {
 		now := time.Now()
 		s.lastSuccessfulInformantComm = &now


### PR DESCRIPTION
This should fix false positives for the "stuck VMs" alert on staging. Validated the old & new (fixed) behavior locally.