### PR TITLE
agent: Expose per-VM size metrics on :9101

### DIFF
--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -43,7 +43,7 @@ type agentState struct {
 	vmClient             *vmclient.Clientset
 	schedulerEventBroker *pubsub.Broker[schedwatch.WatchEvent]
 	schedulerStore       *watch.Store[corev1.Pod]
-	metrics              PromMetrics
+	metrics              GlobalMetrics
 }
 
 func (r MainRunner) newAgentState(
@@ -52,7 +52,7 @@ func (r MainRunner) newAgentState(
 	broker *pubsub.Broker[schedwatch.WatchEvent],
 	schedulerStore *watch.Store[corev1.Pod],
 ) (*agentState, *prometheus.Registry) {
-	metrics, promReg := makePrometheusParts()
+	metrics, promReg := makeGlobalMetrics()
 
 	state := &agentState{
 		lock:                 util.NewChanMutex(),

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -29,6 +29,8 @@ type vmEvent struct {
 	endpointID string
 }
 
+const endpointLabel = "neon/endpoint-id"
+
 // MarshalLogObject implements zapcore.ObjectMarshaler
 func (ev vmEvent) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("kind", string(ev.kind))
@@ -56,6 +58,7 @@ func startVMWatcher(
 	config *Config,
 	vmClient *vmclient.Clientset,
 	metrics watch.Metrics,
+	perVMMetrics PerVMMetrics,
 	nodeName string,
 	submitEvent func(vmEvent),
 ) (*watch.Store[vmapi.VirtualMachine], error) {
@@ -82,6 +85,10 @@ func startVMWatcher(
 		metav1.ListOptions{},
 		watch.HandlerFuncs[*vmapi.VirtualMachine]{
 			AddFunc: func(vm *vmapi.VirtualMachine, preexisting bool) {
+				for k, v := range metricsForVM(vm) {
+					perVMMetrics.vmResources.WithLabelValues(k.labelValues()...).Set(v)
+				}
+
 				if vmIsOurResponsibility(vm, config, nodeName) {
 					event, err := makeVMEvent(logger, vm, vmEventAdded)
 					if err != nil {
@@ -95,6 +102,20 @@ func startVMWatcher(
 				}
 			},
 			UpdateFunc: func(oldVM, newVM *vmapi.VirtualMachine) {
+				oldMetrics := metricsForVM(oldVM, nodeName)
+				newMetrics := metricsForVM(newVM, nodeName)
+
+				// delete old metric label sets that are no longer present
+				for k := range oldMetrics {
+					if _, ok := newMetrics[k]; !ok {
+						perVMMetrics.vmResources.DeleteLabelValues(k.labelValues()...)
+					}
+				}
+				// set all current metric values
+				for k, v := range newMetrics {
+					perVMMetrics.vmResources.WithLabelValues(k.labelValues()...).Set(v)
+				}
+
 				oldIsOurs := vmIsOurResponsibility(oldVM, config, nodeName)
 				newIsOurs := vmIsOurResponsibility(newVM, config, nodeName)
 
@@ -128,6 +149,10 @@ func startVMWatcher(
 				submitEvent(event)
 			},
 			DeleteFunc: func(vm *vmapi.VirtualMachine, maybeStale bool) {
+				for k := range metricsForVM(vm, nodeName) {
+					perVMMetrics.vmResources.DeleteLabelValues(k.labelValues()...)
+				}
+
 				if vmIsOurResponsibility(vm, config, nodeName) {
 					event, err := makeVMEvent(logger, vm, vmEventDeleted)
 					if err != nil {
@@ -152,7 +177,7 @@ func makeVMEvent(logger *zap.Logger, vm *vmapi.VirtualMachine, kind vmEventKind)
 
 	endpointID := ""
 	if vm.Labels != nil {
-		endpointID = vm.Labels[billing.EndpointLabel] // billing needs endpoint IDs anyways, just grab the label name from there
+		endpointID = vm.Labels[endpointLabel]
 	}
 
 	return vmEvent{
@@ -188,5 +213,96 @@ func (e vmEvent) Format(state fmt.State, verb rune) {
 		if verb != 'v' {
 			state.Write([]byte{')'})
 		}
+	}
+}
+
+type vmResourceTuple struct {
+	namespace  string
+	name       string
+	endpointID string
+	resource   vmResource
+	valueType  vmResourceValueType
+}
+
+func metricsForVM(vm *vmapi.VirtualMachine, nodeName string) map[vmResourceTuple]float64 {
+	if vm.Status.Node != nodeName {
+		return nil
+	}
+
+	endpointID := vm.Labels[endpointLabel]
+
+	type kv[K any, V any] struct {
+		key   K
+		value V
+	}
+
+	metrics := make(map[vmResourceTuple]float64)
+
+	// CPU metrics derived from spec
+	specCPU := []kv[vmResourceValueType, *vmapi.MilliCPU]{
+		{key: vmResourceValueMin, value: vm.Spec.Guest.CPUs.Min},
+		{key: vmResourceValueMax, value: vm.Spec.Guest.CPUs.Max},
+		{key: vmResourceValueSpecUse, value: vm.Spec.Guest.CPUs.Use},
+	}
+	for _, t := range specCPU {
+		if t.value != nil {
+			metrics[vmResourceTuple{
+				namespace:  vm.Namespace,
+				name:       vm.Name,
+				endpointID: endpointID,
+				resource:   vmResourceCPU,
+				valueType:  t.key,
+			}] = t.value.AsFloat64()
+		}
+	}
+	// Memory metrics derived from spec
+	specMem := []kv[vmResourceValueType, *int32]{
+		{key: vmResourceValueMin, value: vm.Spec.Guest.MemorySlots.Min},
+		{key: vmResourceValueMax, value: vm.Spec.Guest.MemorySlots.Max},
+		{key: vmResourceValueSpecUse, value: vm.Spec.Guest.MemorySlots.Use},
+	}
+	for _, t := range specMem {
+		if t.value != nil {
+			metrics[vmResourceTuple{
+				namespace:  vm.Namespace,
+				name:       vm.Name,
+				endpointID: endpointID,
+				resource:   vmResourceMem,
+				valueType:  t.key,
+			}] = float64(vm.Spec.Guest.MemorySlotSize.Value() * int64(*t.value))
+		}
+	}
+
+	// Status metrics:
+	if vm.Status.CPUs != nil {
+		metrics[vmResourceTuple{
+			namespace:  vm.Namespace,
+			name:       vm.Name,
+			endpointID: endpointID,
+			resource:   vmResourceCPU,
+			valueType:  vmResourceValueStatusUse,
+		}] = vm.Status.CPUs.AsFloat64()
+	}
+	if vm.Status.MemorySize != nil {
+		// nb: convert to int64 first, because (*resource.Quantity).AsApproximateFloat64() is sometimes very inaccurate.
+		metrics[vmResourceTuple{
+			namespace:  vm.Namespace,
+			name:       vm.Name,
+			endpointID: endpointID,
+			resource:   vmResourceMem,
+			valueType:  vmResourceValueStatusUse,
+		}] = float64(vm.Status.MemorySize.Value())
+	}
+
+	return metrics
+}
+
+func (t vmResourceTuple) labelValues() []string {
+	return []string{
+		t.namespace,
+		t.name,
+		t.endpointID,
+		string(t.resource),
+		string(t.valueType),
 	}
 }


### PR DESCRIPTION
Adds a single new metric `autoscaling_vm_resources`, exposed on a different port because it's expected to be high cardinality.

The metric is parameterized by the resource ("cpu" / "mem") and by what the value represents ("min" / "spec_use" / "status_use" / "max").

CPU values are in units of CPUs, memory values are in units of bytes.

Resolves #385; related to neondatabase/cloud#6444 and neondatabase/cloud#550

---

Still need to test locally before merging.