### PR TITLE
lint workflow: Run on any PR, not just → main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: lints
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
Hit this working on #542 because its base branch isn't main.