### PR TITLE
agent: Add support for metrics provided by vm-monitor

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,8 @@ linters-settings:
       - '^github\.com/tychoish/fun/pubsub\.BrokerOptions$'
       # vmapi.{VirtualMachine,VirtualMachineSpec,VirtualMachineMigration,VirtualMachineMigrationSpec}
       - '^github\.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1\.VirtualMachine(Migration)?(Spec)?$'
+      - '^github\.com/neondatabase/autoscaling/pkg/agent\.MonitorResult$'
+      - '^github\.com/neondatabase/autoscaling/pkg/api\.InformantMetricsMethod$'
 
   # see: <https://golangci-lint.run/usage/linters/#gci>
   gci:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ E2E_TESTS_VM_IMG ?= vm-postgres:15-bullseye
 PG14_DISK_TEST_IMG ?= pg14-disk-test:dev
 
 # Which branch of neondatabase/neon to pull the vm-monitor from
-VM_MONITOR_BRANCH ?= main
+VM_MONITOR_BRANCH ?= sharnoff/monitor-metrics # TEMPORARY!
 
 # kernel for guests
 VM_KERNEL_VERSION ?= "5.15.80"

--- a/pkg/agent/runner_test.go
+++ b/pkg/agent/runner_test.go
@@ -14,7 +14,7 @@ func Test_desiredVMState(t *testing.T) {
 		name string
 
 		// helpers for setting fields of atomicUpdateState:
-		metrics          api.Metrics
+		metrics          agent.VMMetrics
 		vmUsing          api.Resources
 		lastApproved     api.Resources
 		requestedUpscale api.MoreResources
@@ -25,7 +25,7 @@ func Test_desiredVMState(t *testing.T) {
 	}{
 		{
 			name: "BasicScaleup",
-			metrics: api.Metrics{
+			metrics: agent.VMMetrics{
 				LoadAverage1Min:  0.30,
 				LoadAverage5Min:  0.0, // unused
 				MemoryUsageBytes: 0.0,
@@ -39,7 +39,7 @@ func Test_desiredVMState(t *testing.T) {
 		},
 		{
 			name: "MismatchedApprovedNoScaledown",
-			metrics: api.Metrics{
+			metrics: agent.VMMetrics{
 				LoadAverage1Min:  0.0, // ordinarily would like to scale down
 				LoadAverage5Min:  0.0,
 				MemoryUsageBytes: 0.0,
@@ -55,7 +55,7 @@ func Test_desiredVMState(t *testing.T) {
 		{
 			// ref https://github.com/neondatabase/autoscaling/issues/512
 			name: "MismatchedApprovedNoScaledownButVMAtMaximum",
-			metrics: api.Metrics{
+			metrics: agent.VMMetrics{
 				LoadAverage1Min:  0.0, // ordinarily would like to scale down
 				LoadAverage5Min:  0.0,
 				MemoryUsageBytes: 0.0,

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -13,7 +13,7 @@ commit in this repository, possibly unreleased.
 
 | Release | autoscaler-agent | VM monitor |
 |---------|------------------|------------|
-| _Current_ | v1.0 only | v1.0 only |
+| _Current_ | **v1.0-v1.1** | **v1.0-v1.1** |
 | v0.17.0 | v1.0 only | v1.0 only |
 | v0.16.0 | v1.0 only | v1.0 only |
 | v0.15.0 | **v1.0** only | **v1.0** only |


### PR DESCRIPTION
The prometheus output provided by node_exporter / vector is a lot more than we need, and parsing it in the autoscaler-agent (because that's currently how we get metrics) is a little hacky. We already maintain communication with the vm-monitor, so let's just fetch the metrics there too — this also means we can more easily customize the information in the future, like providing stats relevant to the `neon-postgres` cgroup.

This should also help somewhat with providing per-endpoint metrics.

**NB:** This PR currently overrides vm-monitor builds to point to the `sharnoff/monitor-metrics` branch of `neondatabase/neon`. That should be reverted before merging.