### PR TITLE
agent/core: Add rate limit for vm-monitor downscale

### DIFF
--- a/deploy/agent/config_map.yaml
+++ b/deploy/agent/config_map.yaml
@@ -23,6 +23,7 @@ data:
           "unhealthyStartupGracePeriodSeconds": 20,
           "maxHealthCheckSequentialFailuresSeconds": 30,
           "retryDeniedDownscaleSeconds": 5,
+          "deniedDownscaleFollowUpWaitSeconds"; 1,
           "requestedUpscaleValidSeconds": 10,
           "retryFailedRequestSeconds": 3
       },

--- a/deploy/agent/config_map.yaml
+++ b/deploy/agent/config_map.yaml
@@ -23,7 +23,7 @@ data:
           "unhealthyStartupGracePeriodSeconds": 20,
           "maxHealthCheckSequentialFailuresSeconds": 30,
           "retryDeniedDownscaleSeconds": 5,
-          "deniedDownscaleFollowUpWaitSeconds"; 1,
+          "deniedDownscaleFollowUpWaitSeconds": 1,
           "requestedUpscaleValidSeconds": 10,
           "retryFailedRequestSeconds": 3
       },

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -47,6 +47,9 @@ type MonitorConfig struct {
 	// RetryDeniedDownscaleSeconds gives the duration, in seconds, that we must wait before retrying
 	// a downscale request that was previously denied
 	RetryDeniedDownscaleSeconds uint `json:"retryDeniedDownscaleSeconds"`
+	// DeniedDownscaleFollowUpWaitSeconds gives the duration, in seconds, that we must wait before
+	// making another downscale request after one was just denied.
+	DeniedDownscaleFollowUpWaitSeconds uint `json:"deniedDownscaleFollowUpWaitSeconds"`
 	// RequestedUpscaleValidSeconds gives the duration, in seconds, that requested upscaling should
 	// be respected for, before allowing re-downscaling.
 	RequestedUpscaleValidSeconds uint `json:"requestedUpscaleValidSeconds"`
@@ -162,6 +165,7 @@ func (c *Config) validate() error {
 	erc.Whenf(ec, c.Monitor.MaxHealthCheckSequentialFailuresSeconds == 0, zeroTmpl, ".monitor.maxHealthCheckSequentialFailuresSeconds")
 	erc.Whenf(ec, c.Monitor.RetryFailedRequestSeconds == 0, zeroTmpl, ".monitor.retryFailedRequestSeconds")
 	erc.Whenf(ec, c.Monitor.RetryDeniedDownscaleSeconds == 0, zeroTmpl, ".monitor.retryDeniedDownscaleSeconds")
+	erc.Whenf(ec, c.Monitor.DeniedDownscaleFollowUpWaitSeconds == 0, zeroTmpl, ".monitor.deniedDownscaleFollowUpWaitSeconds")
 	erc.Whenf(ec, c.Monitor.RequestedUpscaleValidSeconds == 0, zeroTmpl, ".monitor.requestedUpscaleValidSeconds")
 	// add all errors if there are any: https://github.com/neondatabase/autoscaling/pull/195#discussion_r1170893494
 	ec.Add(c.Scaling.DefaultConfig.Validate())

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -243,6 +243,7 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger, vmInfoUpdated util
 			PluginRetryWait:                    time.Second * time.Duration(r.global.config.Scheduler.RetryFailedRequestSeconds),
 			PluginDeniedRetryWait:              time.Second * time.Duration(r.global.config.Scheduler.RetryDeniedUpscaleSeconds),
 			MonitorDeniedDownscaleCooldown:     time.Second * time.Duration(r.global.config.Monitor.RetryDeniedDownscaleSeconds),
+			MonitorDownscaleFollowUpWait:       time.Second * time.Duration(r.global.config.Monitor.DeniedDownscaleFollowUpWaitSeconds),
 			MonitorRequestedUpscaleValidPeriod: time.Second * time.Duration(r.global.config.Monitor.RequestedUpscaleValidSeconds),
 			MonitorRetryWait:                   time.Second * time.Duration(r.global.config.Monitor.RetryFailedRequestSeconds),
 			Log: core.LogConfig{


### PR DESCRIPTION
Fixes #572; bulk of the diff is just slightly tweaking the test for denied downscaling.