### PR TITLE
agent/runner: Add temporary monitor state dump for len(waiters)

### DIFF
--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -280,6 +280,13 @@ func (disp *Dispatcher) ExitError() error {
 	return disp.exitError
 }
 
+// temporary method to hopefully help with https://github.com/neondatabase/autoscaling/issues/503
+func (disp *Dispatcher) lenWaiters() int {
+	disp.lock.Lock()
+	defer disp.lock.Unlock()
+	return len(disp.waiters)
+}
+
 // Send a message down the connection. Only call this method with types that
 // SerializeMonitorMessage can handle.
 func (disp *Dispatcher) send(ctx context.Context, logger *zap.Logger, id uint64, message any) error {

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -111,12 +111,18 @@ type RunnerState struct {
 	PodIP                 string             `json:"podIP"`
 	ExecutorState         executor.StateDump `json:"executorState"`
 	Scheduler             *SchedulerState    `json:"scheduler"`
+	Monitor               *MonitorState      `json:"monitor"`
 	BackgroundWorkerCount int64              `json:"backgroundWorkerCount"`
 }
 
 // SchedulerState is the state of a Scheduler, constructed as part of a Runner's State Method
 type SchedulerState struct {
 	Info schedwatch.SchedulerInfo `json:"info"`
+}
+
+// Temporary type, to hopefully help with debugging https://github.com/neondatabase/autoscaling/issues/503
+type MonitorState struct {
+	WaitersSize int `json:"waitersSize"`
 }
 
 func (r *Runner) State(ctx context.Context) (*RunnerState, error) {
@@ -132,6 +138,17 @@ func (r *Runner) State(ctx context.Context) (*RunnerState, error) {
 		}
 	}
 
+	var monitorState *MonitorState
+	if r.monitor != nil {
+		monitorState = &MonitorState{
+			WaitersSize: func() int {
+				r.monitor.dispatcher.lock.Lock()
+				defer r.monitor.dispatcher.lock.Unlock()
+				return len(r.monitor.dispatcher.waiters)
+			}(),
+		}
+	}
+
 	var executorState *executor.StateDump
 	if r.executorStateDump != nil /* may be nil if r.Run() hasn't fully started yet */ {
 		s := r.executorStateDump()
@@ -142,6 +159,7 @@ func (r *Runner) State(ctx context.Context) (*RunnerState, error) {
 		PodIP:                 r.podIP,
 		ExecutorState:         *executorState,
 		Scheduler:             scheduler,
+		Monitor:               monitorState,
 		BackgroundWorkerCount: r.backgroundWorkerCount.Load(),
 	}, nil
 }

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -141,11 +141,7 @@ func (r *Runner) State(ctx context.Context) (*RunnerState, error) {
 	var monitorState *MonitorState
 	if r.monitor != nil {
 		monitorState = &MonitorState{
-			WaitersSize: func() int {
-				r.monitor.dispatcher.lock.Lock()
-				defer r.monitor.dispatcher.lock.Unlock()
-				return len(r.monitor.dispatcher.waiters)
-			}(),
+			WaitersSize: r.monitor.dispatcher.lenWaiters(),
 		}
 	}
 


### PR DESCRIPTION
Hopefully should help with debugging https://github.com/neondatabase/autoscaling/issues/503.