### PR TITLE
agent/core: Add retry rate limits for plugin & NeonVM requests

### DIFF
--- a/deploy/agent/config_map.yaml
+++ b/deploy/agent/config_map.yaml
@@ -8,6 +8,7 @@ data:
     {
       "scaling": {
         "requestTimeoutSeconds": 10,
+        "retryFailedRequestSeconds": 5,
         "defaultConfig": {
           "loadAverageFractionTarget": 0.9,
           "memoryUsageFractionTarget": 0.75
@@ -35,6 +36,7 @@ data:
         "schedulerName": "autoscale-scheduler",
         "requestTimeoutSeconds": 2,
         "requestAtLeastEverySeconds": 5,
+        "retryFailedRequestSeconds": 3,
         "retryDeniedUpscaleSeconds": 2,
         "requestPort": 10299
       },

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -65,6 +65,9 @@ type DumpStateConfig struct {
 type ScalingConfig struct {
 	// RequestTimeoutSeconds gives the timeout duration, in seconds, for VM patch requests
 	RequestTimeoutSeconds uint `json:"requestTimeoutSeconds"`
+	// RetryFailedRequestSeconds gives the duration, in seconds, that we must wait after a previous
+	// failed request before making another one.
+	RetryFailedRequestSeconds uint `json:"retryFailedRequestSeconds"`
 	// DefaultConfig gives the default scaling config, to be used if there is no configuration
 	// supplied with the "autoscaling.neon.tech/config" annotation.
 	DefaultConfig api.ScalingConfig `json:"defaultConfig"`
@@ -96,6 +99,9 @@ type SchedulerConfig struct {
 	// RequestAtLeastEverySeconds gives the maximum duration we should go without attempting a
 	// request to the scheduler, even if nothing's changed.
 	RequestAtLeastEverySeconds uint `json:"requestAtLeastEverySeconds"`
+	// RetryFailedRequestSeconds gives the duration, in seconds, that we must wait after a previous
+	// failed request before making another one.
+	RetryFailedRequestSeconds uint `json:"retryFailedRequestSeconds"`
 	// RetryDeniedUpscaleSeconds gives the duration, in seconds, that we must wait before resending
 	// a request for resources that were not approved
 	RetryDeniedUpscaleSeconds uint `json:"retryDeniedUpscaleSeconds"`
@@ -146,6 +152,7 @@ func (c *Config) validate() error {
 	erc.Whenf(ec, c.Metrics.LoadMetricPrefix == "", emptyTmpl, ".metrics.loadMetricPrefix")
 	erc.Whenf(ec, c.Metrics.SecondsBetweenRequests == 0, zeroTmpl, ".metrics.secondsBetweenRequests")
 	erc.Whenf(ec, c.Scaling.RequestTimeoutSeconds == 0, zeroTmpl, ".scaling.requestTimeoutSeconds")
+	erc.Whenf(ec, c.Scaling.RetryFailedRequestSeconds == 0, zeroTmpl, ".scaling.retryFailedRequestSeconds")
 	erc.Whenf(ec, c.Monitor.ResponseTimeoutSeconds == 0, zeroTmpl, ".monitor.responseTimeoutSeconds")
 	erc.Whenf(ec, c.Monitor.ConnectionTimeoutSeconds == 0, zeroTmpl, ".monitor.connectionTimeoutSeconds")
 	erc.Whenf(ec, c.Monitor.ConnectionRetryMinWaitSeconds == 0, zeroTmpl, ".monitor.connectionRetryMinWaitSeconds")
@@ -161,6 +168,7 @@ func (c *Config) validate() error {
 	erc.Whenf(ec, c.Scheduler.RequestPort == 0, zeroTmpl, ".scheduler.requestPort")
 	erc.Whenf(ec, c.Scheduler.RequestTimeoutSeconds == 0, zeroTmpl, ".scheduler.requestTimeoutSeconds")
 	erc.Whenf(ec, c.Scheduler.RequestAtLeastEverySeconds == 0, zeroTmpl, ".scheduler.requestAtLeastEverySeconds")
+	erc.Whenf(ec, c.Scheduler.RetryFailedRequestSeconds == 0, zeroTmpl, ".scheduler.retryFailedRequestSeconds")
 	erc.Whenf(ec, c.Scheduler.RetryDeniedUpscaleSeconds == 0, zeroTmpl, ".scheduler.retryDeniedUpscaleSeconds")
 	erc.Whenf(ec, c.Scheduler.SchedulerName == "", emptyTmpl, ".scheduler.schedulerName")
 

--- a/pkg/agent/core/dumpstate.go
+++ b/pkg/agent/core/dumpstate.go
@@ -44,6 +44,7 @@ type pluginStateDump struct {
 	OngoingRequest bool                 `json:"ongoingRequest"`
 	ComputeUnit    *api.Resources       `json:"computeUnit"`
 	LastRequest    *pluginRequestedDump `json:"lastRequest"`
+	LastFailureAt  *time.Time           `json:"lastRequestAt"`
 	Permit         *api.Resources       `json:"permit"`
 }
 type pluginRequestedDump struct {
@@ -65,6 +66,7 @@ func (s *pluginState) dump() pluginStateDump {
 		OngoingRequest: s.ongoingRequest,
 		ComputeUnit:    shallowCopy(s.computeUnit),
 		LastRequest:    lastRequest,
+		LastFailureAt:  shallowCopy(s.lastFailureAt),
 		Permit:         shallowCopy(s.permit),
 	}
 }

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -237,7 +237,9 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger, vmInfoUpdated util
 		OnNextActions: r.global.metrics.runnerNextActions.Inc,
 		Core: core.Config{
 			DefaultScalingConfig:               r.global.config.Scaling.DefaultConfig,
+			NeonVMRetryWait:                    time.Second * time.Duration(r.global.config.Scaling.RetryFailedRequestSeconds),
 			PluginRequestTick:                  time.Second * time.Duration(r.global.config.Scheduler.RequestAtLeastEverySeconds),
+			PluginRetryWait:                    time.Second * time.Duration(r.global.config.Scheduler.RetryFailedRequestSeconds),
 			PluginDeniedRetryWait:              time.Second * time.Duration(r.global.config.Scheduler.RetryDeniedUpscaleSeconds),
 			MonitorDeniedDownscaleCooldown:     time.Second * time.Duration(r.global.config.Monitor.RetryDeniedDownscaleSeconds),
 			MonitorRequestedUpscaleValidPeriod: time.Second * time.Duration(r.global.config.Monitor.RequestedUpscaleValidSeconds),


### PR DESCRIPTION
Without this, we can end up spamming the scheduler plugin or NeonVM API if there's transient request failures (e.g. if the autoscaler-agent has information about a VM for slightly longer than the plugin or NeonVM controller).

Part of #550.