### PR TITLE
vm-builder: Set pgboucer auth_dbname=postgres to fix database dropping issue

### DIFF
--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -370,6 +370,7 @@ listen_port=6432
 listen_addr=0.0.0.0
 auth_type=scram-sha-256
 auth_user=cloud_admin
+auth_dbname=postgres
 client_tls_sslmode=disable
 server_tls_sslmode=disable
 pool_mode=transaction


### PR DESCRIPTION
See https://neondb.slack.com/archives/C026T7K2YP9/p1697815383381269?thread_ts=1697643821.075019&cid=C026T7K2YP9