### PR TITLE
plugin: Use pod ownerReferences to tell if VM, not label

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -25,7 +25,6 @@ import (
 )
 
 const Name = "AutoscaleEnforcer"
-const LabelVM = vmapi.VirtualMachineNameLabel
 const LabelPluginCreatedMigration = "autoscaling.neon.tech/created-by-scheduler"
 const ConfigMapNamespace = "kube-system"
 const ConfigMapName = "scheduler-plugin-config"
@@ -256,12 +255,8 @@ func (e *AutoscaleEnforcer) Name() string {
 //
 // This function returns nil, nil if the pod is not associated with a NeonVM virtual machine.
 func (e *AutoscaleEnforcer) getVmInfo(logger *zap.Logger, pod *corev1.Pod, action string) (*api.VmInfo, error) {
-	var vmName util.NamespacedName
-	vmName.Namespace = pod.Namespace
-
-	var ok bool
-	vmName.Name, ok = pod.Labels[LabelVM]
-	if !ok {
+	vmName := util.TryPodOwnerVirtualMachine(pod)
+	if vmName == nil {
 		return nil, nil
 	}
 
@@ -834,7 +829,7 @@ func (e *AutoscaleEnforcer) Reserve(
 
 	pName := util.GetNamespacedName(pod)
 	logger := e.logger.With(zap.String("method", "Reserve"), zap.String("node", nodeName), util.PodNameFields(pod))
-	if migrationName := tryMigrationOwnerReference(pod); migrationName != nil {
+	if migrationName := util.TryPodOwnerVirtualMachineMigration(pod); migrationName != nil {
 		logger = logger.With(zap.Object("virtualmachinemigration", *migrationName))
 	}
 

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -3,6 +3,8 @@ package util
 // Kubernetes-specific utility functions
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -26,4 +28,40 @@ func PodCompleted(pod *corev1.Pod) bool {
 // PodStartedBefore returns true iff Pod p started before Pod q
 func PodStartedBefore(p, q *corev1.Pod) bool {
 	return p.Status.StartTime.Before(q.Status.StartTime)
+}
+
+// TryPodOwnerVirtualMachine returns the name of the VirtualMachine that owns the pod, if there is
+// one that does. Otherwise returns nil.
+func TryPodOwnerVirtualMachine(pod *corev1.Pod) *NamespacedName {
+	for _, ref := range pod.OwnerReferences {
+		// For NeonVM, *at time of writing*, the OwnerReference has an APIVersion of
+		// "vm.neon.tech/v1". But:
+		//
+		// 1. It's good to be extra-safe around possible name collisions for the
+		//    "VirtualMachineMigration" name, even though *practically* it's not going to happen;
+		// 2. We can disambiguate with the APIVersion; and
+		// 3. We don't want to match on a fixed version, in case we want to change the version
+		//    number later.
+		//
+		// So, given that the format is "<NAME>/<VERSION>", we can just match on the "<NAME>/" part
+		// of the APIVersion to have the safety we want with the flexibility we need.
+		if strings.HasPrefix(ref.APIVersion, "vm.neon.tech/") && ref.Kind == "VirtualMachine" {
+			// note: OwnerReferences are not permitted to have a different namespace than the owned
+			// object, so because VirtualMachineMigrations are namespaced, it must have the same
+			// namespace as the Pod.
+			return &NamespacedName{Namespace: pod.Namespace, Name: ref.Name}
+		}
+	}
+	return nil
+}
+
+// TryPodOwnerVirtualMachineMigration returns the name of the VirtualMachineMigration that owns the
+// pod, if there is one. Otherwise returns nil.
+func TryPodOwnerVirtualMachineMigration(pod *corev1.Pod) *NamespacedName {
+	for _, ref := range pod.OwnerReferences {
+		if strings.HasPrefix(ref.APIVersion, "vm.neon.tech/") && ref.Kind == "VirtualMachineMigration" {
+			return &NamespacedName{Namespace: pod.Namespace, Name: ref.Name}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Resolves #398; refer there for more info.

This PR also moves the existing methods for checking whether a pod's owned by a VM or VMM into pkg/util/k8s.go, next to the other functions to check properties of pods.