### PR TITLE
fixup #525: handle SIGKILLED postmaster process correctly

### DIFF
--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -44,12 +44,14 @@ RUN set -e \
 		su-exec \
 		e2fsprogs-extra \
 		blkid \
+		flock \
 	&& mv /sbin/acpid         /neonvm/bin/ \
 	&& mv /sbin/udevd         /neonvm/bin/ \
 	&& mv /sbin/agetty        /neonvm/bin/ \
 	&& mv /sbin/su-exec       /neonvm/bin/ \
 	&& mv /usr/sbin/resize2fs /neonvm/bin/resize2fs \
 	&& mv /sbin/blkid         /neonvm/bin/blkid \
+	&& mv /usr/bin/flock	  /neonvm/bin/flock \
 	&& mkdir -p /neonvm/lib \
 	&& cp -f /lib/ld-musl-x86_64.so.1  /neonvm/lib/ \
 	&& cp -f /lib/libblkid.so.1.1.0    /neonvm/lib/libblkid.so.1 \
@@ -143,7 +145,7 @@ fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh
 
-flock /neonvm/vmstart.lock -c 'test -e /neonvm/vmstart.allowed && /neonvm/bin/su-exec {{.User}} /neonvm/bin/sh /neonvm/bin/vmstarter.sh'
+/neonvm/bin/flock -o /neonvm/vmstart.lock -c 'test -e /neonvm/vmstart.allowed && /neonvm/bin/su-exec {{.User}} /neonvm/bin/sh /neonvm/bin/vmstarter.sh'
 `
 
 	scriptInitTab = `

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -131,12 +131,14 @@ RUN set -e \
 		su-exec \
 		e2fsprogs-extra \
 		blkid \
+		flock \
 	&& mv /sbin/acpid         /neonvm/bin/ \
 	&& mv /sbin/udevd         /neonvm/bin/ \
 	&& mv /sbin/agetty        /neonvm/bin/ \
 	&& mv /sbin/su-exec       /neonvm/bin/ \
 	&& mv /usr/sbin/resize2fs /neonvm/bin/resize2fs \
 	&& mv /sbin/blkid         /neonvm/bin/blkid \
+	&& mv /usr/bin/flock	  /neonvm/bin/flock \
 	&& mkdir -p /neonvm/lib \
 	&& cp -f /lib/ld-musl-x86_64.so.1  /neonvm/lib/ \
 	&& cp -f /lib/libblkid.so.1.1.0    /neonvm/lib/libblkid.so.1 \
@@ -233,7 +235,7 @@ fi
 
 /neonvm/bin/chmod +x /neonvm/bin/vmstarter.sh
 
-flock /neonvm/vmstart.lock -c 'test -e /neonvm/vmstart.allowed && /neonvm/bin/su-exec {{.User}} /neonvm/bin/sh /neonvm/bin/vmstarter.sh'
+/neonvm/bin/flock -o /neonvm/vmstart.lock -c 'test -e /neonvm/vmstart.allowed && /neonvm/bin/su-exec {{.User}} /neonvm/bin/sh /neonvm/bin/vmstarter.sh'
 `
 
 	scriptInitTab = `


### PR DESCRIPTION
After rolling out #525 to prod, we noticed that when the postmaster process gets OOM killed, it fails to restart.

The `init` would try to respawn `vmstart` but it would get stuck trying to `flock` the file, before starting `vmstarter.sh` / the new postgres processes.

Investigation showed that we were inherting the file descriptor and flock for `vmstart.lock`  to the child process tree.
Including the `postgres: Local free space monitor`  process, which fails to stop when postmaster gets killed.
Once we'd manually kill it, the respawned `vmstart`'s blocked `flock` would get unblocked.

We never intended to inherit the vmstart.lock file descriptor or flock, so, this PR disables that behavior.
That makes the restart-after-OOM-kill work again.

But, reviewing the file cache code, there's actually a data corruption possiblity here, because after respawn, the old free space monitor process will still be running, able to interfere with the restarted postgres processes.

Created issue https://github.com/neondatabase/neon/issues/5405 for that.
