### PR TITLE
lint workflow: Add job to check generated go code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,6 +65,24 @@ jobs:
             exit 1
           fi
 
+  generated-go:
+    name: check generated go files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: make generate
+        run: |
+          make generate
+      - name: check diff
+        run: |
+          if ! (test -z "$(git ls-files --exclude-standard --others .)$(git diff .)"); then
+            git ls-files --exclude-standard --others .
+            git diff .
+            echo "ERROR: 'make generate' modified the source tree."
+            exit 1
+          fi
+
   codespell:
     name: check spelling with codespell
     runs-on: ubuntu-latest


### PR DESCRIPTION
~~Not sure if it'll work because the makefile target requires docker, but we can see :)~~

Seems to work ok :)