### PR TITLE
add serviceAccountName field

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -69,11 +69,12 @@ type VirtualMachineSpec struct {
 	// +optional
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds"`
 
-	NodeSelector  map[string]string           `json:"nodeSelector,omitempty"`
-	Affinity      *corev1.Affinity            `json:"affinity,omitempty"`
-	Tolerations   []corev1.Toleration         `json:"tolerations,omitempty"`
-	SchedulerName string                      `json:"schedulerName,omitempty"`
-	PodResources  corev1.ResourceRequirements `json:"podResources,omitempty"`
+	NodeSelector       map[string]string           `json:"nodeSelector,omitempty"`
+	Affinity           *corev1.Affinity            `json:"affinity,omitempty"`
+	Tolerations        []corev1.Toleration         `json:"tolerations,omitempty"`
+	SchedulerName      string                      `json:"schedulerName,omitempty"`
+	ServiceAccountName string                      `json:"serviceAccountName,omitempty"`
+	PodResources       corev1.ResourceRequirements `json:"podResources,omitempty"`
 
 	// +kubebuilder:default:=Always
 	// +optional

--- a/neonvm/config/common/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/common/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -2516,6 +2516,8 @@ spec:
                 type: string
               service_links:
                 type: boolean
+              serviceAccountName:
+                type: string
               terminationGracePeriodSeconds:
                 default: 5
                 format: int64

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -1046,6 +1046,7 @@ func podSpec(virtualmachine *vmv1.VirtualMachine) (*corev1.Pod, error) {
 			NodeSelector:                  virtualmachine.Spec.NodeSelector,
 			ImagePullSecrets:              virtualmachine.Spec.ImagePullSecrets,
 			Tolerations:                   virtualmachine.Spec.Tolerations,
+			ServiceAccountName:            virtualmachine.Spec.ServiceAccountName,
 			SchedulerName:                 virtualmachine.Spec.SchedulerName,
 			Affinity:                      affinity,
 			InitContainers: []corev1.Container{


### PR DESCRIPTION
1. first there was this - https://github.com/neondatabase/neonvm/pull/12
2. then was this - https://github.com/neondatabase/autoscaling/pull/140

and now we need serviceAccount again to have ability use IRSA and let applications inside VM have access to AWS resources (s3)
