### PR TITLE
agent/dispatcher: Add more logs to NewDispatcher

### DIFF
--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -98,23 +98,26 @@ func NewDispatcher(
 		return nil, fmt.Errorf("error establishing websocket connection to %s: %w", addr, err)
 	}
 
+	versionRange := api.VersionRange[api.MonitorProtoVersion]{
+		Min: MinMonitorProtocolVersion,
+		Max: MaxMonitorProtocolVersion,
+	}
+	logger.Info("sending protocol version range", zap.Any("range", versionRange))
+
 	// Figure out protocol version
-	err = wsjson.Write(
-		ctx,
-		c,
-		api.VersionRange[api.MonitorProtoVersion]{
-			Min: MinMonitorProtocolVersion,
-			Max: MaxMonitorProtocolVersion,
-		},
-	)
+	err = wsjson.Write(ctx, c, versionRange)
 	if err != nil {
 		return nil, fmt.Errorf("error sending protocol range to monitor: %w", err)
 	}
+
+	logger.Info("reading monitor version response")
 	var version api.MonitorProtocolResponse
 	err = wsjson.Read(ctx, c, &version)
 	if err != nil {
+		logger.Error("failed to read monitor response", zap.Error(err))
 		return nil, fmt.Errorf("error reading monitor response during protocol handshake: %w", err)
 	}
+	logger.Info("got monitor version response", zap.Any("response", version))
 	if version.Error != nil {
 		return nil, fmt.Errorf("monitor returned error during protocol handshake: %q", *version.Error)
 	}


### PR DESCRIPTION
When we run into issues around failed communication between the autoscaler-agent and vm-monitor, the logs on the agent's side are currently not *quite* verbose enough to clearly tell what's going wrong.