### PR TITLE
Fix vm-monitor build

### DIFF
--- a/build/vm-monitor/Dockerfile
+++ b/build/vm-monitor/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.70-alpine as builder
 WORKDIR /workspace
 
-RUN apk add musl-dev git
+RUN apk add musl-dev git openssl-dev
 
 # Which branch to pull from
 ARG BRANCH

--- a/build/vm-monitor/Dockerfile
+++ b/build/vm-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70-alpine as builder
+FROM rust:1.72-alpine as builder
 WORKDIR /workspace
 
 RUN apk add musl-dev git openssl-dev


### PR DESCRIPTION
A build of `vm-monitor` started to fail with
```
#10 14.74 error: failed to run custom build command for `openssl-sys v0.9.90`
...
```
Ref: https://github.com/neondatabase/autoscaling/actions/runs/6537120014/job/17750853127?pr=569


This PR adds `openssl-dev` package to make `cargo build` happy. Also, it updates the base rust image to 1.72 to match the rust version that is used in `neondatabase/neon` repo.
