### PR TITLE
acpi shutdown: correct and robust graceful shutdown

### DIFF
--- a/doc/vm-builder/README.md
+++ b/doc/vm-builder/README.md
@@ -1,0 +1,158 @@
+This README covers non-trivial implementation details of vm-builder / vm-builder-generic.
+
+What `vm-builder` Does
+======================
+
+vm-builder consumes a Docker image and turns it into a new docker image that runs the Docker container in a qemu VM.
+The OS in the VM is a minimal Alpine Linux / busybox environment.
+We use busybox `init` as the init system, configured through `/etc/inittab`.
+Likewise, the `poweroff` command is provided by busybox.
+
+We use a virtual CDROM to deliver the container launch command / entrypoint+arguments into the VM.
+The script is called `vmstarter.sh`.
+It is launched by the `vmstart` script which in turn is configured as a `respawn` service in the `inittab`.
+After `vmstarter.sh` exits, `vmstart` exits, and then gets restarted by `respawn`.
+This is a bit like docker in `--restart=always` mode.
+
+**Graceful shutdown** of the container-turned-VM is done through a virtual ACPI power button event.
+`acpid` handles the ACPI events and we configure it to call the busybox `poweroff` command.
+
+Busybox Init & Shutdown
+=======================
+
+The busybox `poweroff` command is integrated with the busybox `init` command as follows:
+
+0. Invoking busybox `poweroff` signals SIGUSR2 to the busybox `init` process.
+   The `init` process then does the following:
+1. Stop waiting for child processes to exit, and stop restarting child
+   processes that are marked `respawn` in the inittab.
+2. Run the `shutdown` directives in the inittab, in the order
+   in which they are specified.
+3. Send SIGTERM to all processes.
+4. Sleep 1 second.
+5. (minor details omitted)
+6. Call into kernel to poweroff.
+
+What follows are links to the busybox source code to "prove" the above.
+
+The `poweroff` command invoked by acpid is the busybox poweroff.
+At runtime, we take the following branch:
+https://github.com/brgl/busybox//blob/97e9a72c71d0238c9f241612ce4af923c16954c7/init/halt.c#L172-L173
+The `signals[which]` variable is `SIGUSR2` for the `poweroff` "applet".
+
+The code in `init` that handles `SIGUSR2` is the `check_delayed_signals` function that is called form inside `init`'s main loop.
+Code taken at runtime when `poweroff` signals `SIGUSR2`:
+
+* main loop calls `check_delayed_signals`: https://github.com/brgl/busybox//blob/f35ad3bd1287627fc6ca7cc9c1f48b186257dd87/init/init.c#L1219
+* check_delayed_signals detects `SIGUSR2` was signalled and calls `halt_reboot_pwoff`, this call will never return: https://github.com/brgl/busybox//blob/f35ad3bd1287627fc6ca7cc9c1f48b186257dd87/init/init.c#L996-L1005
+* it calls `run_shutdown_and_kill_processes` https://github.com/brgl/busybox//blob/f35ad3bd1287627fc6ca7cc9c1f48b186257dd87/init/init.c#L821
+* Runs `shutdown` actions in the inittab: https://github.com/brgl/busybox//blob/f35ad3bd1287627fc6ca7cc9c1f48b186257dd87/init/init.c#L751-L754
+* SIGTERM, pause, SIGKILL (not relevant for as because we take down postgres & compute_ctl through the shutdown action added in this PR: https://github.com/brgl/busybox//blob/f35ad3bd1287627fc6ca7cc9c1f48b186257dd87/init/init.c#L758-L766
+* Log shutdown and call into kernel: https://github.com/brgl/busybox//blob/f35ad3bd1287627fc6ca7cc9c1f48b186257dd87/init/init.c#L832-L833
+
+
+The Role Of `vm-builder` in Neon Autoscaling
+============================================
+
+In Neon's autoscaling, we use `vm-builder` to turn the `neon.git` compute Docker image into a VM.
+This means the `vmstarter.sh` will launch the `compute_ctl`, which in turn:
+1. waits for a spec
+2. gets basebackup from compute
+3. launches Postgres
+4. waits for Postgres to exit
+5. does a sync safekeepers
+6. exits itself.
+
+Neon Control Plane's `suspend_compute` relies on ACPI shutdown
+signalling for graceful shutdown of the NeonVM.
+If the NeonVM doesn't shut down timely, the pod that contains
+the qemu process gets SIGKILLed.
+
+What Happens On ACPI Shutdown
+=============================
+
+Here is a mermaid diagram of what happens during shutdown:
+
+
+```mermaid
+sequenceDiagram
+
+    participant k8s
+    participant vmrunner
+    participant Qemu
+    participant GuestKernel
+    participant acpid
+    participant poweroff
+    participant init
+    participant vmstart
+    participant vmshutdown
+    participant vmstart.allowed
+    participant flock as flock vmstart.lock
+    participant vmstarter.sh
+
+
+
+    GuestKernel->>init: start
+    init->>vmstart.allowed: create
+    activate vmstart.allowed
+
+    init->>vmstart: start
+    vmstart->>+flock: flock
+    flock->>vmstart.allowed: check existence
+    vmstart.allowed->>flock: .
+
+    flock->>+vmstarter.sh: start and wait
+    Note over vmstarter.sh: workload is running
+    Note over vmstarter.sh: exits for whatever reason
+    vmstarter.sh->>-flock: exits
+    flock->>-vmstart: exits
+    vmstart->>init: exits
+
+    Note over init: has not yet received shutdown request
+    Note over init: so, respawn
+
+    init->>vmstart: start
+    vmstart->>+flock: .
+    flock->>vmstart.allowed: check existence
+    vmstart.allowed->>flock: .
+
+    flock->>+vmstarter.sh: start and wait
+    Note over vmstarter.sh: workload is running
+
+    k8s-)vmrunner: SIGTERM
+    Note over k8s: will SIGKILL the container,<br/>including QEMU after timeout
+    vmrunner->>Qemu: send ACPI power button event
+    Qemu-)GuestKernel: ACPI power button event
+    GuestKernel->>acpid: .
+    acpid->>poweroff: .
+    poweroff->>init: SIGUSR2
+    Note over init: will no longer respawn<br/>but also not stop anything either
+    Note over init: run shutdown actions
+    init->>vmshutdown: start
+    vmshutdown->>vmstart.allowed: unlink
+    deactivate vmstart.allowed
+    Note over vmstart.allowed: vmstart's existence check<br/>will fail from here on
+    vmshutdown-)vmstarter.sh: signal to shut down,<br/>e.g., pg_ctl stop
+    Note over vmshutdown: wait until acquired flock,<br/>ensures vmstarter.sh is not running
+    vmshutdown-xflock: try acquire, still held
+    vmstarter.sh->>-flock: exits in<br/>response to signal
+    flock->>-vmstart: exits
+    vmshutdown->>+flock: try acquire, success
+    flock->>-vmshutdown: exit immediately
+    vmshutdown->>init: exit
+
+    Note over init: SIGTERM
+    Note over init: sleep 1 second
+    Note over init: kill everything
+    init->>GuestKernel: power off system call
+    Note over GuestKernel: powers off the machine
+```
+
+## TLA+ Model Of Shutdown
+
+The `./shutdown/shutdown.tla` model is a PlusCal specification of the shutdown procedure.
+
+TLC model checker configuration:
+
+* Check for deadlocks, there shouldn't be any.
+* Check temporal properties `TEMPORAL PROPERTIES` at the bottom of the spec.

--- a/doc/vm-builder/README.md
+++ b/doc/vm-builder/README.md
@@ -148,6 +148,33 @@ sequenceDiagram
     Note over GuestKernel: powers off the machine
 ```
 
+## How It Looks Inside The VM
+
+In a neon.git-compute-image-turned-vm image, running in staging, it looks like this
+
+```
+ps -eHo pid,command | cat
+...
+/neonvm/bin/sh /neonvm/bin/vmstart
+  149     flock /neonvm/vmstart.lock -c test -e /neonvm/vmstart.allowed && /neonvm/bin/su-exec postgres /neonvm/bin/sh /neonvm/bin/vmstarter.sh
+  150       /bin/sh -c test -e /neonvm/vmstart.allowed && /neonvm/bin/su-exec postgres /neonvm/bin/sh /neonvm/bin/vmstarter.sh
+  151         /neonvm/bin/sh /neonvm/bin/vmstarter.sh
+  152           /usr/local/bin/compute_ctl -D /var/db/postgres/compute/pgdata -b /usr/local/bin/postgres -C postgresql://cloud_admin@127.0.0.1/postgres?options=-c%20default_transaction_read_only=false --remote-ext-config {"bucket":"neon-dev-extensions-us-east-2","region":"us-east-2"} --compute-id compute-long-flower-94034268 --control-plane-uri http://neon-compute-api.aws.neon.build:9096
+  178             /usr/local/bin/postgres -D /var/db/postgres/compute/pgdata
+  182               postgres: checkpointer
+  183               postgres: background writer
+  185               postgres: walwriter
+  186               postgres: autovacuum launcher
+  187               postgres: pg_cron launcher
+  188               postgres: TimescaleDB Background Worker Launcher
+  189               postgres: WAL proposer streaming 0/1FD62B0
+  190               postgres: Local free space monitor
+  191               postgres: logical replication launcher
+  201               postgres: cloud_admin postgres 127.0.0.1(33860) idle
+  204               postgres: cloud_admin postgres ::1(53686) idle
+...
+```
+
 ## TLA+ Model Of Shutdown
 
 The `./shutdown/shutdown.tla` model is a PlusCal specification of the shutdown procedure.

--- a/doc/vm-builder/shutdown/shutdown.tla
+++ b/doc/vm-builder/shutdown/shutdown.tla
@@ -11,8 +11,15 @@ variables
     start_allowed_locked = FALSE, \* vmstart.lock
 
     \* ACPI & unix signal delivery, modeled through variables that are polled/await'ed
-    pg_ctl_stop_signal = FALSE,
     shutdown_signal_received = FALSE,
+    postgres_running = NULL,
+    postgres_spawn_pending = NULL,
+    postgres_shutdown_request_pending = NULL,
+    postgres_next_pids = <<1,2>>, \* bound number of crashes
+    postgres_exited_pids = {},
+
+    machine_running = TRUE,
+    vmshutdown_exited = FALSE,
 
     \* for temporal invariants
     vmstarter_sh_running = FALSE
@@ -29,11 +36,16 @@ begin
             skip;
         end either;
     end while;
+    wait_for_vmshutdown:
+        await vmshutdown_exited;
+    poweroff_to_kernel:
+        machine_running := FALSE;
 end process;
 
 fair process respawn_vmstart = "respawn_vmstart"
 variables
-    debug_shutdown_request_observed = TRUE
+    debug_shutdown_request_observed = TRUE,
+    respawn_current_postgres_pid = NULL
 begin
     init:
     while ~shutdown_signal_received do
@@ -43,15 +55,15 @@ begin
             start_allowed_locked := TRUE;
         respawn_check_start_allowed:
             if start_allowed then
+        respawn_launch_vmstarter_sh:
                 vmstarter_sh_running := TRUE;
-        respawn_wait_vmstart_exit:
-                either
-                    await pg_ctl_stop_signal;
-                or
-                    \* compute_ctl or postgres crashed or exited on its own
-                    \* TODO: ensure through temporal property that we can respawn it without a shutdown request
-                    skip;
-                end either;
+        respawn_vmstarter_launch_postgres:
+                postgres_spawn_pending := Head(postgres_next_pids);
+                respawn_current_postgres_pid := postgres_spawn_pending;
+                postgres_next_pids := Tail(postgres_next_pids);
+        respawn_vmstarter_wait_postgres:
+                await respawn_current_postgres_pid \in postgres_exited_pids;
+        respawn_vmstarter_sh_exits:
                 vmstarter_sh_running := FALSE;
             else
         respawn_not_allowed:
@@ -63,6 +75,39 @@ begin
 
 end process;
 
+fair process postgres = "postgres"
+begin
+    init:
+    while machine_running do
+        postgres_wait_to_be_launched:
+            await ~machine_running \/ postgres_spawn_pending /= NULL;
+            if ~machine_running then
+                goto halt;
+            else
+                postgres_running := postgres_spawn_pending;
+                postgres_spawn_pending := NULL;
+            end if;
+
+        postgres_await_shutdown_or_crash:
+
+            \* crash only if we have pids left
+            if Len(postgres_next_pids) > 0 then
+                either
+                    await postgres_shutdown_request_pending = postgres_running;
+                or
+                    \* crash
+                    skip;
+                end either;
+            else
+                await postgres_shutdown_request_pending = postgres_running;
+            end if;
+            postgres_exited_pids  := postgres_exited_pids \union {postgres_running};
+            postgres_running := NULL;
+    end while;
+    halt:
+       skip;
+end process;
+
 fair process vmshutdown = "vmshutdown"
 begin
     init:
@@ -71,39 +116,58 @@ begin
     vmshutdown_inhibit_new_starts:
         start_allowed := FALSE; \* rm the vmstart.allowed file on disk
     vmshutdown_pg_ctl_stop:
-        pg_ctl_stop_signal := TRUE;
-    vmshutdown_wait_existing_command:
+        \* the `if` models signal loss
+        if postgres_running /= NULL then
+            postgres_shutdown_request_pending := postgres_running;
+        end if;
+    vmshutdown_wait_for_running_command:
         await start_allowed_locked = FALSE; \* flock the file blocking exclusive; if an existing command is running, this waits until it's completed
     vmshutdown_done:
+        vmshutdown_exited := TRUE;
         skip;
 end process;
 
 
 end algorithm; *)
-\* BEGIN TRANSLATION (chksum(pcal) = "fe7b2e4d" /\ chksum(tla) = "799a3841")
-\* Label init of process init at line 24 col 5 changed to init_
-\* Label init of process respawn_vmstart at line 39 col 5 changed to init_r
-\* Label init of process vmshutdown at line 69 col 9 changed to init_v
-VARIABLES start_allowed, start_allowed_locked, pg_ctl_stop_signal,
-          shutdown_signal_received, vmstarter_sh_running, pc,
-          debug_shutdown_request_observed
+\* BEGIN TRANSLATION (chksum(pcal) = "48a3e1a5" /\ chksum(tla) = "2cd9490d")
+\* Label init of process init at line 31 col 5 changed to init_
+\* Label init of process respawn_vmstart at line 51 col 5 changed to init_r
+\* Label init of process postgres at line 81 col 5 changed to init_p
+\* Label init of process vmshutdown at line 114 col 9 changed to init_v
+VARIABLES start_allowed, start_allowed_locked, shutdown_signal_received,
+          postgres_running, postgres_spawn_pending,
+          postgres_shutdown_request_pending, postgres_next_pids,
+          postgres_exited_pids, machine_running, vmshutdown_exited,
+          vmstarter_sh_running, pc, debug_shutdown_request_observed,
+          respawn_current_postgres_pid
 
-vars == << start_allowed, start_allowed_locked, pg_ctl_stop_signal,
-           shutdown_signal_received, vmstarter_sh_running, pc,
-           debug_shutdown_request_observed >>
+vars == << start_allowed, start_allowed_locked, shutdown_signal_received,
+           postgres_running, postgres_spawn_pending,
+           postgres_shutdown_request_pending, postgres_next_pids,
+           postgres_exited_pids, machine_running, vmshutdown_exited,
+           vmstarter_sh_running, pc, debug_shutdown_request_observed,
+           respawn_current_postgres_pid >>
 
-ProcSet == {"init"} \cup {"respawn_vmstart"} \cup {"vmshutdown"}
+ProcSet == {"init"} \cup {"respawn_vmstart"} \cup {"postgres"} \cup {"vmshutdown"}
 
 Init == (* Global variables *)
         /\ start_allowed = TRUE
         /\ start_allowed_locked = FALSE
-        /\ pg_ctl_stop_signal = FALSE
         /\ shutdown_signal_received = FALSE
+        /\ postgres_running = NULL
+        /\ postgres_spawn_pending = NULL
+        /\ postgres_shutdown_request_pending = NULL
+        /\ postgres_next_pids = <<1,2>>
+        /\ postgres_exited_pids = {}
+        /\ machine_running = TRUE
+        /\ vmshutdown_exited = FALSE
         /\ vmstarter_sh_running = FALSE
         (* Process respawn_vmstart *)
         /\ debug_shutdown_request_observed = TRUE
+        /\ respawn_current_postgres_pid = NULL
         /\ pc = [self \in ProcSet |-> CASE self = "init" -> "init_"
                                         [] self = "respawn_vmstart" -> "init_r"
+                                        [] self = "postgres" -> "init_p"
                                         [] self = "vmshutdown" -> "init_v"]
 
 init_ == /\ pc["init"] = "init_"
@@ -112,134 +176,349 @@ init_ == /\ pc["init"] = "init_"
                        \/ /\ TRUE
                           /\ UNCHANGED shutdown_signal_received
                     /\ pc' = [pc EXCEPT !["init"] = "init_"]
-               ELSE /\ pc' = [pc EXCEPT !["init"] = "Done"]
+               ELSE /\ pc' = [pc EXCEPT !["init"] = "wait_for_vmshutdown"]
                     /\ UNCHANGED shutdown_signal_received
-         /\ UNCHANGED << start_allowed, start_allowed_locked,
-                         pg_ctl_stop_signal, vmstarter_sh_running,
-                         debug_shutdown_request_observed >>
+         /\ UNCHANGED << start_allowed, start_allowed_locked, postgres_running,
+                         postgres_spawn_pending,
+                         postgres_shutdown_request_pending, postgres_next_pids,
+                         postgres_exited_pids, machine_running,
+                         vmshutdown_exited, vmstarter_sh_running,
+                         debug_shutdown_request_observed,
+                         respawn_current_postgres_pid >>
 
-init == init_
+wait_for_vmshutdown == /\ pc["init"] = "wait_for_vmshutdown"
+                       /\ vmshutdown_exited
+                       /\ pc' = [pc EXCEPT !["init"] = "poweroff_to_kernel"]
+                       /\ UNCHANGED << start_allowed, start_allowed_locked,
+                                       shutdown_signal_received,
+                                       postgres_running,
+                                       postgres_spawn_pending,
+                                       postgres_shutdown_request_pending,
+                                       postgres_next_pids,
+                                       postgres_exited_pids, machine_running,
+                                       vmshutdown_exited, vmstarter_sh_running,
+                                       debug_shutdown_request_observed,
+                                       respawn_current_postgres_pid >>
+
+poweroff_to_kernel == /\ pc["init"] = "poweroff_to_kernel"
+                      /\ machine_running' = FALSE
+                      /\ pc' = [pc EXCEPT !["init"] = "Done"]
+                      /\ UNCHANGED << start_allowed, start_allowed_locked,
+                                      shutdown_signal_received,
+                                      postgres_running, postgres_spawn_pending,
+                                      postgres_shutdown_request_pending,
+                                      postgres_next_pids, postgres_exited_pids,
+                                      vmshutdown_exited, vmstarter_sh_running,
+                                      debug_shutdown_request_observed,
+                                      respawn_current_postgres_pid >>
+
+init == init_ \/ wait_for_vmshutdown \/ poweroff_to_kernel
 
 init_r == /\ pc["respawn_vmstart"] = "init_r"
           /\ IF ~shutdown_signal_received
                 THEN /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_flock_enter"]
                 ELSE /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "Done"]
           /\ UNCHANGED << start_allowed, start_allowed_locked,
-                          pg_ctl_stop_signal, shutdown_signal_received,
+                          shutdown_signal_received, postgres_running,
+                          postgres_spawn_pending,
+                          postgres_shutdown_request_pending,
+                          postgres_next_pids, postgres_exited_pids,
+                          machine_running, vmshutdown_exited,
                           vmstarter_sh_running,
-                          debug_shutdown_request_observed >>
+                          debug_shutdown_request_observed,
+                          respawn_current_postgres_pid >>
 
 respawn_flock_enter == /\ pc["respawn_vmstart"] = "respawn_flock_enter"
                        /\ start_allowed_locked = FALSE
                        /\ start_allowed_locked' = TRUE
                        /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_check_start_allowed"]
-                       /\ UNCHANGED << start_allowed, pg_ctl_stop_signal,
-                                       shutdown_signal_received,
-                                       vmstarter_sh_running,
-                                       debug_shutdown_request_observed >>
+                       /\ UNCHANGED << start_allowed, shutdown_signal_received,
+                                       postgres_running,
+                                       postgres_spawn_pending,
+                                       postgres_shutdown_request_pending,
+                                       postgres_next_pids,
+                                       postgres_exited_pids, machine_running,
+                                       vmshutdown_exited, vmstarter_sh_running,
+                                       debug_shutdown_request_observed,
+                                       respawn_current_postgres_pid >>
 
 respawn_check_start_allowed == /\ pc["respawn_vmstart"] = "respawn_check_start_allowed"
                                /\ IF start_allowed
-                                     THEN /\ vmstarter_sh_running' = TRUE
-                                          /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_wait_vmstart_exit"]
+                                     THEN /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_launch_vmstarter_sh"]
                                      ELSE /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_not_allowed"]
-                                          /\ UNCHANGED vmstarter_sh_running
                                /\ UNCHANGED << start_allowed,
                                                start_allowed_locked,
-                                               pg_ctl_stop_signal,
                                                shutdown_signal_received,
-                                               debug_shutdown_request_observed >>
+                                               postgres_running,
+                                               postgres_spawn_pending,
+                                               postgres_shutdown_request_pending,
+                                               postgres_next_pids,
+                                               postgres_exited_pids,
+                                               machine_running,
+                                               vmshutdown_exited,
+                                               vmstarter_sh_running,
+                                               debug_shutdown_request_observed,
+                                               respawn_current_postgres_pid >>
 
-respawn_wait_vmstart_exit == /\ pc["respawn_vmstart"] = "respawn_wait_vmstart_exit"
-                             /\ \/ /\ pg_ctl_stop_signal
-                                \/ /\ TRUE
-                             /\ vmstarter_sh_running' = FALSE
-                             /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_flock_exit"]
-                             /\ UNCHANGED << start_allowed,
-                                             start_allowed_locked,
-                                             pg_ctl_stop_signal,
-                                             shutdown_signal_received,
-                                             debug_shutdown_request_observed >>
+respawn_launch_vmstarter_sh == /\ pc["respawn_vmstart"] = "respawn_launch_vmstarter_sh"
+                               /\ vmstarter_sh_running' = TRUE
+                               /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_vmstarter_launch_postgres"]
+                               /\ UNCHANGED << start_allowed,
+                                               start_allowed_locked,
+                                               shutdown_signal_received,
+                                               postgres_running,
+                                               postgres_spawn_pending,
+                                               postgres_shutdown_request_pending,
+                                               postgres_next_pids,
+                                               postgres_exited_pids,
+                                               machine_running,
+                                               vmshutdown_exited,
+                                               debug_shutdown_request_observed,
+                                               respawn_current_postgres_pid >>
+
+respawn_vmstarter_launch_postgres == /\ pc["respawn_vmstart"] = "respawn_vmstarter_launch_postgres"
+                                     /\ postgres_spawn_pending' = Head(postgres_next_pids)
+                                     /\ respawn_current_postgres_pid' = postgres_spawn_pending'
+                                     /\ postgres_next_pids' = Tail(postgres_next_pids)
+                                     /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_vmstarter_wait_postgres"]
+                                     /\ UNCHANGED << start_allowed,
+                                                     start_allowed_locked,
+                                                     shutdown_signal_received,
+                                                     postgres_running,
+                                                     postgres_shutdown_request_pending,
+                                                     postgres_exited_pids,
+                                                     machine_running,
+                                                     vmshutdown_exited,
+                                                     vmstarter_sh_running,
+                                                     debug_shutdown_request_observed >>
+
+respawn_vmstarter_wait_postgres == /\ pc["respawn_vmstart"] = "respawn_vmstarter_wait_postgres"
+                                   /\ respawn_current_postgres_pid \in postgres_exited_pids
+                                   /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_vmstarter_sh_exits"]
+                                   /\ UNCHANGED << start_allowed,
+                                                   start_allowed_locked,
+                                                   shutdown_signal_received,
+                                                   postgres_running,
+                                                   postgres_spawn_pending,
+                                                   postgres_shutdown_request_pending,
+                                                   postgres_next_pids,
+                                                   postgres_exited_pids,
+                                                   machine_running,
+                                                   vmshutdown_exited,
+                                                   vmstarter_sh_running,
+                                                   debug_shutdown_request_observed,
+                                                   respawn_current_postgres_pid >>
+
+respawn_vmstarter_sh_exits == /\ pc["respawn_vmstart"] = "respawn_vmstarter_sh_exits"
+                              /\ vmstarter_sh_running' = FALSE
+                              /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_flock_exit"]
+                              /\ UNCHANGED << start_allowed,
+                                              start_allowed_locked,
+                                              shutdown_signal_received,
+                                              postgres_running,
+                                              postgres_spawn_pending,
+                                              postgres_shutdown_request_pending,
+                                              postgres_next_pids,
+                                              postgres_exited_pids,
+                                              machine_running,
+                                              vmshutdown_exited,
+                                              debug_shutdown_request_observed,
+                                              respawn_current_postgres_pid >>
 
 respawn_not_allowed == /\ pc["respawn_vmstart"] = "respawn_not_allowed"
                        /\ debug_shutdown_request_observed' = TRUE
                        /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_flock_exit"]
                        /\ UNCHANGED << start_allowed, start_allowed_locked,
-                                       pg_ctl_stop_signal,
                                        shutdown_signal_received,
-                                       vmstarter_sh_running >>
+                                       postgres_running,
+                                       postgres_spawn_pending,
+                                       postgres_shutdown_request_pending,
+                                       postgres_next_pids,
+                                       postgres_exited_pids, machine_running,
+                                       vmshutdown_exited, vmstarter_sh_running,
+                                       respawn_current_postgres_pid >>
 
 respawn_flock_exit == /\ pc["respawn_vmstart"] = "respawn_flock_exit"
                       /\ start_allowed_locked' = FALSE
                       /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "init_r"]
-                      /\ UNCHANGED << start_allowed, pg_ctl_stop_signal,
-                                      shutdown_signal_received,
+                      /\ UNCHANGED << start_allowed, shutdown_signal_received,
+                                      postgres_running, postgres_spawn_pending,
+                                      postgres_shutdown_request_pending,
+                                      postgres_next_pids, postgres_exited_pids,
+                                      machine_running, vmshutdown_exited,
                                       vmstarter_sh_running,
-                                      debug_shutdown_request_observed >>
+                                      debug_shutdown_request_observed,
+                                      respawn_current_postgres_pid >>
 
 respawn_vmstart == init_r \/ respawn_flock_enter
                       \/ respawn_check_start_allowed
-                      \/ respawn_wait_vmstart_exit \/ respawn_not_allowed
+                      \/ respawn_launch_vmstarter_sh
+                      \/ respawn_vmstarter_launch_postgres
+                      \/ respawn_vmstarter_wait_postgres
+                      \/ respawn_vmstarter_sh_exits \/ respawn_not_allowed
                       \/ respawn_flock_exit
+
+init_p == /\ pc["postgres"] = "init_p"
+          /\ IF machine_running
+                THEN /\ pc' = [pc EXCEPT !["postgres"] = "postgres_wait_to_be_launched"]
+                ELSE /\ pc' = [pc EXCEPT !["postgres"] = "halt"]
+          /\ UNCHANGED << start_allowed, start_allowed_locked,
+                          shutdown_signal_received, postgres_running,
+                          postgres_spawn_pending,
+                          postgres_shutdown_request_pending,
+                          postgres_next_pids, postgres_exited_pids,
+                          machine_running, vmshutdown_exited,
+                          vmstarter_sh_running,
+                          debug_shutdown_request_observed,
+                          respawn_current_postgres_pid >>
+
+postgres_wait_to_be_launched == /\ pc["postgres"] = "postgres_wait_to_be_launched"
+                                /\ ~machine_running \/ postgres_spawn_pending /= NULL
+                                /\ IF ~machine_running
+                                      THEN /\ pc' = [pc EXCEPT !["postgres"] = "halt"]
+                                           /\ UNCHANGED << postgres_running,
+                                                           postgres_spawn_pending >>
+                                      ELSE /\ postgres_running' = postgres_spawn_pending
+                                           /\ postgres_spawn_pending' = NULL
+                                           /\ pc' = [pc EXCEPT !["postgres"] = "postgres_await_shutdown_or_crash"]
+                                /\ UNCHANGED << start_allowed,
+                                                start_allowed_locked,
+                                                shutdown_signal_received,
+                                                postgres_shutdown_request_pending,
+                                                postgres_next_pids,
+                                                postgres_exited_pids,
+                                                machine_running,
+                                                vmshutdown_exited,
+                                                vmstarter_sh_running,
+                                                debug_shutdown_request_observed,
+                                                respawn_current_postgres_pid >>
+
+postgres_await_shutdown_or_crash == /\ pc["postgres"] = "postgres_await_shutdown_or_crash"
+                                    /\ IF Len(postgres_next_pids) > 0
+                                          THEN /\ \/ /\ postgres_shutdown_request_pending = postgres_running
+                                                  \/ /\ TRUE
+                                          ELSE /\ postgres_shutdown_request_pending = postgres_running
+                                    /\ postgres_exited_pids' = (postgres_exited_pids \union {postgres_running})
+                                    /\ postgres_running' = NULL
+                                    /\ pc' = [pc EXCEPT !["postgres"] = "init_p"]
+                                    /\ UNCHANGED << start_allowed,
+                                                    start_allowed_locked,
+                                                    shutdown_signal_received,
+                                                    postgres_spawn_pending,
+                                                    postgres_shutdown_request_pending,
+                                                    postgres_next_pids,
+                                                    machine_running,
+                                                    vmshutdown_exited,
+                                                    vmstarter_sh_running,
+                                                    debug_shutdown_request_observed,
+                                                    respawn_current_postgres_pid >>
+
+halt == /\ pc["postgres"] = "halt"
+        /\ TRUE
+        /\ pc' = [pc EXCEPT !["postgres"] = "Done"]
+        /\ UNCHANGED << start_allowed, start_allowed_locked,
+                        shutdown_signal_received, postgres_running,
+                        postgres_spawn_pending,
+                        postgres_shutdown_request_pending, postgres_next_pids,
+                        postgres_exited_pids, machine_running,
+                        vmshutdown_exited, vmstarter_sh_running,
+                        debug_shutdown_request_observed,
+                        respawn_current_postgres_pid >>
+
+postgres == init_p \/ postgres_wait_to_be_launched
+               \/ postgres_await_shutdown_or_crash \/ halt
 
 init_v == /\ pc["vmshutdown"] = "init_v"
           /\ shutdown_signal_received
           /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_inhibit_new_starts"]
           /\ UNCHANGED << start_allowed, start_allowed_locked,
-                          pg_ctl_stop_signal, shutdown_signal_received,
+                          shutdown_signal_received, postgres_running,
+                          postgres_spawn_pending,
+                          postgres_shutdown_request_pending,
+                          postgres_next_pids, postgres_exited_pids,
+                          machine_running, vmshutdown_exited,
                           vmstarter_sh_running,
-                          debug_shutdown_request_observed >>
+                          debug_shutdown_request_observed,
+                          respawn_current_postgres_pid >>
 
 vmshutdown_inhibit_new_starts == /\ pc["vmshutdown"] = "vmshutdown_inhibit_new_starts"
                                  /\ start_allowed' = FALSE
                                  /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_pg_ctl_stop"]
                                  /\ UNCHANGED << start_allowed_locked,
-                                                 pg_ctl_stop_signal,
                                                  shutdown_signal_received,
+                                                 postgres_running,
+                                                 postgres_spawn_pending,
+                                                 postgres_shutdown_request_pending,
+                                                 postgres_next_pids,
+                                                 postgres_exited_pids,
+                                                 machine_running,
+                                                 vmshutdown_exited,
                                                  vmstarter_sh_running,
-                                                 debug_shutdown_request_observed >>
+                                                 debug_shutdown_request_observed,
+                                                 respawn_current_postgres_pid >>
 
 vmshutdown_pg_ctl_stop == /\ pc["vmshutdown"] = "vmshutdown_pg_ctl_stop"
-                          /\ pg_ctl_stop_signal' = TRUE
-                          /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_wait_existing_command"]
+                          /\ IF postgres_running /= NULL
+                                THEN /\ postgres_shutdown_request_pending' = postgres_running
+                                ELSE /\ TRUE
+                                     /\ UNCHANGED postgres_shutdown_request_pending
+                          /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_wait_for_running_command"]
                           /\ UNCHANGED << start_allowed, start_allowed_locked,
                                           shutdown_signal_received,
+                                          postgres_running,
+                                          postgres_spawn_pending,
+                                          postgres_next_pids,
+                                          postgres_exited_pids,
+                                          machine_running, vmshutdown_exited,
                                           vmstarter_sh_running,
-                                          debug_shutdown_request_observed >>
+                                          debug_shutdown_request_observed,
+                                          respawn_current_postgres_pid >>
 
-vmshutdown_wait_existing_command == /\ pc["vmshutdown"] = "vmshutdown_wait_existing_command"
-                                    /\ start_allowed_locked = FALSE
-                                    /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_done"]
-                                    /\ UNCHANGED << start_allowed,
-                                                    start_allowed_locked,
-                                                    pg_ctl_stop_signal,
-                                                    shutdown_signal_received,
-                                                    vmstarter_sh_running,
-                                                    debug_shutdown_request_observed >>
+vmshutdown_wait_for_running_command == /\ pc["vmshutdown"] = "vmshutdown_wait_for_running_command"
+                                       /\ start_allowed_locked = FALSE
+                                       /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_done"]
+                                       /\ UNCHANGED << start_allowed,
+                                                       start_allowed_locked,
+                                                       shutdown_signal_received,
+                                                       postgres_running,
+                                                       postgres_spawn_pending,
+                                                       postgres_shutdown_request_pending,
+                                                       postgres_next_pids,
+                                                       postgres_exited_pids,
+                                                       machine_running,
+                                                       vmshutdown_exited,
+                                                       vmstarter_sh_running,
+                                                       debug_shutdown_request_observed,
+                                                       respawn_current_postgres_pid >>
 
 vmshutdown_done == /\ pc["vmshutdown"] = "vmshutdown_done"
+                   /\ vmshutdown_exited' = TRUE
                    /\ TRUE
                    /\ pc' = [pc EXCEPT !["vmshutdown"] = "Done"]
                    /\ UNCHANGED << start_allowed, start_allowed_locked,
-                                   pg_ctl_stop_signal,
-                                   shutdown_signal_received,
-                                   vmstarter_sh_running,
-                                   debug_shutdown_request_observed >>
+                                   shutdown_signal_received, postgres_running,
+                                   postgres_spawn_pending,
+                                   postgres_shutdown_request_pending,
+                                   postgres_next_pids, postgres_exited_pids,
+                                   machine_running, vmstarter_sh_running,
+                                   debug_shutdown_request_observed,
+                                   respawn_current_postgres_pid >>
 
 vmshutdown == init_v \/ vmshutdown_inhibit_new_starts
                  \/ vmshutdown_pg_ctl_stop
-                 \/ vmshutdown_wait_existing_command \/ vmshutdown_done
+                 \/ vmshutdown_wait_for_running_command \/ vmshutdown_done
 
 (* Allow infinite stuttering to prevent deadlock on termination. *)
 Terminating == /\ \A self \in ProcSet: pc[self] = "Done"
                /\ UNCHANGED vars
 
-Next == init \/ respawn_vmstart \/ vmshutdown
+Next == init \/ respawn_vmstart \/ postgres \/ vmshutdown
            \/ Terminating
 
 Spec == /\ Init /\ [][Next]_vars
         /\ WF_vars(init)
         /\ WF_vars(respawn_vmstart)
+        /\ WF_vars(postgres)
         /\ WF_vars(vmshutdown)
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
@@ -254,5 +533,5 @@ RespawnBeforeShutdownCanRestartWithoutPendingShutdown == TRUE \* TODO: how to ex
 
 =============================================================================
 \* Modification History
-\* Last modified Mon Sep 25 09:22:40 CEST 2023 by cs
+\* Last modified Mon Sep 25 10:28:09 CEST 2023 by cs
 \* Created Sun Sep 24 12:17:50 CEST 2023 by cs

--- a/doc/vm-builder/shutdown/shutdown.tla
+++ b/doc/vm-builder/shutdown/shutdown.tla
@@ -44,7 +44,6 @@ end process;
 
 fair process respawn_vmstart = "respawn_vmstart"
 variables
-    debug_shutdown_request_observed = TRUE,
     respawn_current_postgres_pid = NULL
 begin
     init:
@@ -67,7 +66,7 @@ begin
                 vmstarter_sh_running := FALSE;
             else
         respawn_not_allowed:
-                debug_shutdown_request_observed := TRUE;
+                skip;
             end if;
         respawn_flock_exit:
             start_allowed_locked := FALSE;
@@ -129,24 +128,22 @@ end process;
 
 
 end algorithm; *)
-\* BEGIN TRANSLATION (chksum(pcal) = "48a3e1a5" /\ chksum(tla) = "2cd9490d")
+\* BEGIN TRANSLATION (chksum(pcal) = "cef566c4" /\ chksum(tla) = "a118bce0")
 \* Label init of process init at line 31 col 5 changed to init_
-\* Label init of process respawn_vmstart at line 51 col 5 changed to init_r
-\* Label init of process postgres at line 81 col 5 changed to init_p
-\* Label init of process vmshutdown at line 114 col 9 changed to init_v
+\* Label init of process respawn_vmstart at line 50 col 5 changed to init_r
+\* Label init of process postgres at line 80 col 5 changed to init_p
+\* Label init of process vmshutdown at line 113 col 9 changed to init_v
 VARIABLES start_allowed, start_allowed_locked, shutdown_signal_received,
           postgres_running, postgres_spawn_pending,
           postgres_shutdown_request_pending, postgres_next_pids,
           postgres_exited_pids, machine_running, vmshutdown_exited,
-          vmstarter_sh_running, pc, debug_shutdown_request_observed,
-          respawn_current_postgres_pid
+          vmstarter_sh_running, pc, respawn_current_postgres_pid
 
 vars == << start_allowed, start_allowed_locked, shutdown_signal_received,
            postgres_running, postgres_spawn_pending,
            postgres_shutdown_request_pending, postgres_next_pids,
            postgres_exited_pids, machine_running, vmshutdown_exited,
-           vmstarter_sh_running, pc, debug_shutdown_request_observed,
-           respawn_current_postgres_pid >>
+           vmstarter_sh_running, pc, respawn_current_postgres_pid >>
 
 ProcSet == {"init"} \cup {"respawn_vmstart"} \cup {"postgres"} \cup {"vmshutdown"}
 
@@ -163,7 +160,6 @@ Init == (* Global variables *)
         /\ vmshutdown_exited = FALSE
         /\ vmstarter_sh_running = FALSE
         (* Process respawn_vmstart *)
-        /\ debug_shutdown_request_observed = TRUE
         /\ respawn_current_postgres_pid = NULL
         /\ pc = [self \in ProcSet |-> CASE self = "init" -> "init_"
                                         [] self = "respawn_vmstart" -> "init_r"
@@ -183,7 +179,6 @@ init_ == /\ pc["init"] = "init_"
                          postgres_shutdown_request_pending, postgres_next_pids,
                          postgres_exited_pids, machine_running,
                          vmshutdown_exited, vmstarter_sh_running,
-                         debug_shutdown_request_observed,
                          respawn_current_postgres_pid >>
 
 wait_for_vmshutdown == /\ pc["init"] = "wait_for_vmshutdown"
@@ -197,7 +192,6 @@ wait_for_vmshutdown == /\ pc["init"] = "wait_for_vmshutdown"
                                        postgres_next_pids,
                                        postgres_exited_pids, machine_running,
                                        vmshutdown_exited, vmstarter_sh_running,
-                                       debug_shutdown_request_observed,
                                        respawn_current_postgres_pid >>
 
 poweroff_to_kernel == /\ pc["init"] = "poweroff_to_kernel"
@@ -209,7 +203,6 @@ poweroff_to_kernel == /\ pc["init"] = "poweroff_to_kernel"
                                       postgres_shutdown_request_pending,
                                       postgres_next_pids, postgres_exited_pids,
                                       vmshutdown_exited, vmstarter_sh_running,
-                                      debug_shutdown_request_observed,
                                       respawn_current_postgres_pid >>
 
 init == init_ \/ wait_for_vmshutdown \/ poweroff_to_kernel
@@ -224,9 +217,7 @@ init_r == /\ pc["respawn_vmstart"] = "init_r"
                           postgres_shutdown_request_pending,
                           postgres_next_pids, postgres_exited_pids,
                           machine_running, vmshutdown_exited,
-                          vmstarter_sh_running,
-                          debug_shutdown_request_observed,
-                          respawn_current_postgres_pid >>
+                          vmstarter_sh_running, respawn_current_postgres_pid >>
 
 respawn_flock_enter == /\ pc["respawn_vmstart"] = "respawn_flock_enter"
                        /\ start_allowed_locked = FALSE
@@ -239,7 +230,6 @@ respawn_flock_enter == /\ pc["respawn_vmstart"] = "respawn_flock_enter"
                                        postgres_next_pids,
                                        postgres_exited_pids, machine_running,
                                        vmshutdown_exited, vmstarter_sh_running,
-                                       debug_shutdown_request_observed,
                                        respawn_current_postgres_pid >>
 
 respawn_check_start_allowed == /\ pc["respawn_vmstart"] = "respawn_check_start_allowed"
@@ -257,7 +247,6 @@ respawn_check_start_allowed == /\ pc["respawn_vmstart"] = "respawn_check_start_a
                                                machine_running,
                                                vmshutdown_exited,
                                                vmstarter_sh_running,
-                                               debug_shutdown_request_observed,
                                                respawn_current_postgres_pid >>
 
 respawn_launch_vmstarter_sh == /\ pc["respawn_vmstart"] = "respawn_launch_vmstarter_sh"
@@ -273,7 +262,6 @@ respawn_launch_vmstarter_sh == /\ pc["respawn_vmstart"] = "respawn_launch_vmstar
                                                postgres_exited_pids,
                                                machine_running,
                                                vmshutdown_exited,
-                                               debug_shutdown_request_observed,
                                                respawn_current_postgres_pid >>
 
 respawn_vmstarter_launch_postgres == /\ pc["respawn_vmstart"] = "respawn_vmstarter_launch_postgres"
@@ -289,8 +277,7 @@ respawn_vmstarter_launch_postgres == /\ pc["respawn_vmstart"] = "respawn_vmstart
                                                      postgres_exited_pids,
                                                      machine_running,
                                                      vmshutdown_exited,
-                                                     vmstarter_sh_running,
-                                                     debug_shutdown_request_observed >>
+                                                     vmstarter_sh_running >>
 
 respawn_vmstarter_wait_postgres == /\ pc["respawn_vmstart"] = "respawn_vmstarter_wait_postgres"
                                    /\ respawn_current_postgres_pid \in postgres_exited_pids
@@ -306,7 +293,6 @@ respawn_vmstarter_wait_postgres == /\ pc["respawn_vmstart"] = "respawn_vmstarter
                                                    machine_running,
                                                    vmshutdown_exited,
                                                    vmstarter_sh_running,
-                                                   debug_shutdown_request_observed,
                                                    respawn_current_postgres_pid >>
 
 respawn_vmstarter_sh_exits == /\ pc["respawn_vmstart"] = "respawn_vmstarter_sh_exits"
@@ -322,11 +308,10 @@ respawn_vmstarter_sh_exits == /\ pc["respawn_vmstart"] = "respawn_vmstarter_sh_e
                                               postgres_exited_pids,
                                               machine_running,
                                               vmshutdown_exited,
-                                              debug_shutdown_request_observed,
                                               respawn_current_postgres_pid >>
 
 respawn_not_allowed == /\ pc["respawn_vmstart"] = "respawn_not_allowed"
-                       /\ debug_shutdown_request_observed' = TRUE
+                       /\ TRUE
                        /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_flock_exit"]
                        /\ UNCHANGED << start_allowed, start_allowed_locked,
                                        shutdown_signal_received,
@@ -347,7 +332,6 @@ respawn_flock_exit == /\ pc["respawn_vmstart"] = "respawn_flock_exit"
                                       postgres_next_pids, postgres_exited_pids,
                                       machine_running, vmshutdown_exited,
                                       vmstarter_sh_running,
-                                      debug_shutdown_request_observed,
                                       respawn_current_postgres_pid >>
 
 respawn_vmstart == init_r \/ respawn_flock_enter
@@ -368,9 +352,7 @@ init_p == /\ pc["postgres"] = "init_p"
                           postgres_shutdown_request_pending,
                           postgres_next_pids, postgres_exited_pids,
                           machine_running, vmshutdown_exited,
-                          vmstarter_sh_running,
-                          debug_shutdown_request_observed,
-                          respawn_current_postgres_pid >>
+                          vmstarter_sh_running, respawn_current_postgres_pid >>
 
 postgres_wait_to_be_launched == /\ pc["postgres"] = "postgres_wait_to_be_launched"
                                 /\ ~machine_running \/ postgres_spawn_pending /= NULL
@@ -390,7 +372,6 @@ postgres_wait_to_be_launched == /\ pc["postgres"] = "postgres_wait_to_be_launche
                                                 machine_running,
                                                 vmshutdown_exited,
                                                 vmstarter_sh_running,
-                                                debug_shutdown_request_observed,
                                                 respawn_current_postgres_pid >>
 
 postgres_await_shutdown_or_crash == /\ pc["postgres"] = "postgres_await_shutdown_or_crash"
@@ -410,7 +391,6 @@ postgres_await_shutdown_or_crash == /\ pc["postgres"] = "postgres_await_shutdown
                                                     machine_running,
                                                     vmshutdown_exited,
                                                     vmstarter_sh_running,
-                                                    debug_shutdown_request_observed,
                                                     respawn_current_postgres_pid >>
 
 halt == /\ pc["postgres"] = "halt"
@@ -422,7 +402,6 @@ halt == /\ pc["postgres"] = "halt"
                         postgres_shutdown_request_pending, postgres_next_pids,
                         postgres_exited_pids, machine_running,
                         vmshutdown_exited, vmstarter_sh_running,
-                        debug_shutdown_request_observed,
                         respawn_current_postgres_pid >>
 
 postgres == init_p \/ postgres_wait_to_be_launched
@@ -437,9 +416,7 @@ init_v == /\ pc["vmshutdown"] = "init_v"
                           postgres_shutdown_request_pending,
                           postgres_next_pids, postgres_exited_pids,
                           machine_running, vmshutdown_exited,
-                          vmstarter_sh_running,
-                          debug_shutdown_request_observed,
-                          respawn_current_postgres_pid >>
+                          vmstarter_sh_running, respawn_current_postgres_pid >>
 
 vmshutdown_inhibit_new_starts == /\ pc["vmshutdown"] = "vmshutdown_inhibit_new_starts"
                                  /\ start_allowed' = FALSE
@@ -454,7 +431,6 @@ vmshutdown_inhibit_new_starts == /\ pc["vmshutdown"] = "vmshutdown_inhibit_new_s
                                                  machine_running,
                                                  vmshutdown_exited,
                                                  vmstarter_sh_running,
-                                                 debug_shutdown_request_observed,
                                                  respawn_current_postgres_pid >>
 
 vmshutdown_pg_ctl_stop == /\ pc["vmshutdown"] = "vmshutdown_pg_ctl_stop"
@@ -471,7 +447,6 @@ vmshutdown_pg_ctl_stop == /\ pc["vmshutdown"] = "vmshutdown_pg_ctl_stop"
                                           postgres_exited_pids,
                                           machine_running, vmshutdown_exited,
                                           vmstarter_sh_running,
-                                          debug_shutdown_request_observed,
                                           respawn_current_postgres_pid >>
 
 vmshutdown_wait_for_running_command == /\ pc["vmshutdown"] = "vmshutdown_wait_for_running_command"
@@ -488,7 +463,6 @@ vmshutdown_wait_for_running_command == /\ pc["vmshutdown"] = "vmshutdown_wait_fo
                                                        machine_running,
                                                        vmshutdown_exited,
                                                        vmstarter_sh_running,
-                                                       debug_shutdown_request_observed,
                                                        respawn_current_postgres_pid >>
 
 vmshutdown_done == /\ pc["vmshutdown"] = "vmshutdown_done"
@@ -501,7 +475,6 @@ vmshutdown_done == /\ pc["vmshutdown"] = "vmshutdown_done"
                                    postgres_shutdown_request_pending,
                                    postgres_next_pids, postgres_exited_pids,
                                    machine_running, vmstarter_sh_running,
-                                   debug_shutdown_request_observed,
                                    respawn_current_postgres_pid >>
 
 vmshutdown == init_v \/ vmshutdown_inhibit_new_starts
@@ -533,5 +506,5 @@ RespawnBeforeShutdownCanRestartWithoutPendingShutdown == TRUE \* TODO: how to ex
 
 =============================================================================
 \* Modification History
-\* Last modified Mon Sep 25 10:28:09 CEST 2023 by cs
+\* Last modified Mon Sep 25 11:17:51 CEST 2023 by cs
 \* Created Sun Sep 24 12:17:50 CEST 2023 by cs

--- a/doc/vm-builder/shutdown/shutdown.tla
+++ b/doc/vm-builder/shutdown/shutdown.tla
@@ -1,0 +1,236 @@
+----------------------------- MODULE vmshutdown -----------------------------
+
+EXTENDS Sequences, Integers, TLC
+
+CONSTANT NULL
+
+(*--algorithm vmshutdown
+
+variables
+    start_allowed = TRUE, \* vmstart.allowed
+    start_allowed_locked = FALSE, \* vmstart.lock
+
+    \* ACPI & unix signal delivery, modeled through variables that are polled/await'ed
+    pg_ctl_stop_signal = FALSE,
+    shutdown_signal_received = FALSE,
+
+    \* for temporal invariants
+    vmstart_running = FALSE
+
+
+fair process init = "init"
+begin
+    init:
+    while ~shutdown_signal_received do
+        either
+            \* disable respawn loop & run vmshutdown
+            shutdown_signal_received := TRUE;
+        or
+            skip;
+        end either;
+    end while;
+end process;
+
+fair process respawn_vmstart = "respawn_vmstart"
+variables
+    debug_shutdown_request_observed = TRUE
+begin
+    init:
+    while ~shutdown_signal_received do
+
+        respawn_lock_and_check_allowed:
+            await start_allowed_locked = FALSE;
+            start_allowed_locked := TRUE;
+            if start_allowed then
+                vmstart_running := TRUE;
+
+        respawn_wait_vmstart_exit:
+                either
+                    await pg_ctl_stop_signal;
+                or
+                    \* compute_ctl or postgres crashed or exited on its own
+                    \* TODO: ensure through temporal property that we can respawn it without a shutdown request
+                    skip;
+                end either;
+                vmstart_running := FALSE;
+                start_allowed_locked := FALSE;
+            else
+        respawn_not_allowed:
+                start_allowed_locked := FALSE;
+                debug_shutdown_request_observed := TRUE;
+            end if;
+    end while;
+
+end process;
+
+fair process vmshutdown = "vmshutdown"
+begin
+    init:
+        await shutdown_signal_received;
+
+    vmshutdown_inhibit_new_starts:
+        start_allowed := FALSE; \* rm the vmstart.allowed file on disk
+    vmshutdown_pg_ctl_stop:
+        pg_ctl_stop_signal := TRUE;
+    vmshutdown_wait_existing_command:
+        await start_allowed_locked = FALSE; \* flock the file blocking exclusive; if an existing command is running, this waits until it's completed
+    vmshutdown_done:
+        skip;
+end process;
+
+
+end algorithm; *)
+\* BEGIN TRANSLATION (chksum(pcal) = "3197c7f1" /\ chksum(tla) = "feaa39e9")
+\* Label init of process init at line 24 col 5 changed to init_
+\* Label init of process respawn_vmstart at line 39 col 5 changed to init_r
+\* Label init of process vmshutdown at line 69 col 9 changed to init_v
+VARIABLES start_allowed, start_allowed_locked, pg_ctl_stop_signal,
+          shutdown_signal_received, vmstart_running, pc,
+          debug_shutdown_request_observed
+
+vars == << start_allowed, start_allowed_locked, pg_ctl_stop_signal,
+           shutdown_signal_received, vmstart_running, pc,
+           debug_shutdown_request_observed >>
+
+ProcSet == {"init"} \cup {"respawn_vmstart"} \cup {"vmshutdown"}
+
+Init == (* Global variables *)
+        /\ start_allowed = TRUE
+        /\ start_allowed_locked = FALSE
+        /\ pg_ctl_stop_signal = FALSE
+        /\ shutdown_signal_received = FALSE
+        /\ vmstart_running = FALSE
+        (* Process respawn_vmstart *)
+        /\ debug_shutdown_request_observed = TRUE
+        /\ pc = [self \in ProcSet |-> CASE self = "init" -> "init_"
+                                        [] self = "respawn_vmstart" -> "init_r"
+                                        [] self = "vmshutdown" -> "init_v"]
+
+init_ == /\ pc["init"] = "init_"
+         /\ IF ~shutdown_signal_received
+               THEN /\ \/ /\ shutdown_signal_received' = TRUE
+                       \/ /\ TRUE
+                          /\ UNCHANGED shutdown_signal_received
+                    /\ pc' = [pc EXCEPT !["init"] = "init_"]
+               ELSE /\ pc' = [pc EXCEPT !["init"] = "Done"]
+                    /\ UNCHANGED shutdown_signal_received
+         /\ UNCHANGED << start_allowed, start_allowed_locked,
+                         pg_ctl_stop_signal, vmstart_running,
+                         debug_shutdown_request_observed >>
+
+init == init_
+
+init_r == /\ pc["respawn_vmstart"] = "init_r"
+          /\ IF ~shutdown_signal_received
+                THEN /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_lock_and_check_allowed"]
+                ELSE /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "Done"]
+          /\ UNCHANGED << start_allowed, start_allowed_locked,
+                          pg_ctl_stop_signal, shutdown_signal_received,
+                          vmstart_running, debug_shutdown_request_observed >>
+
+respawn_lock_and_check_allowed == /\ pc["respawn_vmstart"] = "respawn_lock_and_check_allowed"
+                                  /\ start_allowed_locked = FALSE
+                                  /\ start_allowed_locked' = TRUE
+                                  /\ IF start_allowed
+                                        THEN /\ vmstart_running' = TRUE
+                                             /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_wait_vmstart_exit"]
+                                        ELSE /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "respawn_not_allowed"]
+                                             /\ UNCHANGED vmstart_running
+                                  /\ UNCHANGED << start_allowed,
+                                                  pg_ctl_stop_signal,
+                                                  shutdown_signal_received,
+                                                  debug_shutdown_request_observed >>
+
+respawn_wait_vmstart_exit == /\ pc["respawn_vmstart"] = "respawn_wait_vmstart_exit"
+                             /\ \/ /\ pg_ctl_stop_signal
+                                \/ /\ TRUE
+                             /\ vmstart_running' = FALSE
+                             /\ start_allowed_locked' = FALSE
+                             /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "init_r"]
+                             /\ UNCHANGED << start_allowed, pg_ctl_stop_signal,
+                                             shutdown_signal_received,
+                                             debug_shutdown_request_observed >>
+
+respawn_not_allowed == /\ pc["respawn_vmstart"] = "respawn_not_allowed"
+                       /\ start_allowed_locked' = FALSE
+                       /\ debug_shutdown_request_observed' = TRUE
+                       /\ pc' = [pc EXCEPT !["respawn_vmstart"] = "init_r"]
+                       /\ UNCHANGED << start_allowed, pg_ctl_stop_signal,
+                                       shutdown_signal_received,
+                                       vmstart_running >>
+
+respawn_vmstart == init_r \/ respawn_lock_and_check_allowed
+                      \/ respawn_wait_vmstart_exit \/ respawn_not_allowed
+
+init_v == /\ pc["vmshutdown"] = "init_v"
+          /\ shutdown_signal_received
+          /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_inhibit_new_starts"]
+          /\ UNCHANGED << start_allowed, start_allowed_locked,
+                          pg_ctl_stop_signal, shutdown_signal_received,
+                          vmstart_running, debug_shutdown_request_observed >>
+
+vmshutdown_inhibit_new_starts == /\ pc["vmshutdown"] = "vmshutdown_inhibit_new_starts"
+                                 /\ start_allowed' = FALSE
+                                 /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_pg_ctl_stop"]
+                                 /\ UNCHANGED << start_allowed_locked,
+                                                 pg_ctl_stop_signal,
+                                                 shutdown_signal_received,
+                                                 vmstart_running,
+                                                 debug_shutdown_request_observed >>
+
+vmshutdown_pg_ctl_stop == /\ pc["vmshutdown"] = "vmshutdown_pg_ctl_stop"
+                          /\ pg_ctl_stop_signal' = TRUE
+                          /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_wait_existing_command"]
+                          /\ UNCHANGED << start_allowed, start_allowed_locked,
+                                          shutdown_signal_received,
+                                          vmstart_running,
+                                          debug_shutdown_request_observed >>
+
+vmshutdown_wait_existing_command == /\ pc["vmshutdown"] = "vmshutdown_wait_existing_command"
+                                    /\ start_allowed_locked = FALSE
+                                    /\ pc' = [pc EXCEPT !["vmshutdown"] = "vmshutdown_done"]
+                                    /\ UNCHANGED << start_allowed,
+                                                    start_allowed_locked,
+                                                    pg_ctl_stop_signal,
+                                                    shutdown_signal_received,
+                                                    vmstart_running,
+                                                    debug_shutdown_request_observed >>
+
+vmshutdown_done == /\ pc["vmshutdown"] = "vmshutdown_done"
+                   /\ TRUE
+                   /\ pc' = [pc EXCEPT !["vmshutdown"] = "Done"]
+                   /\ UNCHANGED << start_allowed, start_allowed_locked,
+                                   pg_ctl_stop_signal,
+                                   shutdown_signal_received, vmstart_running,
+                                   debug_shutdown_request_observed >>
+
+vmshutdown == init_v \/ vmshutdown_inhibit_new_starts
+                 \/ vmshutdown_pg_ctl_stop
+                 \/ vmshutdown_wait_existing_command \/ vmshutdown_done
+
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == /\ \A self \in ProcSet: pc[self] = "Done"
+               /\ UNCHANGED vars
+
+Next == init \/ respawn_vmstart \/ vmshutdown
+           \/ Terminating
+
+Spec == /\ Init /\ [][Next]_vars
+        /\ WF_vars(init)
+        /\ WF_vars(respawn_vmstart)
+        /\ WF_vars(vmshutdown)
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION
+
+\* TEMPORAL PROPERTIES:
+\* If we signal ACPI shutdown, vmstart eventually stops running and never restarts
+ShutdownSignalWorks == (shutdown_signal_received ~> ([](~vmstart_running)))
+\* Before we signal ACPI shutdown, respawn works
+RespawnBeforeShutdownCanRestartWithoutPendingShutdown == TRUE \* TODO: how to express this?
+
+=============================================================================
+\* Modification History
+\* Last modified Sun Sep 24 18:31:33 CEST 2023 by cs
+\* Created Sun Sep 24 12:17:50 CEST 2023 by cs

--- a/doc/vm-builder/shutdown/shutdown.tla
+++ b/doc/vm-builder/shutdown/shutdown.tla
@@ -90,12 +90,12 @@ begin
 
         postgres_await_shutdown_or_crash:
 
-            \* crash only if we have pids left
+            \* bound number of crashes to pids left, otherwise we have infinite state space "until" shutdown signal gets delivered
             if Len(postgres_next_pids) > 0 then
                 either
                     await postgres_shutdown_request_pending = postgres_running;
                 or
-                    \* crash
+                    \* crash / exit on its own
                     skip;
                 end either;
             else

--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -77,8 +77,8 @@ RUN set -e \
 ADD inittab   /neonvm/bin/inittab
 ADD vminit    /neonvm/bin/vminit
 ADD vmstart   /neonvm/bin/vmstart
+ADD vmshutdown /neonvm/bin/vmshutdown
 ADD vmacpi    /neonvm/acpi/vmacpi
-ADD powerdown /neonvm/bin/powerdown
 RUN chmod +rx /neonvm/bin/vminit /neonvm/bin/vmstart /neonvm/bin/vmshutdown
 
 FROM vm-runtime AS builder

--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -163,12 +163,16 @@ action=/neonvm/bin/poweroff
 `
 
 	scriptVmShutdown = `#!/neonvm/bin/sh
-	rm /neonvm/vmstart.allowed
-	if [ -e /neonvm/vmstart.allowed ]; then
-		echo "Error: could not remove vmstart.allowed marker, might hang indefinitely during shutdown" >2&
-	fi
-	# wait for ongoing command to exit by grabbing the lock
-	flock /neonvm/vmstart.lock true
+rm /neonvm/vmstart.allowed
+if [ -e /neonvm/vmstart.allowed ]; then
+	echo "Error: could not remove vmstart.allowed marker, might hang indefinitely during shutdown" 1>&2
+fi
+# wait for ongoing command to exit by grabbing the lock
+if flock /neonvm/vmstart.lock true; then
+	echo "vmstart workload shut down cleanly" 1>&2
+else
+	echo "error: vmshutdown flock failed" 1>&2
+fi
 `
 
 	scriptVmInit = `#!/neonvm/bin/sh

--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -167,8 +167,8 @@ action=/neonvm/bin/poweroff
 	if [ -e /neonvm/vmstart.allowed ]; then
 		echo "Error: could not remove vmstart.allowed marker, might hang indefinitely during shutdown" >2&
 	fi
-	# wait for ongoing command to exit
-	flock /neonvm/vmstart.lock
+	# wait for ongoing command to exit by grabbing the lock
+	flock /neonvm/vmstart.lock true
 `
 
 	scriptVmInit = `#!/neonvm/bin/sh

--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -79,7 +79,7 @@ ADD vminit    /neonvm/bin/vminit
 ADD vmstart   /neonvm/bin/vmstart
 ADD vmacpi    /neonvm/acpi/vmacpi
 ADD powerdown /neonvm/bin/powerdown
-RUN chmod +rx /neonvm/bin/vminit /neonvm/bin/vmstart /neonvm/bin/powerdown
+RUN chmod +rx /neonvm/bin/vminit /neonvm/bin/vmstart /neonvm/bin/vmshutdown
 
 FROM vm-runtime AS builder
 ARG DISK_SIZE

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -265,8 +265,8 @@ if [ -e /neonvm/vmstart.allowed ]; then
 	echo "Error: could not remove vmstart.allowed marker, might hang indefinitely during shutdown" >2&
 fi
 su -p postgres --session-command '/usr/local/bin/pg_ctl stop -D /var/db/postgres/compute/pgdata -m fast --wait -t 10'
-# wait for ongoing command to exit
-flock /neonvm/vmstart.lock
+# wait for ongoing command to exit by grabbing the lock
+flock /neonvm/vmstart.lock true
 `
 
 	scriptVmInit = `#!/neonvm/bin/sh

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -262,11 +262,15 @@ action=/neonvm/bin/poweroff
 	scriptVmShutdown = `#!/neonvm/bin/sh
 rm /neonvm/vmstart.allowed
 if [ -e /neonvm/vmstart.allowed ]; then
-	echo "Error: could not remove vmstart.allowed marker, might hang indefinitely during shutdown" >2&
+	echo "Error: could not remove vmstart.allowed marker, might hang indefinitely during shutdown" 1>&2
 fi
 su -p postgres --session-command '/usr/local/bin/pg_ctl stop -D /var/db/postgres/compute/pgdata -m fast --wait -t 10'
 # wait for ongoing command to exit by grabbing the lock
-flock /neonvm/vmstart.lock true
+if flock /neonvm/vmstart.lock true; then
+	echo "vmstart workload shut down cleanly" 1>&2
+else
+	echo "error: vmshutdown flock failed" 1>&2
+fi
 `
 
 	scriptVmInit = `#!/neonvm/bin/sh

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -231,16 +231,14 @@ else
     /neonvm/bin/echo -n {{range .Cmd}}' '{{.}}{{end}} >> /neonvm/bin/vmstarter.sh
 fi
 
-/neonvm/bin/cat <<'EOF' >>/neonvm/bin/vmstarter.sh
-
-if [ -e "/neonvm/vmstart_command_finished.fifo" ]; then
-	echo ' ' > /neonvm/vmstart_command_finished.fifo
-fi
-EOF
-
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh
 
 /neonvm/bin/su-exec {{.User}} /neonvm/bin/sh /neonvm/bin/vmstarter.sh
+
+# signal vmshutdown that vmstarter.sh has exited
+if [ -e "/neonvm/vmstart_command_finished.fifo" ]; then
+	echo ' ' > /neonvm/vmstart_command_finished.fifo
+fi
 `
 
 	scriptInitTab = `
@@ -268,6 +266,7 @@ action=/neonvm/bin/poweroff
 	scriptVmShutdown = `#!/neonvm/bin/sh
 mkfifo /neonvm/vmstart_command_finished.fifo || exit 2
 su -p postgres --session-command '/usr/local/bin/pg_ctl stop -D /var/db/postgres/compute/pgdata -m fast --wait -t 10'
+# wait for vmstart to signal exit of vmstarter.sh
 cat /neonvm/vmstart_command_finished.fifo
 `
 

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -173,7 +173,7 @@ ADD vmshutdown /neonvm/bin/vmshutdown
 ADD vmacpi    /neonvm/acpi/vmacpi
 ADD vector.yaml /neonvm/config/vector.yaml
 ADD powerdown /neonvm/bin/powerdown
-RUN chmod +rx /neonvm/bin/vminit /neonvm/bin/vmstart /neonvm/bin/vmshutdown /neonvm/bin/powerdown
+RUN chmod +rx /neonvm/bin/vminit /neonvm/bin/vmstart /neonvm/bin/vmshutdown
 
 FROM vm-runtime AS builder
 ARG DISK_SIZE

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -172,7 +172,6 @@ ADD vmstart   /neonvm/bin/vmstart
 ADD vmshutdown /neonvm/bin/vmshutdown
 ADD vmacpi    /neonvm/acpi/vmacpi
 ADD vector.yaml /neonvm/config/vector.yaml
-ADD powerdown /neonvm/bin/powerdown
 RUN chmod +rx /neonvm/bin/vminit /neonvm/bin/vmstart /neonvm/bin/vmshutdown
 
 FROM vm-runtime AS builder

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -233,17 +233,13 @@ fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh
 
-/neonvm/bin/su-exec {{.User}} /neonvm/bin/sh /neonvm/bin/vmstarter.sh
-
-# signal vmshutdown that vmstarter.sh has exited
-if [ -e "/neonvm/vmstart_command_finished.fifo" ]; then
-	echo ' ' > /neonvm/vmstart_command_finished.fifo
-fi
+flock /neonvm/vmstart.lock -c 'test -e /neonvm/vmstart.allowed && /neonvm/bin/su-exec {{.User}} /neonvm/bin/sh /neonvm/bin/vmstarter.sh'
 `
 
 	scriptInitTab = `
 ::sysinit:/neonvm/bin/vminit
 ::sysinit:cgconfigparser -l /etc/cgconfig.conf -s 1664
+::once:/neonvm/bin/touch /neonvm/vmstart.allowed
 ::respawn:/neonvm/bin/udhcpc -t 1 -T 1 -A 1 -f -i eth0 -O 121 -O 119 -s /neonvm/bin/udhcpc.script
 ::respawn:/neonvm/bin/udevd
 ::respawn:/neonvm/bin/acpid -f -c /neonvm/acpi
@@ -264,10 +260,13 @@ action=/neonvm/bin/poweroff
 `
 
 	scriptVmShutdown = `#!/neonvm/bin/sh
-mkfifo /neonvm/vmstart_command_finished.fifo || exit 2
+rm /neonvm/vmstart.allowed
+if [ -e /neonvm/vmstart.allowed ]; then
+	echo "Error: could not remove vmstart.allowed marker, might hang indefinitely during shutdown" >2&
+fi
 su -p postgres --session-command '/usr/local/bin/pg_ctl stop -D /var/db/postgres/compute/pgdata -m fast --wait -t 10'
-# wait for vmstart to signal exit of vmstarter.sh
-cat /neonvm/vmstart_command_finished.fifo
+# wait for ongoing command to exit
+flock /neonvm/vmstart.lock
 `
 
 	scriptVmInit = `#!/neonvm/bin/sh


### PR DESCRIPTION
We're seeing unclosed connections from VM-based computes to pageservers.
They are reproducibly due to `suspend_compute` actions in console.

An earlier attempt to mitigate this was made in
https://github.com/neondatabase/autoscaling/pull/523
but it didn't show any effect.

See the `README.md` added in this PR for details.