### PR TITLE
neonvm: Add EmptyDisk.Discard option

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -310,6 +310,8 @@ type DiskSource struct {
 
 type EmptyDiskSource struct {
 	Size resource.Quantity `json:"size"`
+	// Discard enables the "discard" mount option for the filesystem
+	Discard bool `json:"discard,omitempty"`
 }
 
 type TmpfsDiskSource struct {

--- a/neonvm/config/common/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/common/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -963,6 +963,10 @@ spec:
                       description: EmptyDisk represents a temporary empty qcow2 disk
                         that shares a vm's lifetime.
                       properties:
+                        discard:
+                          description: Discard enables the "discard" mount option
+                            for the filesystem
+                          type: boolean
                         size:
                           anyOf:
                           - type: integer


### PR DESCRIPTION
It enables the "discard" mount option, which can be used instead of fstrim to propagate hole punches down to the backing file (I think).

See also:

- https://chrisirwin.ca/posts/discard-with-kvm-2020/
- https://serverfault.com/questions/896448/qemu-trim-and-discard-on-a-physical-ssd-device