### PR TITLE
neonvm/builder: Allow any user to cgexec out of top-level cgroup

### DIFF
--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -187,6 +187,18 @@ chmod 1777 /dev/shm
 mount -t proc  proc  /proc
 mount -t sysfs sysfs /sys
 mount -t cgroup2 cgroup2 /sys/fs/cgroup
+
+# Allow all users to move processes to/from the root cgroup.
+#
+# This is required in order to be able to 'cgexec' anything, if the entrypoint is not being run as
+# root, because moving tasks betweeen one cgroup and another *requires write access to the
+# cgroup.procs file of the common ancestor*, and because the entrypoint isn't already in a cgroup,
+# any new tasks are automatically placed in the top-level cgroup.
+#
+# This *would* be bad for security, if we relied on cgroups for security; but instead because they
+# are just used for cooperative signaling, this should be mostly ok.
+chmod go+w /sys/fs/cgroup/cgroup.procs
+
 mount -t devpts -o noexec,nosuid       devpts    /dev/pts
 mount -t tmpfs  -o noexec,nosuid,nodev shm-tmpfs /dev/shm
 

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -285,6 +285,18 @@ chmod 1777 /dev/shm
 mount -t proc  proc  /proc
 mount -t sysfs sysfs /sys
 mount -t cgroup2 cgroup2 /sys/fs/cgroup
+
+# Allow all users to move processes to/from the root cgroup.
+#
+# This is required in order to be able to 'cgexec' anything, if the entrypoint is not being run as
+# root, because moving tasks betweeen one cgroup and another *requires write access to the
+# cgroup.procs file of the common ancestor*, and because the entrypoint isn't already in a cgroup,
+# any new tasks are automatically placed in the top-level cgroup.
+#
+# This *would* be bad for security, if we relied on cgroups for security; but instead because they
+# are just used for cooperative signaling, this should be mostly ok.
+chmod go+w /sys/fs/cgroup/cgroup.procs
+
 mount -t devpts -o noexec,nosuid       devpts    /dev/pts
 mount -t tmpfs  -o noexec,nosuid,nodev shm-tmpfs /dev/shm
 


### PR DESCRIPTION
The relevant information is in the comments added, but to replicate it here for completeness:

> Allow all users to move processes to/from the root cgroup.
>
> This is required in order to be able to 'cgexec' anything, if the entrypoint is not being run as root, because moving tasks betweeen one cgroup and another *requires write access to the cgroup.procs file of the common ancestor*, and because the entrypoint isn't already in a cgroup, any new tasks are automatically placed in the top-level cgroup.
>
> This *would* be bad for security, if we relied on cgroups for security; but instead because they are just used for cooperative signaling, this should be mostly ok.

In debugging this, I found portions of this answer very helpful: https://unix.stackexchange.com/a/741631

We don't have systemd running the cgroups, so we don't have equivalent per-user cgroups that they have permission to move tasks to/from, so the easiest solution is to just give all users access.

---

This should unblock neondatabase/neon#4920, and may be why neondatabase/cloud#5143 did not work. I've validated locally that this allows running e.g. `cgexec -g memory:neon-test ...` as the `vm-monitor` user in the pg14-disk-test image.