### PR TITLE
neonvm/runner: Fix EmptyDisk chmod getting overwritten

### DIFF
--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -226,8 +226,9 @@ func createISO9660runtime(diskPath string, command []string, args []string, env 
 					opts = "-o discard"
 				}
 
-				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/chmod 0777 %s`, disk.MountPath))
 				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/mount %s $(/neonvm/bin/blkid -L %s) %s`, opts, disk.Name, disk.MountPath))
+				// Note: chmod must be after mount, otherwise it gets overwritten by mount.
+				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/chmod 0777 %s`, disk.MountPath))
 			case disk.ConfigMap != nil || disk.Secret != nil:
 				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/mount -o ro,mode=0644 $(/neonvm/bin/blkid -L %s) %s`, disk.Name, disk.MountPath))
 			case disk.Tmpfs != nil:


### PR DESCRIPTION
Not sure why this happens here, and not for tmpfs, but oh well. Validated locally that this fixes the problem.