### PR TITLE
error: upgrade fun, simplify error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/onsi/gomega v1.24.2
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/prometheus/client_golang v1.14.0
-	github.com/tychoish/fun v0.8.5
+	github.com/tychoish/fun v0.10.6
 	github.com/vishvananda/netlink v1.1.1-0.20220125195016-0639e7e787ba
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9

--- a/go.sum
+++ b/go.sum
@@ -645,6 +645,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tychoish/fun v0.8.5 h1:8uTFk2fG8mxDyRmqMj6llKE8+vTuQRclUkl0/tyYwAU=
 github.com/tychoish/fun v0.8.5/go.mod h1:84A+BwGecz23UotmbB4mtvVS5ZcsZpspecduxpwF/XM=
+github.com/tychoish/fun v0.10.6 h1:UqJZY8I9hPsXGcuS1XdX5gNZKIcJRywjy+jD9oHRR+s=
+github.com/tychoish/fun v0.10.6/go.mod h1:ZZfrwtsnHHV81ecZCBPp57DjjYY9Io39JH2QSXNpKn4=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/go.sum
+++ b/go.sum
@@ -643,8 +643,6 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tychoish/fun v0.8.5 h1:8uTFk2fG8mxDyRmqMj6llKE8+vTuQRclUkl0/tyYwAU=
-github.com/tychoish/fun v0.8.5/go.mod h1:84A+BwGecz23UotmbB4mtvVS5ZcsZpspecduxpwF/XM=
 github.com/tychoish/fun v0.10.6 h1:UqJZY8I9hPsXGcuS1XdX5gNZKIcJRywjy+jD9oHRR+s=
 github.com/tychoish/fun v0.10.6/go.mod h1:ZZfrwtsnHHV81ecZCBPp57DjjYY9Io39JH2QSXNpKn4=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/tychoish/fun/erc"
-
 	"github.com/neondatabase/autoscaling/pkg/agent/billing"
 	"github.com/neondatabase/autoscaling/pkg/api"
+	"github.com/tychoish/fun/ers"
 )
 
 type Config struct {
@@ -135,43 +134,41 @@ func ReadConfig(path string) (*Config, error) {
 }
 
 func (c *Config) validate() error {
-	ec := &erc.Collector{}
-
 	const (
 		emptyTmpl = "field %q cannot be empty"
 		zeroTmpl  = "field %q cannot be zero"
 	)
 
-	erc.Whenf(ec, c.Billing != nil && c.Billing.ActiveTimeMetricName == "", emptyTmpl, ".billing.activeTimeMetricName")
-	erc.Whenf(ec, c.Billing != nil && c.Billing.CPUMetricName == "", emptyTmpl, ".billing.cpuMetricName")
-	erc.Whenf(ec, c.Billing != nil && c.Billing.CollectEverySeconds == 0, zeroTmpl, ".billing.collectEverySeconds")
-	erc.Whenf(ec, c.Billing != nil && c.Billing.AccumulateEverySeconds == 0, zeroTmpl, ".billing.accumulateEverySeconds")
-	erc.Whenf(ec, c.Billing != nil && c.Billing.PushEverySeconds == 0, zeroTmpl, ".billing.pushEverySeconds")
-	erc.Whenf(ec, c.Billing != nil && c.Billing.PushRequestTimeoutSeconds == 0, zeroTmpl, ".billing.pushRequestTimeoutSeconds")
-	erc.Whenf(ec, c.Billing != nil && c.Billing.MaxBatchSize == 0, zeroTmpl, ".billing.maxBatchSize")
-	erc.Whenf(ec, c.Billing != nil && c.Billing.URL == "", emptyTmpl, ".billing.url")
-	erc.Whenf(ec, c.DumpState != nil && c.DumpState.Port == 0, zeroTmpl, ".dumpState.port")
-	erc.Whenf(ec, c.DumpState != nil && c.DumpState.TimeoutSeconds == 0, zeroTmpl, ".dumpState.timeoutSeconds")
-	erc.Whenf(ec, c.Informant.DownscaleTimeoutSeconds == 0, zeroTmpl, ".informant.downscaleTimeoutSeconds")
-	erc.Whenf(ec, c.Informant.RegisterRetrySeconds == 0, zeroTmpl, ".informant.registerRetrySeconds")
-	erc.Whenf(ec, c.Informant.RegisterTimeoutSeconds == 0, zeroTmpl, ".informant.registerTimeoutSeconds")
-	erc.Whenf(ec, c.Informant.RequestTimeoutSeconds == 0, zeroTmpl, ".informant.requestTimeoutSeconds")
-	erc.Whenf(ec, c.Informant.RetryServerMinWaitSeconds == 0, zeroTmpl, ".informant.retryServerMinWaitSeconds")
-	erc.Whenf(ec, c.Informant.RetryServerNormalWaitSeconds == 0, zeroTmpl, ".informant.retryServerNormalWaitSeconds")
-	erc.Whenf(ec, c.Informant.ServerPort == 0, zeroTmpl, ".informant.serverPort")
-	erc.Whenf(ec, c.Informant.CallbackPort == 0, zeroTmpl, ".informant.callbackPort")
-	erc.Whenf(ec, c.Informant.UnhealthyAfterSilenceDurationSeconds == 0, zeroTmpl, ".informant.unhealthyAfterSilenceDurationSeconds")
-	erc.Whenf(ec, c.Informant.UnhealthyStartupGracePeriodSeconds == 0, zeroTmpl, ".informant.unhealthyStartupGracePeriodSeconds")
-	erc.Whenf(ec, c.Metrics.LoadMetricPrefix == "", emptyTmpl, ".metrics.loadMetricPrefix")
-	erc.Whenf(ec, c.Metrics.SecondsBetweenRequests == 0, zeroTmpl, ".metrics.secondsBetweenRequests")
-	erc.Whenf(ec, c.Scaling.RequestTimeoutSeconds == 0, zeroTmpl, ".scaling.requestTimeoutSeconds")
-	erc.Whenf(ec, c.Monitor.ResponseTimeoutSeconds == 0, zeroTmpl, ".monitor.responseTimeoutSeconds")
-	erc.Whenf(ec, c.Monitor.ConnectionTimeoutSeconds == 0, zeroTmpl, ".monitor.connectionTimeoutSeconds")
-	// add all errors if there are any: https://github.com/neondatabase/autoscaling/pull/195#discussion_r1170893494
-	ec.Add(c.Scaling.DefaultConfig.Validate())
-	erc.Whenf(ec, c.Scheduler.RequestPort == 0, zeroTmpl, ".scheduler.requestPort")
-	erc.Whenf(ec, c.Scheduler.RequestTimeoutSeconds == 0, zeroTmpl, ".scheduler.requestTimeoutSeconds")
-	erc.Whenf(ec, c.Scheduler.SchedulerName == "", emptyTmpl, ".scheduler.schedulerName")
-
-	return ec.Resolve()
+	return ers.Join(
+		ers.Whenf(c.Billing != nil && c.Billing.ActiveTimeMetricName == "", emptyTmpl, ".billing.activeTimeMetricName"),
+		ers.Whenf(c.Billing != nil && c.Billing.CPUMetricName == "", emptyTmpl, ".billing.cpuMetricName"),
+		ers.Whenf(c.Billing != nil && c.Billing.CollectEverySeconds == 0, zeroTmpl, ".billing.collectEverySeconds"),
+		ers.Whenf(c.Billing != nil && c.Billing.AccumulateEverySeconds == 0, zeroTmpl, ".billing.accumulateEverySeconds"),
+		ers.Whenf(c.Billing != nil && c.Billing.PushEverySeconds == 0, zeroTmpl, ".billing.pushEverySeconds"),
+		ers.Whenf(c.Billing != nil && c.Billing.PushRequestTimeoutSeconds == 0, zeroTmpl, ".billing.pushRequestTimeoutSeconds"),
+		ers.Whenf(c.Billing != nil && c.Billing.MaxBatchSize == 0, zeroTmpl, ".billing.maxBatchSize"),
+		ers.Whenf(c.Billing != nil && c.Billing.URL == "", emptyTmpl, ".billing.url"),
+		ers.Whenf(c.DumpState != nil && c.DumpState.Port == 0, zeroTmpl, ".dumpState.port"),
+		ers.Whenf(c.DumpState != nil && c.DumpState.TimeoutSeconds == 0, zeroTmpl, ".dumpState.timeoutSeconds"),
+		ers.Whenf(c.Informant.DownscaleTimeoutSeconds == 0, zeroTmpl, ".informant.downscaleTimeoutSeconds"),
+		ers.Whenf(c.Informant.RegisterRetrySeconds == 0, zeroTmpl, ".informant.registerRetrySeconds"),
+		ers.Whenf(c.Informant.RegisterTimeoutSeconds == 0, zeroTmpl, ".informant.registerTimeoutSeconds"),
+		ers.Whenf(c.Informant.RequestTimeoutSeconds == 0, zeroTmpl, ".informant.requestTimeoutSeconds"),
+		ers.Whenf(c.Informant.RetryServerMinWaitSeconds == 0, zeroTmpl, ".informant.retryServerMinWaitSeconds"),
+		ers.Whenf(c.Informant.RetryServerNormalWaitSeconds == 0, zeroTmpl, ".informant.retryServerNormalWaitSeconds"),
+		ers.Whenf(c.Informant.ServerPort == 0, zeroTmpl, ".informant.serverPort"),
+		ers.Whenf(c.Informant.CallbackPort == 0, zeroTmpl, ".informant.callbackPort"),
+		ers.Whenf(c.Informant.UnhealthyAfterSilenceDurationSeconds == 0, zeroTmpl, ".informant.unhealthyAfterSilenceDurationSeconds"),
+		ers.Whenf(c.Informant.UnhealthyStartupGracePeriodSeconds == 0, zeroTmpl, ".informant.unhealthyStartupGracePeriodSeconds"),
+		ers.Whenf(c.Metrics.LoadMetricPrefix == "", emptyTmpl, ".metrics.loadMetricPrefix"),
+		ers.Whenf(c.Metrics.SecondsBetweenRequests == 0, zeroTmpl, ".metrics.secondsBetweenRequests"),
+		ers.Whenf(c.Scaling.RequestTimeoutSeconds == 0, zeroTmpl, ".scaling.requestTimeoutSeconds"),
+		ers.Whenf(c.Monitor.ResponseTimeoutSeconds == 0, zeroTmpl, ".monitor.responseTimeoutSeconds"),
+		ers.Whenf(c.Monitor.ConnectionTimeoutSeconds == 0, zeroTmpl, ".monitor.connectionTimeoutSeconds"),
+		// add all errors if there are any: https://github.com/neondatabase/autoscaling/pull/195#discussion_r1170893494
+		c.Scaling.DefaultConfig.Validate(),
+		ers.Whenf(c.Scheduler.RequestPort == 0, zeroTmpl, ".scheduler.requestPort"),
+		ers.Whenf(c.Scheduler.RequestTimeoutSeconds == 0, zeroTmpl, ".scheduler.requestTimeoutSeconds"),
+		ers.Whenf(c.Scheduler.SchedulerName == "", emptyTmpl, ".scheduler.schedulerName"),
+	)
 }

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/tychoish/fun/ers"
+
 	"github.com/neondatabase/autoscaling/pkg/agent/billing"
 	"github.com/neondatabase/autoscaling/pkg/api"
-	"github.com/tychoish/fun/ers"
 )
 
 type Config struct {

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -261,10 +261,10 @@ func (b ResourceBounds) validate(path string, memSlotSize *resource.Quantity) er
 	// ers.Whenf is nil if the condition is false; also does not
 	// resolve/format the string unless the condition is true.
 	es.Push(ers.Whenf(b.CPU.IsZero(), "%s.cpu: must have a non-zero value", path))
-	es.Push(ers.Whenf(b.Mem.IsZero() || b.Mem.Value() < 0),
-		"%s.mem: must have value greater than zero", path)
-	es.Push(ers.Whenf(Mem.Value()%memSlotSize.Value() != 0,
-		"%s.mem: must be divisiable by VM memory slot size %s", memSlotSize))
+	es.Push(ers.Whenf(b.Mem.IsZero() || b.Mem.Value() < 0,
+		"%s.mem: must have value greater than zero", path))
+	es.Push(ers.Whenf(b.Mem.Value()%memSlotSize.Value() != 0,
+		"%s.mem: must be divisiable by VM memory slot size %s", path, memSlotSize))
 
 	// ers.Stack is always error, and is non-nil here: calling
 	// resolve returns nil if none of the above are errors:


### PR DESCRIPTION
Thought I'd do one last bump of this, and make a few changes to take advantage of 

I wrote up the following about the various error handling options. 

(The other differnce between using `ers.{Wrap,Join,Collect}`. and
using `%w` is that the concatination of the errors with `%w` happens
in the format of the error itself, with the ers tools, it's a property
of `ers.Stack` (which underpins all of the ers/erc tooling?), so you
can disassemble a stack-based error and have each individual error be
tractable and usable?)

------

The basic overview is:

- `ers.Join` (like `errors.Join`) combines a collection of errors,
  however, rather than using a slice, it uses the `ers.Stack`, which
  as a size-tracking linked list, can be used more incrementally and
  has more intuitive Wrapping/Unwrapping sementics. Like `errors.Join`
  this function drops nil errors, and returns nil when there are no
  errors. Where `errors.Join` has a string output form that joins
  constituent errors with a `\n`, `ers.Join` uses `: ` which is
  consistent with the way we think about wrapped errors (and typically
  format), it also reduces the amount of escaping that has to happen
  in log output.

- this `ers.Stack` is the same type that's been at the heart of the
  `erc.Collector` forever, so things don't really change. While
  `ers.Stack` isn't thread-safe, it's just a size-tracking linked
  list, for errors (thereby avoiding the preallocation temptation,)
  with helpers (e.g. Push/Add) much like the Collector. 
  
  Pros:
  - minimal overhead
  - good ergonomics (push/add ignore nil errors).
  - reasonable semantics, and tools (e.g. `ers.AsStack` and
    `ers.Unwind`) to introspect error values.
  - respects `Is` and `As` interfaces, while also avoiding the
    awkwardness of having an `Unwrap` method that returns a slice.
      
  Cons:
  - Stack objects implement `error`, so if you return an error stack
    as an error, it's non-nil even when it's empty. ~~I'm going to add a
    `Resolve()` method before merging this just to reduce confusion.~~
  - not in the standard library, (though fully compatible.)
  
- `erc.Collector` just wraps the ers.Stack object with a mutex
  (essentially,) and provides some higher level interfaces. The mutex
  is useful for collecting errors from operations in different worker
  functions. However, because the the collector checks to see if the
  error is non-nil before taking the mutex, any mutex cost/contention
  happens outside of the happy path.

- Nothing that happens here uses it, but [following from this
  post](https://dave.cheney.net/2016/04/07/constant-errors) the `ers`
  package has an `Error` type which wraps `string` and makes it
  possible to declare sentinel errors as constants. There are some
  other goodies in the `ers` package: helpers to attach and access
  timestamps from errors, the Wrap (eaiser than `%w` for common cases)
  and When (for making errors conditional to avoid really verbose
  aggregation forms) an their `Whenf`/`Wrapf` helpers that build their
  strings lazily. A `Strings()` helper for converting a slice of
  errors into a slice of strings (dropping nil errors), and some
  panics-to-errors tooling.

(As always, fun doesn't have any non-stdlib dependencies, and the ers
package is upstream of (nearly) all packages in the fun module, and
the test coverage on this stuff is pretty darn good. While my impulse
is to fix problems or confusion with the API rather than let broken
semantics remain in the name of stability, the dependency and testing
will help avoid bit rot.)