### PR TITLE
Update alpine image from 3.16 to 3.19 (qemu from 7.0.0 to 8.1.3)

### DIFF
--- a/.github/workflows/vm-example.yaml
+++ b/.github/workflows/vm-example.yaml
@@ -32,10 +32,10 @@ jobs:
           username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
-      - name: build vm-alpine:3.18
-        run:  bin/vm-builder -src alpine:3.18 -dst neondatabase/vm-alpine:3.18
-      - name: push vm-alpine:3.18
-        run:  docker push -q neondatabase/vm-alpine:3.18
+      - name: build vm-alpine:3.19
+        run:  bin/vm-builder -src alpine:3.19 -dst neondatabase/vm-alpine:3.19
+      - name: push vm-alpine:3.19
+        run:  docker push -q neondatabase/vm-alpine:3.19
 
       - name: build vm-ubuntu:22.04
         run:  bin/vm-builder -src ubuntu:22.04 -dst neondatabase/vm-ubuntu:22.04

--- a/.github/workflows/vm-example.yaml
+++ b/.github/workflows/vm-example.yaml
@@ -32,10 +32,10 @@ jobs:
           username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
-      - name: build vm-alpine:3.16
-        run:  bin/vm-builder -src alpine:3.16 -dst neondatabase/vm-alpine:3.16
-      - name: push vm-alpine:3.16
-        run:  docker push -q neondatabase/vm-alpine:3.16
+      - name: build vm-alpine:3.18
+        run:  bin/vm-builder -src alpine:3.18 -dst neondatabase/vm-alpine:3.18
+      - name: push vm-alpine:3.18
+        run:  docker push -q neondatabase/vm-alpine:3.18
 
       - name: build vm-ubuntu:22.04
         run:  bin/vm-builder -src ubuntu:22.04 -dst neondatabase/vm-ubuntu:22.04

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ docker-build-pg14-disk-test: bin/vm-builder ## Build a VM image for testing
 	    chmod uga+rw 'vm-examples/pg14-disk-test/ssh_id_rsa' 'vm-examples/pg14-disk-test/ssh_id_rsa.pub'; \
 	fi
 
-	./bin/vm-builder -src alpine:3.16 -dst $(PG14_DISK_TEST_IMG) -spec vm-examples/pg14-disk-test/image-spec.yaml
+	./bin/vm-builder -src alpine:3.18 -dst $(PG14_DISK_TEST_IMG) -spec vm-examples/pg14-disk-test/image-spec.yaml
 
 #.PHONY: docker-push
 #docker-push: ## Push docker image with the controller.

--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ docker-build-pg14-disk-test: bin/vm-builder ## Build a VM image for testing
 	    chmod uga+rw 'vm-examples/pg14-disk-test/ssh_id_rsa' 'vm-examples/pg14-disk-test/ssh_id_rsa.pub'; \
 	fi
 
-	./bin/vm-builder -src alpine:3.18 -dst $(PG14_DISK_TEST_IMG) -spec vm-examples/pg14-disk-test/image-spec.yaml
+	./bin/vm-builder -src alpine:3.19 -dst $(PG14_DISK_TEST_IMG) -spec vm-examples/pg14-disk-test/image-spec.yaml
 
 #.PHONY: docker-push
 #docker-push: ## Push docker image with the controller.

--- a/neonvm/PROJECT
+++ b/neonvm/PROJECT
@@ -14,7 +14,7 @@ plugins:
       options:
         containerCommand: ping,8.8.8.8
         containerPort: "8080"
-        image: alpine:3.16
+        image: alpine:3.18
       version: v1
   grafana.kubebuilder.io/v1-alpha: {}
 projectName: neonvm

--- a/neonvm/PROJECT
+++ b/neonvm/PROJECT
@@ -14,7 +14,7 @@ plugins:
       options:
         containerCommand: ping,8.8.8.8
         containerPort: "8080"
-        image: alpine:3.18
+        image: alpine:3.19
       version: v1
   grafana.kubebuilder.io/v1-alpha: {}
 projectName: neonvm

--- a/neonvm/hack/Dockerfile.kernel-builder
+++ b/neonvm/hack/Dockerfile.kernel-builder
@@ -41,6 +41,6 @@ RUN cd linux-${KERNEL_VERSION} && make -j `nproc`
 
 # Use alpine so that `cp` is available when loading custom kernels for the runner pod.
 # See the neonvm controller's pod creation logic for more detail.
-FROM alpine:3.18
+FROM alpine:3.19
 ARG KERNEL_VERSION
 COPY --from=build /build/linux-${KERNEL_VERSION}/arch/x86/boot/bzImage /vmlinuz

--- a/neonvm/runner/Dockerfile
+++ b/neonvm/runner/Dockerfile
@@ -26,7 +26,7 @@ COPY pkg/util pkg/util
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /runner neonvm/runner/main.go
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 RUN apk add --no-cache \
     tini \

--- a/neonvm/runner/Dockerfile
+++ b/neonvm/runner/Dockerfile
@@ -26,7 +26,7 @@ COPY pkg/util pkg/util
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /runner neonvm/runner/main.go
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 RUN apk add --no-cache \
     tini \

--- a/neonvm/samples/vm-example/Dockerfile
+++ b/neonvm/samples/vm-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18 AS rootdisk
+FROM alpine:3.19 AS rootdisk
 
 RUN set -e \
 	&& apk add --no-cache \
@@ -35,7 +35,7 @@ ADD postgresql.conf /etc/postgresql/
 ADD pg_hba.conf     /etc/postgresql/
 
 
-FROM alpine:3.18 AS image
+FROM alpine:3.19 AS image
 
 ARG DISK_SIZE=2G
 
@@ -47,6 +47,6 @@ RUN set -e \
     && rm -f /disk.raw \
     && qemu-img info /disk.qcow2
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 COPY --from=image /disk.qcow2 /

--- a/neonvm/samples/vm-example/Dockerfile
+++ b/neonvm/samples/vm-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 AS rootdisk
+FROM alpine:3.18 AS rootdisk
 
 RUN set -e \
 	&& apk add --no-cache \
@@ -35,7 +35,7 @@ ADD postgresql.conf /etc/postgresql/
 ADD pg_hba.conf     /etc/postgresql/
 
 
-FROM alpine:3.16 AS image
+FROM alpine:3.18 AS image
 
 ARG DISK_SIZE=2G
 
@@ -47,6 +47,6 @@ RUN set -e \
     && rm -f /disk.raw \
     && qemu-img info /disk.qcow2
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 COPY --from=image /disk.qcow2 /

--- a/neonvm/tools/vm-builder/files/Dockerfile.img
+++ b/neonvm/tools/vm-builder/files/Dockerfile.img
@@ -7,13 +7,12 @@ FROM {{.RootDiskImage}} AS rootdisk
 USER root
 {{.SpecMerge}}
 
-FROM alpine:3.16 AS vm-runtime
+FROM alpine:3.18 AS vm-runtime
 # add busybox
-ENV BUSYBOX_VERSION 1.35.0
 RUN set -e \
 	&& mkdir -p /neonvm/bin /neonvm/runtime /neonvm/config \
-	&& wget -q https://busybox.net/downloads/binaries/${BUSYBOX_VERSION}-x86_64-linux-musl/busybox -O /neonvm/bin/busybox \
-	&& chmod +x /neonvm/bin/busybox \
+	&& apk add --no-cache --no-progress --quiet busybox \
+	&& cp -f /bin/busybox /neonvm/bin/busybox \
 	&& /neonvm/bin/busybox --install -s /neonvm/bin
 
 # add udevd and agetty (with shared libs)
@@ -36,12 +35,12 @@ RUN set -e \
 	&& mkdir -p /neonvm/lib \
 	&& cp -f /lib/ld-musl-x86_64.so.1  /neonvm/lib/ \
 	&& cp -f /lib/libblkid.so.1.1.0    /neonvm/lib/libblkid.so.1 \
-	&& cp -f /lib/libcrypto.so.1.1     /neonvm/lib/ \
-	&& cp -f /lib/libkmod.so.2.3.7     /neonvm/lib/libkmod.so.2 \
+	&& cp -f /lib/libcrypto.so.3       /neonvm/lib/ \
+	&& cp -f /lib/libkmod.so.2.4.0     /neonvm/lib/libkmod.so.2 \
 	&& cp -f /lib/libudev.so.1.6.3     /neonvm/lib/libudev.so.1 \
-	&& cp -f /lib/libz.so.1.2.12       /neonvm/lib/libz.so.1 \
-	&& cp -f /usr/lib/liblzma.so.5.2.5 /neonvm/lib/liblzma.so.5 \
-	&& cp -f /usr/lib/libzstd.so.1.5.2 /neonvm/lib/libzstd.so.1 \
+	&& cp -f /lib/libz.so.1.2.13       /neonvm/lib/libz.so.1 \
+	&& cp -f /usr/lib/liblzma.so.5.4.3 /neonvm/lib/liblzma.so.5 \
+	&& cp -f /usr/lib/libzstd.so.1.5.5 /neonvm/lib/libzstd.so.1 \
 	&& cp -f /lib/libe2p.so.2          /neonvm/lib/libe2p.so.2 \
 	&& cp -f /lib/libext2fs.so.2       /neonvm/lib/libext2fs.so.2 \
 	&& cp -f /lib/libcom_err.so.2      /neonvm/lib/libcom_err.so.2 \
@@ -81,6 +80,6 @@ RUN set -e \
     && mkfs.ext4 -L vmroot -d /rootdisk /disk.raw ${DISK_SIZE} \
     && qemu-img convert -f raw -O qcow2 -o cluster_size=2M,lazy_refcounts=on /disk.raw /disk.qcow2
 
-FROM alpine:3.16
+FROM alpine:3.18
 RUN apk add --no-cache --no-progress --quiet qemu-img
 COPY --from=builder /disk.qcow2 /

--- a/neonvm/tools/vm-builder/files/Dockerfile.img
+++ b/neonvm/tools/vm-builder/files/Dockerfile.img
@@ -7,7 +7,7 @@ FROM {{.RootDiskImage}} AS rootdisk
 USER root
 {{.SpecMerge}}
 
-FROM alpine:3.18 AS vm-runtime
+FROM alpine:3.19 AS vm-runtime
 # add busybox
 RUN set -e \
 	&& mkdir -p /neonvm/bin /neonvm/runtime /neonvm/config \
@@ -36,11 +36,11 @@ RUN set -e \
 	&& cp -f /lib/ld-musl-x86_64.so.1  /neonvm/lib/ \
 	&& cp -f /lib/libblkid.so.1.1.0    /neonvm/lib/libblkid.so.1 \
 	&& cp -f /lib/libcrypto.so.3       /neonvm/lib/ \
-	&& cp -f /lib/libkmod.so.2.4.0     /neonvm/lib/libkmod.so.2 \
-	&& cp -f /lib/libudev.so.1.6.3     /neonvm/lib/libudev.so.1 \
-	&& cp -f /lib/libz.so.1.2.13       /neonvm/lib/libz.so.1 \
-	&& cp -f /usr/lib/liblzma.so.5.4.3 /neonvm/lib/liblzma.so.5 \
-	&& cp -f /usr/lib/libzstd.so.1.5.5 /neonvm/lib/libzstd.so.1 \
+	&& cp -f /lib/libkmod.so.2         /neonvm/lib/libkmod.so.2 \
+	&& cp -f /lib/libudev.so.1         /neonvm/lib/libudev.so.1 \
+	&& cp -f /lib/libz.so.1            /neonvm/lib/libz.so.1 \
+	&& cp -f /usr/lib/liblzma.so.5     /neonvm/lib/liblzma.so.5 \
+	&& cp -f /usr/lib/libzstd.so.1     /neonvm/lib/libzstd.so.1 \
 	&& cp -f /lib/libe2p.so.2          /neonvm/lib/libe2p.so.2 \
 	&& cp -f /lib/libext2fs.so.2       /neonvm/lib/libext2fs.so.2 \
 	&& cp -f /lib/libcom_err.so.2      /neonvm/lib/libcom_err.so.2 \
@@ -80,6 +80,6 @@ RUN set -e \
     && mkfs.ext4 -L vmroot -d /rootdisk /disk.raw ${DISK_SIZE} \
     && qemu-img convert -f raw -O qcow2 -o cluster_size=2M,lazy_refcounts=on /disk.raw /disk.qcow2
 
-FROM alpine:3.18
+FROM alpine:3.19
 RUN apk add --no-cache --no-progress --quiet qemu-img
 COPY --from=builder /disk.qcow2 /

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// vm-builder --src alpine:3.16 --dst vm-alpine:dev --file vm-alpine.qcow2
+// vm-builder --src alpine:3.18 --dst vm-alpine:dev --file vm-alpine.qcow2
 
 var (
 	//go:embed files/Dockerfile.img
@@ -46,8 +46,8 @@ var (
 var (
 	Version string
 
-	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.16`)
-	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
+	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.18`)
+	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.18`)
 	size      = flag.String("size", "1G", `Size for disk image: --size=1G`)
 	outFile   = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
 	specFile  = flag.String("spec", "", `File containing additional customization: --spec=spec.yaml`)

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// vm-builder --src alpine:3.18 --dst vm-alpine:dev --file vm-alpine.qcow2
+// vm-builder --src alpine:3.19 --dst vm-alpine:dev --file vm-alpine.qcow2
 
 var (
 	//go:embed files/Dockerfile.img
@@ -46,8 +46,8 @@ var (
 var (
 	Version string
 
-	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.18`)
-	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.18`)
+	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.19`)
+	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.19`)
 	size      = flag.String("size", "1G", `Size for disk image: --size=1G`)
 	outFile   = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
 	specFile  = flag.String("spec", "", `File containing additional customization: --spec=spec.yaml`)

--- a/neonvm/tools/vxlan/Dockerfile
+++ b/neonvm/tools/vxlan/Dockerfile
@@ -21,7 +21,7 @@ COPY neonvm/tools/vxlan/controller/ neonvm/tools/vxlan/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /vxlan-controller neonvm/tools/vxlan/controller/main.go
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 RUN apk add --no-cache \
     tini \

--- a/neonvm/tools/vxlan/Dockerfile
+++ b/neonvm/tools/vxlan/Dockerfile
@@ -21,7 +21,7 @@ COPY neonvm/tools/vxlan/controller/ neonvm/tools/vxlan/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /vxlan-controller neonvm/tools/vxlan/controller/main.go
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 RUN apk add --no-cache \
     tini \

--- a/scripts/ssh-into-vm.sh
+++ b/scripts/ssh-into-vm.sh
@@ -98,7 +98,7 @@ CONTAINER_CFG='
         '"$NODE_SELECTOR"'
         "containers": [{
             "name": "'"ssh-$vm_name"'",
-            "image": "alpine:3.16",
+            "image": "alpine:3.18",
             "args": [
                 "/bin/sh",
                 "-c",

--- a/scripts/ssh-into-vm.sh
+++ b/scripts/ssh-into-vm.sh
@@ -68,18 +68,18 @@ vm_ip="$(kubectl get neonvm "$vm_name" -o jsonpath='{.status.podIP}')"
 # '
 #
 # nad_file="ssh-nad-$NAD_NAME.tmp"
-# 
+#
 # cleanup () {
 #     rm "$nad_file"
 #     kubectl delete network-attachment-definitions.k8s.cni.cncf.io "$NAD_NAME"
 # }
-# 
+#
 # trap cleanup EXIT INT TERM
-# 
+#
 # echo "$NAD" > "$nad_file"
 # kubectl apply -f "$nad_file"
 
-if [ -n "$NODE_NAME" ]; then 
+if [ -n "$NODE_NAME" ]; then
     NODE_SELECTOR='"nodeSelector": { "kubernetes.io/hostname": "'"$NODE_NAME"'" },'
 else
     NODE_SELECTOR=""
@@ -88,7 +88,7 @@ fi
 # Provide a manual configuration for the container so that we can pass through the ssh private key
 #
 # Note: this requires creating the 'vm-ssh' secret, as described in the readme.
-# Note: the defaultMode below, is decimal 384 and therefore octal 600 
+# Note: the defaultMode below, is decimal 384 and therefore octal 600
 # Note: setting StrictHostKeyChecking=no disables the "authenticity of host" dialog
 SSH_OPTS='-o StrictHostKeyChecking=no'
 CONTAINER_CFG='
@@ -98,7 +98,7 @@ CONTAINER_CFG='
         '"$NODE_SELECTOR"'
         "containers": [{
             "name": "'"ssh-$vm_name"'",
-            "image": "alpine:3.18",
+            "image": "alpine:3.19",
             "args": [
                 "/bin/sh",
                 "-c",

--- a/vm-examples/pg14-disk-test/image-spec.yaml
+++ b/vm-examples/pg14-disk-test/image-spec.yaml
@@ -63,7 +63,7 @@ build: |
   RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
 
   # Build the allocation tester:
-  FROM alpine:3.16 AS allocate-loop-builder
+  FROM alpine:3.18 AS allocate-loop-builder
   RUN set -e \
       && apk add gcc musl-dev
   COPY allocate-loop.c allocate-loop.c

--- a/vm-examples/pg14-disk-test/image-spec.yaml
+++ b/vm-examples/pg14-disk-test/image-spec.yaml
@@ -63,7 +63,7 @@ build: |
   RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
 
   # Build the allocation tester:
-  FROM alpine:3.18 AS allocate-loop-builder
+  FROM alpine:3.19 AS allocate-loop-builder
   RUN set -e \
       && apk add gcc musl-dev
   COPY allocate-loop.c allocate-loop.c

--- a/vm-examples/pg14-disk-test/sshd_config
+++ b/vm-examples/pg14-disk-test/sshd_config
@@ -5,7 +5,7 @@
 
 # This sshd was compiled with PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# sshd_config adapted from alpine:3.18 default sshd_config
+# sshd_config adapted from alpine:3.16 default sshd_config
 
 # The strategy used for options in the default sshd_config shipped with
 # OpenSSH is to specify options with their default value where

--- a/vm-examples/pg14-disk-test/sshd_config
+++ b/vm-examples/pg14-disk-test/sshd_config
@@ -5,7 +5,7 @@
 
 # This sshd was compiled with PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# sshd_config adapted from alpine:3.16 default sshd_config
+# sshd_config adapted from alpine:3.18 default sshd_config
 
 # The strategy used for options in the default sshd_config shipped with
 # OpenSSH is to specify options with their default value where


### PR DESCRIPTION
Update base Alpine Linux image from 3.16 to 3.18, which effectively updates qemu from 7.0.0 to 8.1.3

Related changelogs:
- https://www.alpinelinux.org/posts/Alpine-3.17.0-released.html
- https://www.alpinelinux.org/posts/Alpine-3.18.0-released.html
- https://www.alpinelinux.org/posts/Alpine-3.19.0-released.html
- https://www.qemu.org/2023/04/20/qemu-8-0-0/ 
- https://www.qemu.org/2023/08/22/qemu-8-1-0/

