### PR TITLE
vm-builder: disable prepared statements support for pgbouncer

### DIFF
--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -376,7 +376,7 @@ server_tls_sslmode=disable
 pool_mode=transaction
 max_client_conn=10000
 default_pool_size=16
-max_prepared_statements=100
+max_prepared_statements=0
 `
 )
 


### PR DESCRIPTION
Disable prepared statement support for pgbouncer by setting `max_prepared_statements=0`.

It was initially enabled in https://github.com/neondatabase/autoscaling/pull/566, but we encountered some problems with them. And we can't just revert that PR (to pgbouncer 1.18) because we started to use `auth_dbname`, which is added in pgbouncer 1.19.

Ref https://neondb.slack.com/archives/C063B6SCHDX