### PR TITLE
propagate informant server contexts to dispatcher

### DIFF
--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -426,7 +426,7 @@ func (s *InformantServer) RegisterWithInformant(ctx context.Context, logger *zap
 		// pre-declare disp so that err get's assigned to err from enclosing scope,
 		// overwriting original request error.
 		var disp *Dispatcher
-		disp, err = NewDispatcher(logger, addr, s)
+		disp, err = NewDispatcher(ctx, logger, addr, s)
 		// If the error is not nil, it will get handled below
 		if err == nil {
 			// Acquire the lock late so as not to hold it will connecting to the
@@ -454,7 +454,7 @@ func (s *InformantServer) RegisterWithInformant(ctx context.Context, logger *zap
 						context.Background(),
 						disp.logger,
 						"dispatcher message handler",
-						func(context.Context, *zap.Logger) { disp.run() },
+						func(ctx context.Context, _ *zap.Logger) { disp.run(ctx) },
 					)
 				} else if s.exitStatus != nil {
 					// we exited -> close ws

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -453,7 +453,7 @@ func (s *InformantServer) RegisterWithInformant(ctx context.Context, logger *zap
 						ctx,
 						disp.logger,
 						"dispatcher message handler",
-						func(ctx context.Context, _ *zap.Logger) { disp.run(ctx) },
+						ignoreLogger(disp.run),
 					)
 				} else if s.exitStatus != nil {
 					// we exited -> close ws

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -449,9 +449,8 @@ func (s *InformantServer) RegisterWithInformant(ctx context.Context, logger *zap
 							},
 						},
 					}
-					// TODO: fix context/logger stuff
 					s.runner.spawnBackgroundWorker(
-						context.Background(),
+						ctx,
 						disp.logger,
 						"dispatcher message handler",
 						func(ctx context.Context, _ *zap.Logger) { disp.run(ctx) },


### PR DESCRIPTION
This should ensure that if the outer context is cancelled (for example, the informant server shutting down), we (the goroutine doing `disp.run(ctx)`) also shut down.

Not having this previously caused an error where the informant server would shut down, close the websocket, and then because the `disp.run` goroutine was not hooked into the context, it wouldn't be shut down and would try to read from the closed connection.