### PR TITLE
billing: Change idempotency key format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/digitalocean/go-qemu v0.0.0-20220826173844-d5f5e3ceed89
 	github.com/docker/docker v20.10.24+incompatible
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20210525090646-64b7a4574d14
-	github.com/google/uuid v1.3.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/k8snetworkplumbingwg/whereabouts v0.6.1
 	github.com/kdomanski/iso9660 v0.3.3
@@ -118,6 +117,7 @@ require (
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/pkg/agent/billing/billing.go
+++ b/pkg/agent/billing/billing.go
@@ -264,10 +264,14 @@ func logAddedEvent(logger *zap.Logger, event *billing.IncrementalEvent) *billing
 func (s *metricsState) drainEnqueue(logger *zap.Logger, conf *Config, hostname string, queue eventQueuePusher[*billing.IncrementalEvent]) {
 	now := time.Now()
 
+	countInBatch := 0
+	batchSize := 2 * len(s.historical)
+
 	for key, history := range s.historical {
 		history.finalizeCurrentTimeSlice()
 
-		queue.enqueue(logAddedEvent(logger, billing.Enrich(hostname, &billing.IncrementalEvent{
+		countInBatch += 1
+		queue.enqueue(logAddedEvent(logger, billing.Enrich(now, hostname, countInBatch, batchSize, &billing.IncrementalEvent{
 			MetricName:     conf.CPUMetricName,
 			Type:           "", // set by billing.Enrich
 			IdempotencyKey: "", // set by billing.Enrich
@@ -278,7 +282,8 @@ func (s *metricsState) drainEnqueue(logger *zap.Logger, conf *Config, hostname s
 			StopTime:  now,
 			Value:     int(math.Round(history.total.cpu)),
 		})))
-		queue.enqueue(logAddedEvent(logger, billing.Enrich(hostname, &billing.IncrementalEvent{
+		countInBatch += 1
+		queue.enqueue(logAddedEvent(logger, billing.Enrich(now, hostname, countInBatch, batchSize, &billing.IncrementalEvent{
 			MetricName:     conf.ActiveTimeMetricName,
 			Type:           "", // set by billing.Enrich
 			IdempotencyKey: "", // set by billing.Enrich


### PR DESCRIPTION
Quoting a conversation about the current format:

> It’s quite big but mostly used only for deduplication purposes so that
> it can be any unique value.

And

> Pageservers use
> ```
> <timestamp with milliseconds>-<pageserver_id>-<number of event in the batch>
> ```

So the new format is

```
<RFC3339 timestamp with microseconds>-<pod name>-<number in batch>/<total batch size>
```