### PR TITLE
agent/dispatcher: Add request(ish) message metrics

### DIFF
--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -164,7 +164,12 @@ func (disp *Dispatcher) unregisterWaiter(id uint64) {
 
 // Make a request to the monitor and wait for a response. The value passed as message must be a
 // valid value to send to the monitor. See the docs for SerializeInformantMessage for more.
-func (disp *Dispatcher) Call(ctx context.Context, timeout time.Duration, messageType string, message any) (*MonitorResult, error) {
+func (disp *Dispatcher) Call(
+	ctx context.Context,
+	timeout time.Duration,
+	messageType string,
+	message any,
+) (*MonitorResult, error) {
 	id := disp.lastTransactionID.Add(2)
 	sender, receiver := util.NewSingleSignalPair[waiterResult]()
 

--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -281,6 +281,10 @@ func (disp *Dispatcher) HandleMessage(
 		} else if rootErr != nil {
 			err = rootErr
 		} else {
+			// if HandleMessage bailed without panicking or setting rootErr, but *also* without
+			// sending a message to the waiter, we should make sure that *something* gets sent, so
+			// the message doesn't just time out. But we don't have more information, so the error
+			// is still just "unknown".
 			err = errors.New("unknown")
 		}
 

--- a/pkg/agent/informant.go
+++ b/pkg/agent/informant.go
@@ -1158,7 +1158,7 @@ func (s *InformantServer) Upscale(ctx context.Context, logger *zap.Logger, to ap
 func (s *InformantServer) MonitorHealthCheck(ctx context.Context, logger *zap.Logger) error {
 	timeout := time.Second * time.Duration(s.runner.global.config.Monitor.ResponseTimeoutSeconds)
 
-	_, err := s.dispatcher.Call(ctx, timeout, api.HealthCheck{})
+	_, err := s.dispatcher.Call(ctx, timeout, "HealthCheck", api.HealthCheck{})
 
 	s.runner.lock.Lock()
 	defer s.runner.lock.Unlock()
@@ -1197,7 +1197,7 @@ func (s *InformantServer) MonitorUpscale(ctx context.Context, logger *zap.Logger
 
 	timeout := time.Second * time.Duration(s.runner.global.config.Monitor.ResponseTimeoutSeconds)
 
-	_, err := s.dispatcher.Call(ctx, timeout, api.UpscaleNotification{
+	_, err := s.dispatcher.Call(ctx, timeout, "UpscaleNotification", api.UpscaleNotification{
 		Granted: api.Allocation{Cpu: cpu, Mem: mem},
 	})
 	if err != nil {
@@ -1227,7 +1227,7 @@ func (s *InformantServer) MonitorDownscale(ctx context.Context, logger *zap.Logg
 
 	timeout := time.Second * time.Duration(s.runner.global.config.Monitor.ResponseTimeoutSeconds)
 
-	res, err := s.dispatcher.Call(ctx, timeout, api.DownscaleRequest{
+	res, err := s.dispatcher.Call(ctx, timeout, "DownscaleRequest", api.DownscaleRequest{
 		Target: api.Allocation{Cpu: cpu, Mem: mem},
 	})
 	if err != nil {


### PR DESCRIPTION
Builds on #499. Two parts to this PR:

- [x] "request" metrics (transactions initiated by the agent)
- [x] "response" metrics (transactions initiated by the monitor)