### PR TITLE
neonvm/controller: Exit Scaling reconcile early if problem with runne…

### DIFF
--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -542,6 +542,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 					Status:  metav1.ConditionFalse,
 					Reason:  "Reconciling",
 					Message: fmt.Sprintf("Pod (%s) for VirtualMachine (%s) succeeded", virtualmachine.Status.PodName, virtualmachine.Name)})
+			return nil
 		case corev1.PodFailed:
 			virtualmachine.Status.Phase = vmv1.VmFailed
 			meta.SetStatusCondition(&virtualmachine.Status.Conditions,
@@ -549,6 +550,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 					Status:  metav1.ConditionTrue,
 					Reason:  "Reconciling",
 					Message: fmt.Sprintf("Pod (%s) for VirtualMachine (%s) failed", virtualmachine.Status.PodName, virtualmachine.Name)})
+			return nil
 		case corev1.PodUnknown:
 			virtualmachine.Status.Phase = vmv1.VmPending
 			meta.SetStatusCondition(&virtualmachine.Status.Conditions,
@@ -556,6 +558,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 					Status:  metav1.ConditionUnknown,
 					Reason:  "Reconciling",
 					Message: fmt.Sprintf("Pod (%s) for VirtualMachine (%s) in Unknown phase", virtualmachine.Status.PodName, virtualmachine.Name)})
+			return nil
 		default:
 			// do nothing
 		}


### PR DESCRIPTION
…r pod

Follow-up to #483, because the underlying issue occurred again. ref https://neondb.slack.com/archives/C03TN5G758R/p1692684221543939?thread_ts=1692672953.277279&cid=C03TN5G758R