### PR TITLE
release workflow: Add 'free disk space' step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: free disk space
+        uses: jlumbroso/free-disk-space@v1.3.0
       - name: git checkout
         uses: actions/checkout@v3
       - name: get version and git info


### PR DESCRIPTION
Latest release attempt has been hitting issues running out of disk partway through, so this should unblock that.

Long-term we probably want to switch this to our self-hosted runners but there's some known issues preventing that for now.

Ref https://neondb.slack.com/archives/C059ZC138NR/p1697120311648149?thread_ts=1697120074.180899