### PR TITLE
agent/core: Fix invalid plugin request on limited downscale

### DIFF
--- a/pkg/agent/core/state.go
+++ b/pkg/agent/core/state.go
@@ -368,7 +368,7 @@ func (s *State) calculatePluginAction(
 	// ... and this isn't a duplicate (or, at least it's been long enough)
 	shouldRequestNewResources := wantToRequestNewResources && !waitingOnRetryBackoff
 
-	permittedRequestResources := desiredResources
+	permittedRequestResources := requestResources
 	if !shouldRequestNewResources {
 		permittedRequestResources = currentResources
 	}


### PR DESCRIPTION
Found on staging after v0.18.0-patch1 because of "response validation" failures in the logs. The issue occurs under specific conditions of multiple actions happening at the same time.

The added test case replicates the original sequence; refer there for more detail on what went wrong. See also, the [original logs](https://neonprod.grafana.net/goto/V3j8haGIg?orgId=1).

Part of #550.