### PR TITLE
lint workflow: Add codespell checks (spellchecking)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
-# "style: function formatting (#46)" - changes formatting of function params, exculsively from
+# "style: function formatting (#46)" - changes formatting of function params, exclusively from
 # single-line to multi-line
 f8fb06a1565599c3d44a1951c7a50b6c065cdb96
 # "intermediate commit: de-indent some blocks (#113)" - factored out of #113 to make blame clear.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,3 +65,13 @@ jobs:
             exit 1
           fi
 
+  codespell:
+    name: check spelling with codespell
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: codespell-project/actions-codespell@94259cd8be02ad2903ba34a22d9c13de21a74461 # v2.0
+        with:
+          check_hidden: true
+          skip: go.sum,*.patch # '*.patch' references cluster-autoscaler/ca.patch, but somehow skipping directly doesn't work...

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -239,7 +239,7 @@ simply returns with an ack.
 
 There are two additional messages types that either party may send:
 - `InvalidMessage`: sent when either party fails to deserialize a message it received
-- `InternalError`: used to indicate that an error occured while processing a request,
+- `InternalError`: used to indicate that an error occurred while processing a request,
   for example, if the monitor errors while trying to downscale
 
 ## Footguns

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -23,7 +23,7 @@ RUN cd autoscaler/cluster-autoscaler \
 # There are other ways of solving this (see: https://www.arp242.net/static-go.html), but the easiest
 # thing is to just disable cgo.
 
-# We're done buiding. Copy the binary over into the final product.
+# We're done building. Copy the binary over into the final product.
 #
 # This is adapted from CA's Dockerfile.amd64, here:
 # https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.24.1/cluster-autoscaler/Dockerfile.amd64

--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -103,7 +103,7 @@ $ grep -E -B 3 -A 3 '[<=>]{7}' $tmpdir/cluster-autoscaler/utils/kubernetes/liste
 	"k8s.io/apimachinery/pkg/runtime"
 $
 $ # As always though, you should manually inspect that the changes are still sensible.
-$ <manually resovle conflicts + check the rest of the patch yourself>
+$ <manually resolve conflicts + check the rest of the patch yourself>
 $
 $ # AFTER RESOLVING CONFLICTS:
 $ # If there were any conflicts, reset the repo state (so that `git diff` is correct)

--- a/k3d/cilium.yaml
+++ b/k3d/cilium.yaml
@@ -141,7 +141,7 @@ data:
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: default
-  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # Unique ID of the cluster. Must be unique across all connected clusters and
   # in the range of 1 and 255. Only relevant when building a mesh of clusters.
   cluster-id: "0"
 

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -718,7 +718,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 // updates the values of the runner pod's labels and annotations so that they are exactly equal to
 // the set of labels/annotations we expect - minus some that are ignored.
 //
-// The reason we also need to delete unrecongized labels/annotations is so that if a
+// The reason we also need to delete unrecognized labels/annotations is so that if a
 // label/annotation on the VM itself is deleted, we can accurately reflect that in the pod.
 func updatePodMetadataIfNecessary(ctx context.Context, c client.Client, vm *vmv1.VirtualMachine, runnerPod *corev1.Pod) error {
 	log := log.FromContext(ctx)
@@ -1278,22 +1278,22 @@ func (r *VirtualMachineReconciler) tryUpdateVM(ctx context.Context, virtualmachi
 	return r.Update(ctx, virtualmachine)
 }
 
-// return Netwrok Attachment Definition name with IPAM settings
+// return Network Attachment Definition name with IPAM settings
 func nadIpamName() (string, error) {
 	return getEnvVarValue("NAD_IPAM_NAME")
 }
 
-// return Netwrok Attachment Definition namespace with IPAM settings
+// return Network Attachment Definition namespace with IPAM settings
 func nadIpamNamespace() (string, error) {
 	return getEnvVarValue("NAD_IPAM_NAMESPACE")
 }
 
-// return Netwrok Attachment Definition name for second interface in Runner
+// return Network Attachment Definition name for second interface in Runner
 func nadRunnerName() (string, error) {
 	return getEnvVarValue("NAD_RUNNER_NAME")
 }
 
-// return Netwrok Attachment Definition namespace for second interface in Runner
+// return Network Attachment Definition namespace for second interface in Runner
 func nadRunnerNamespace() (string, error) {
 	return getEnvVarValue("NAD_RUNNER_NAMESPACE")
 }

--- a/neonvm/controllers/virtualmachine_qmp_queries.go
+++ b/neonvm/controllers/virtualmachine_qmp_queries.go
@@ -422,7 +422,7 @@ func QmpUnplugMemory(ip string, port int32) error {
 			merr = errors.Join(merr, err)
 			continue
 		}
-		// succesfully deleted memory device
+		// successfully deleted memory device
 		break
 	}
 	if i >= 0 {

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -109,7 +109,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 			if err := r.Update(ctx, migration); err != nil {
 				return ctrl.Result{}, err
 			}
-			// stop this reconcilation cycle, new will be triggered as Migration updated
+			// stop this reconciliation cycle, new will be triggered as Migration updated
 			return ctrl.Result{}, nil
 		}
 	} else {
@@ -158,7 +158,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 			log.Info("Failed to add owner to Migration", "error", err)
 			return ctrl.Result{}, err
 		}
-		// stop this reconcilation cycle, new will be triggered as Migration updated
+		// stop this reconciliation cycle, new will be triggered as Migration updated
 		return ctrl.Result{}, nil
 	}
 
@@ -331,7 +331,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 		case corev1.PodUnknown:
 			message := fmt.Sprintf("Target Pod (%s) in Unknown phase", targetRunner.Name)
 			log.Info(message)
-			r.Recorder.Event(migration, "Warning", "Unknow", message)
+			r.Recorder.Event(migration, "Warning", "Unknown", message)
 			meta.SetStatusCondition(&migration.Status.Conditions,
 				metav1.Condition{Type: typeAvailableVirtualMachineMigration,
 					Status:  metav1.ConditionUnknown,
@@ -529,7 +529,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 			migration.Status.SourcePodIP = ""
 			return r.updateMigrationStatus(ctx, migration)
 		}
-		// all done, stop reconcilation
+		// all done, stop reconciliation
 		return ctrl.Result{}, nil
 
 	case vmv1.VmmFailed:
@@ -542,12 +542,12 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 				return ctrl.Result{}, err
 			}
 		}
-		// all done, stop reconcilation
+		// all done, stop reconciliation
 		return ctrl.Result{}, nil
 
 	default:
 		// not sure what to do, so try rqueue
-		log.Info("Requeuing cuurent request")
+		log.Info("Requeuing current request")
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 

--- a/neonvm/pkg/README.md
+++ b/neonvm/pkg/README.md
@@ -1,6 +1,6 @@
 ## IP address management example
 
-### Creat Netwrok Attachment Definition
+### Creat Network Attachment Definition
 
 ```console
 kubectl apply -f ipam-demo-nad.yaml
@@ -12,7 +12,7 @@ kubectl apply -f ipam-demo-nad.yaml
 go run ipam-demo.go
 ```
 
-### Delete Netwrok Attachment Definition
+### Delete Network Attachment Definition
 
 ```console
 kubectl delete -f ipam-demo-nad.yaml

--- a/neonvm/pkg/ipam/ipam.go
+++ b/neonvm/pkg/ipam/ipam.go
@@ -32,7 +32,7 @@ const (
 
 	UnnamedNetwork string = ""
 
-	// kubermetes client-go rate limiter settings
+	// kubernetes client-go rate limiter settings
 	// https://pkg.go.dev/k8s.io/client-go@v0.27.2/rest#Config
 	KubernetesClientQPS   = 100
 	KubernetesClientBurst = 200
@@ -74,7 +74,7 @@ func New(ctx context.Context, nadName string, nadNamespace string) (*IPAM, error
 		return nil, fmt.Errorf("error building kubernetes configuration: %v", err)
 	}
 
-	// tune Kubernetes client perfomance
+	// tune Kubernetes client performance
 	cfg.QPS = KubernetesClientQPS
 	cfg.Burst = KubernetesClientBurst
 
@@ -309,7 +309,7 @@ func (i *IPAM) runIPAM(ctx context.Context, vmName string, vmNamespace string, a
 				}
 				return ip, fmt.Errorf("error updating IP pool: %v", err)
 			}
-			// pool was readed, acquire or release was processed, pool was updated
+			// pool was read, acquire or release was processed, pool was updated
 			// now we can break retry loop
 			break
 		}

--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -204,7 +204,7 @@ mount -t cgroup2 cgroup2 /sys/fs/cgroup
 # Allow all users to move processes to/from the root cgroup.
 #
 # This is required in order to be able to 'cgexec' anything, if the entrypoint is not being run as
-# root, because moving tasks betweeen one cgroup and another *requires write access to the
+# root, because moving tasks between one cgroup and another *requires write access to the
 # cgroup.procs file of the common ancestor*, and because the entrypoint isn't already in a cgroup,
 # any new tasks are automatically placed in the top-level cgroup.
 #

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -299,7 +299,7 @@ mount -t cgroup2 cgroup2 /sys/fs/cgroup
 # Allow all users to move processes to/from the root cgroup.
 #
 # This is required in order to be able to 'cgexec' anything, if the entrypoint is not being run as
-# root, because moving tasks betweeen one cgroup and another *requires write access to the
+# root, because moving tasks between one cgroup and another *requires write access to the
 # cgroup.procs file of the common ancestor*, and because the entrypoint isn't already in a cgroup,
 # any new tasks are automatically placed in the top-level cgroup.
 #

--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -44,7 +44,7 @@ type Dispatcher struct {
 
 	// When someone sends a message, the dispatcher will attach a transaction id
 	// to it so that it knows when a response is back. When it receives a message
-	// with the same transaction id, it knows that that is the repsonse to the original
+	// with the same transaction id, it knows that that is the response to the original
 	// message and will send it down the SignalSender so the original sender can use it.
 	waiters map[uint64]util.SignalSender[waiterResult]
 
@@ -620,7 +620,7 @@ func (disp *Dispatcher) run(ctx context.Context, logger *zap.Logger, upscaleRequ
 				zap.Uint64("id", id),
 				zap.String("error", err.Error),
 			)
-			// Indicate to the receiver that an error occured
+			// Indicate to the receiver that an error occurred
 			sender.Send(waiterResult{
 				err: errors.New("vm-monitor internal error"),
 				res: nil,
@@ -639,7 +639,7 @@ func (disp *Dispatcher) run(ctx context.Context, logger *zap.Logger, upscaleRequ
 		sender, ok := disp.waiters[id]
 		if ok {
 			logger.Info("vm-monitor responded to health check", zap.Uint64("id", id))
-			// Indicate to the receiver that an error occured
+			// Indicate to the receiver that an error occurred
 			sender.Send(waiterResult{
 				err: nil,
 				res: &MonitorResult{

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -346,7 +346,7 @@ func (s *agentState) loggerForRunner(vmName, podName util.NamespacedName) *zap.L
 func (s *agentState) newRunner(vmInfo api.VmInfo, podName util.NamespacedName, podIP string, restartCount int) *Runner {
 	return &Runner{
 		global:                          s,
-		status:                          nil, // set by calller
+		status:                          nil, // set by caller
 		schedulerRespondedWithMigration: false,
 
 		shutdown:         nil, // set by (*Runner).Run

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -505,7 +505,7 @@ func (r *Runner) handleVMResources(
 			if !newVMInfo.ScalingEnabled {
 				// This shouldn't happen because any update to the VM object that has
 				// ScalingEnabled=false should get translated into a "deletion" so the runner stops.
-				// So we shoudln't get an "update" event, and if we do, something's gone very wrong.
+				// So we shouldn't get an "update" event, and if we do, something's gone very wrong.
 				panic("explicit VM update given but scaling is disabled")
 			}
 
@@ -1229,7 +1229,7 @@ func (s *AtomicUpdateState) DesiredVMState(allowDecrease bool) api.Resources {
 	// If no decreases are allowed, then we *must* make sure that the VM's usage value has not
 	// decreased, even if it's greater than the VM maximum.
 	//
-	// We can run into situtations like this when VM scale-down on bounds change fails, so we end up
+	// We can run into situations like this when VM scale-down on bounds change fails, so we end up
 	// with a usage value greater than the maximum.
 	if !allowDecrease {
 		result = result.Max(s.VM.Using())

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -383,7 +383,7 @@ type InvalidMessage struct {
 	Error string `json:"error"`
 }
 
-// This type can be sent by either party to signal that an error occured carrying
+// This type can be sent by either party to signal that an error occurred carrying
 // out the other party's request, for example, the monitor erroring while trying
 // to downscale. The receiving party can they log the error or propagate it as they
 // see fit.
@@ -446,7 +446,7 @@ type MonitorProtoVersion uint32
 const (
 	// MonitorProtoV1_0 represents v1.0 of the agent<->monitor protocol - the initial version.
 	//
-	// Currently the lastest version.
+	// Currently the latest version.
 	MonitorProtoV1_0 = iota + 1
 
 	// latestMonitorProtoVersion represents the latest version of the agent<->Monitor protocol
@@ -477,6 +477,6 @@ type MonitorProtocolResponse struct {
 	// Otherwise, will be set to 0 (MonitorProtocolVersion's zero value).
 	Version MonitorProtoVersion `json:"version,omitempty"`
 
-	// Will be nil if no error occured.
+	// Will be nil if no error occurred.
 	Error *string `json:"error,omitempty"`
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -422,7 +422,7 @@ func (e *AutoscaleEnforcer) Filter(
 	if vmInfo == nil {
 		otherPodInfo, err = extractPodOtherPodResourceState(pod)
 		if err != nil {
-			logger.Error("Error extracing resource state for non-VM pod", zap.Error(err))
+			logger.Error("Error extracting resource state for non-VM pod", zap.Error(err))
 			return framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
 				fmt.Sprintf("Error getting pod info: %s", err),
@@ -890,7 +890,7 @@ func (e *AutoscaleEnforcer) Reserve(
 	if vmInfo == nil {
 		podResources, err := extractPodOtherPodResourceState(pod)
 		if err != nil {
-			logger.Error("Error extracing resource state for non-VM pod", zap.Error(err))
+			logger.Error("Error extracting resource state for non-VM pod", zap.Error(err))
 			return framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
 				fmt.Sprintf("Error getting non-VM pod info: %v", err),

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -87,7 +87,7 @@ func (e *AutoscaleEnforcer) startPermitHandler(ctx context.Context, logger *zap.
 
 		responseBody, err := json.Marshal(&resp)
 		if err != nil {
-			logger.Panic("Failed to encode repsonse JSON", zap.Error(err))
+			logger.Panic("Failed to encode response JSON", zap.Error(err))
 		}
 
 		logger.Info(

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -1423,7 +1423,7 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context, logger *zap.Lo
 			testingOnlyAlwaysMigrate: vmInfo.AlwaysMigrate,
 		}
 
-		// If scaling isn't enabled *or* the pod is invovled in an ongoing migration, then we can be
+		// If scaling isn't enabled *or* the pod is involved in an ongoing migration, then we can be
 		// more precise about usage (because scaling is forbidden while migrating).
 		if !vmInfo.ScalingEnabled || migrationName != nil {
 			ps.vCPU.Buffer = 0

--- a/pkg/util/watch/watch.go
+++ b/pkg/util/watch/watch.go
@@ -60,7 +60,7 @@ type Accessors[L any, T any] struct {
 // Object is implemented by pointers to T, where T is typically the resource that we're
 // actually watching.
 //
-// Example implementors: *corev1.Pod, *corev1.Node
+// Example implementers: *corev1.Pod, *corev1.Node
 type Object[T any] interface {
 	~*T
 	runtime.Object
@@ -494,7 +494,7 @@ func handleEvent[T any, P ~*T](
 	obj := (*T)(ptr)
 
 	// Some of the cases below don't actually require locking the store. Most of the events that we
-	// recieve *do* though, so we're better off doing it here for simplicity.
+	// receive *do* though, so we're better off doing it here for simplicity.
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 


### PR DESCRIPTION
Builds on #541, based on neondatabase/neon#5450.

Maybe worthwhile to merge via rebase, so that the spelling fixes can be added to .git-blame-ignore-revs.