### PR TITLE
agent: Log when handling VM events

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -93,6 +93,7 @@ func (s *agentState) handleEvent(ctx context.Context, logger *zap.Logger, event 
 		zap.Object("virtualmachine", event.vmInfo.NamespacedName()),
 		zap.Object("pod", util.NamespacedName{Namespace: event.vmInfo.Namespace, Name: event.podName}),
 	)
+	logger.Debug("Handling event for VM")
 
 	if err := s.lock.TryLock(ctx); err != nil {
 		logger.Warn("Context canceled while starting to handle event", zap.Error(err))


### PR DESCRIPTION
Currently we don't, so it can be hard to piece together when the autoscaler-agent knew what.

May upgrade this from debug -> info, or move into the VM watcher itself. We'll see — just want _something_ for now.