### PR TITLE
plugin: Fix migration source deletion event kind

### DIFF
--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -148,7 +148,7 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 				if !util.PodCompleted(oldPod) && util.PodCompleted(newPod) {
 					logger.Info("Received update event for completion of pod", zap.Object("pod", name))
 
-					if isVM {
+					if isVM || util.TryPodOwnerVirtualMachineMigration(newPod) != nil {
 						callbacks.submitVMDeletion(logger, name)
 					} else {
 						callbacks.submitPodDeletion(logger, name)
@@ -156,7 +156,7 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 					return // no other handling worthwhile if the pod's done.
 				}
 
-				// CHeck if the pod is part of a new migration, or if a migration it *was* part of
+				// Check if the pod is part of a new migration, or if a migration it *was* part of
 				// has now ended.
 				oldMigration := util.TryPodOwnerVirtualMachineMigration(oldPod)
 				newMigration := util.TryPodOwnerVirtualMachineMigration(newPod)


### PR DESCRIPTION
In short: after #563, deleting a migration before completion has caused the scheduler plugin to incorrectly interpret the deletion event for the source (or target? not entirely sure) pod as referring to a pod (rather than a VM), because all pods related to a VM will have the vm.neon.tech/name label, but only the pod currently _running_ the VM will be marked as "owned" by the VM; the other will be owned by the migration.