### PR TITLE
Fix some exhaustruct lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,8 @@ linters-settings:
       - '^github.com/prometheus/client_golang/prometheus(/.*)?\.\w+Opts$'
       - '^github\.com/containerd/cgroups/v3/cgroup2\.(Resources|Memory)'
       - '^github\.com/tychoish/fun/pubsub\.BrokerOptions$'
+      - '^github\.com/neondatabase/autoscaling/pkg/util\.JSONPatch$'
+      - '^github\.com/neondatabase/autoscaling/pkg/util/watch\.HandlerFuncs$'
       # vmapi.{VirtualMachine,VirtualMachineSpec,VirtualMachineMigration,VirtualMachineMigrationSpec}
       - '^github\.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1\.VirtualMachine(Migration)?(Spec)?$'
 

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -273,6 +273,7 @@ func (c *nodeConfig) vCpuLimits(total *resource.Quantity) (_ nodeResourceState[v
 		Total:                vmapi.MilliCPU(totalMilli),
 		Watermark:            vmapi.MilliCPU(c.Cpu.Watermark * float32(totalMilli)),
 		Reserved:             0,
+		Buffer:               0,
 		CapacityPressure:     0,
 		PressureAccountedFor: 0,
 	}, margin, nil
@@ -301,6 +302,7 @@ func (c *nodeConfig) memoryLimits(
 		Total:                uint16(totalSlots),
 		Watermark:            uint16(c.Memory.Watermark * float32(totalSlots)),
 		Reserved:             0,
+		Buffer:               0,
 		CapacityPressure:     0,
 		PressureAccountedFor: 0,
 	}, margin, nil

--- a/pkg/util/watch/watch.go
+++ b/pkg/util/watch/watch.go
@@ -149,12 +149,15 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 	sendStop, stopSignal := util.NewSingleSignalPair[struct{}]()
 
 	store := Store[T]{
+		mutex:         sync.Mutex{},
 		objects:       make(map[types.UID]*T),
 		triggerRelist: make(chan struct{}, 1), // ensure sends are non-blocking
 		relisted:      make(chan struct{}),
 		nextIndexID:   0,
 		indexes:       make(map[uint64]Index[T]),
 		stopSignal:    sendStop,
+		stopped:       atomic.Bool{},
+		failing:       atomic.Bool{},
 	}
 
 	items := accessors.Items(initialList)


### PR DESCRIPTION
Noticed while working on #371, but it appears that golangci-lint will sometimes hide errors that it *should* be showing if compiling succeeds. So if, hypothetically, you're impacted by golang/go#58218 and normally you're able to get by with `go build -buildvcs=false ./...` but golangci-lint doesn't have that functionality, then this is able to reproduce on main.