### PR TITLE
neonvm/runner: Skip QEMU powerdown if already exited

### DIFF
--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -956,6 +956,8 @@ func terminateQemuOnSigterm(ctx context.Context, logger *zap.Logger, qmpPort int
 	select {
 	case <-c:
 	case <-ctx.Done():
+		logger.Info("context canceled, not going to powerdown QEMU because it's already finished")
+		return
 	}
 
 	logger.Info("got signal, sending powerdown command to QEMU")


### PR DESCRIPTION
This isn't the cause of any problems we're observing, but it should make things a bit clearer in the future.

Basically, the context only gets canceled here:

https://github.com/neondatabase/autoscaling/blob/e5248b0c27dfae55a5f648cad695dc84db2ffc13/neonvm/runner/main.go#L644-L650

i.e. after QEMU has already exited, so this should make it a little more clear when we get connection errors that it's not because the context was canceled.

cc @problame