### PR TITLE
agent/executor: Log core.Action*s as zap.Object for api.Resources formatting

### DIFF
--- a/pkg/agent/core/action.go
+++ b/pkg/agent/core/action.go
@@ -3,6 +3,8 @@ package core
 import (
 	"time"
 
+	"go.uber.org/zap/zapcore"
+
 	"github.com/neondatabase/autoscaling/pkg/api"
 )
 
@@ -37,4 +39,57 @@ type ActionMonitorDownscale struct {
 type ActionMonitorUpscale struct {
 	Current api.Resources `json:"current"`
 	Target  api.Resources `json:"target"`
+}
+
+func addObjectPtr[T zapcore.ObjectMarshaler](enc zapcore.ObjectEncoder, key string, value *T) error {
+	if value != nil {
+		return enc.AddObject(key, *value)
+	} else {
+		// nil ObjectMarshaler is not sound, but nil reflected is, and it shortcuts reflection
+		return enc.AddReflected(key, nil)
+	}
+}
+
+func (s ActionSet) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	addObjectPtr(enc, "wait", s.Wait)
+	addObjectPtr(enc, "pluginRequest", s.PluginRequest)
+	addObjectPtr(enc, "neonvmRequest", s.NeonVMRequest)
+	addObjectPtr(enc, "monitorDownscale", s.MonitorDownscale)
+	addObjectPtr(enc, "monitorUpscale", s.MonitorUpscale)
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, so that ActionWait can be used with zap.Object
+func (a ActionWait) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddDuration("duration", a.Duration)
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, so that ActionPluginRequest can be used with zap.Object
+func (a ActionPluginRequest) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	addObjectPtr(enc, "lastPermit", a.LastPermit)
+	enc.AddObject("target", a.Target)
+	enc.AddReflected("metrics", a.Metrics)
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, so that ActionNeonVMRequest can be used with zap.Object
+func (a ActionNeonVMRequest) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddObject("current", a.Current)
+	enc.AddObject("target", a.Target)
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, so that ActionMonitorDownscale can be used with zap.Object
+func (a ActionMonitorDownscale) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddObject("current", a.Current)
+	enc.AddObject("target", a.Target)
+	return nil
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, so that ActionMonitorUpscale can be used with zap.Object
+func (a ActionMonitorUpscale) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddObject("current", a.Current)
+	enc.AddObject("target", a.Target)
+	return nil
 }

--- a/pkg/agent/executor/exec_monitor.go
+++ b/pkg/agent/executor/exec_monitor.go
@@ -55,7 +55,7 @@ func (c *ExecutorCoreWithClients) DoMonitorDownscales(ctx context.Context, logge
 		action := *last.actions.MonitorDownscale
 
 		if updated := c.updateIfActionsUnchanged(last, func(state *core.State) {
-			logger.Info("Starting vm-monitor downscale request", zap.Any("action", action))
+			logger.Info("Starting vm-monitor downscale request", zap.Object("action", action))
 			startTime = time.Now()
 			monitorIface = c.clients.Monitor.GetHandle()
 			state.Monitor().StartingDownscaleRequest(startTime, action.Target)
@@ -75,7 +75,7 @@ func (c *ExecutorCoreWithClients) DoMonitorDownscales(ctx context.Context, logge
 		c.update(func(state *core.State) {
 			unchanged := generationUnchanged(monitorIface)
 			logFields := []zap.Field{
-				zap.Any("action", action),
+				zap.Object("action", action),
 				zap.Duration("duration", endTime.Sub(startTime)),
 				zap.Bool("unchanged", unchanged),
 			}
@@ -145,7 +145,7 @@ func (c *ExecutorCoreWithClients) DoMonitorUpscales(ctx context.Context, logger 
 		action := *last.actions.MonitorUpscale
 
 		if updated := c.updateIfActionsUnchanged(last, func(state *core.State) {
-			logger.Info("Starting vm-monitor upscale request", zap.Any("action", action))
+			logger.Info("Starting vm-monitor upscale request", zap.Object("action", action))
 			startTime = time.Now()
 			monitorIface = c.clients.Monitor.GetHandle()
 			state.Monitor().StartingUpscaleRequest(startTime, action.Target)
@@ -165,7 +165,7 @@ func (c *ExecutorCoreWithClients) DoMonitorUpscales(ctx context.Context, logger 
 		c.update(func(state *core.State) {
 			unchanged := generationUnchanged(monitorIface)
 			logFields := []zap.Field{
-				zap.Any("action", action),
+				zap.Object("action", action),
 				zap.Duration("duration", endTime.Sub(startTime)),
 				zap.Bool("unchanged", unchanged),
 			}

--- a/pkg/agent/executor/exec_neonvm.go
+++ b/pkg/agent/executor/exec_neonvm.go
@@ -39,7 +39,7 @@ func (c *ExecutorCoreWithClients) DoNeonVMRequests(ctx context.Context, logger *
 		action := *last.actions.NeonVMRequest
 
 		if updated := c.updateIfActionsUnchanged(last, func(state *core.State) {
-			logger.Info("Starting NeonVM request", zap.Any("action", action))
+			logger.Info("Starting NeonVM request", zap.Object("action", action))
 			startTime = time.Now()
 			state.NeonVM().StartingRequest(startTime, action.Target)
 		}); !updated {
@@ -48,7 +48,7 @@ func (c *ExecutorCoreWithClients) DoNeonVMRequests(ctx context.Context, logger *
 
 		err := c.clients.NeonVM.Request(ctx, ifaceLogger, action.Current, action.Target)
 		endTime := time.Now()
-		logFields := []zap.Field{zap.Any("action", action), zap.Duration("duration", endTime.Sub(startTime))}
+		logFields := []zap.Field{zap.Object("action", action), zap.Duration("duration", endTime.Sub(startTime))}
 
 		c.update(func(state *core.State) {
 			if err != nil {

--- a/pkg/agent/executor/exec_plugin.go
+++ b/pkg/agent/executor/exec_plugin.go
@@ -54,7 +54,7 @@ func (c *ExecutorCoreWithClients) DoPluginRequests(ctx context.Context, logger *
 		action := *last.actions.PluginRequest
 
 		if updated := c.updateIfActionsUnchanged(last, func(state *core.State) {
-			logger.Info("Starting plugin request", zap.Any("action", action))
+			logger.Info("Starting plugin request", zap.Object("action", action))
 			startTime = time.Now()
 			pluginIface = c.clients.Plugin.GetHandle()
 			state.Plugin().StartingRequest(startTime, action.Target)
@@ -74,7 +74,7 @@ func (c *ExecutorCoreWithClients) DoPluginRequests(ctx context.Context, logger *
 		c.update(func(state *core.State) {
 			unchanged := generationUnchanged(pluginIface)
 			logFields := []zap.Field{
-				zap.Any("action", action),
+				zap.Object("action", action),
 				zap.Duration("duration", endTime.Sub(startTime)),
 				zap.Bool("unchanged", unchanged),
 			}


### PR DESCRIPTION
tl;dr the JSON formatting is fixed because it's also the over-the-wire format, but the logs are easier to parse (and make dashboards out of) if api.Resources values have CPU as floats rather than with the 'm' suffix (e.g. '0.25' instead of '250m').

Part of #550, specifically this issue:

> Resource change logging uses `m` suffix for CPU instead of decimal, e.g. 250m not 0.25 (harder to parse logs)