### PR TITLE
CI: add k8s logs from e2e-tests to GitHub Summary

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -78,29 +78,64 @@ jobs:
             echo "skipping cluster logs because no cluster found in kubectl context"
             exit 0
           fi
+
           namespaces=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}')
           for namespace in $namespaces; do
+            if [[ "$namespace" == "neonvm-system" ]] || [[ "$namespace" == kuttl-test-* ]]; then
+              tee_if_needed=$GITHUB_STEP_SUMMARY
+            else
+              tee_if_needed=/dev/null
+            fi
+
+            {
+              echo "<details>"
+              echo "<summary>Namespace=$namespace</summary>"
+            } | tee -a $tee_if_needed
+
             pods=$(kubectl get pods -n $namespace -o jsonpath='{.items[*].metadata.name}')
             for pod in $pods; do
-              echo "*** Namespace=$namespace Pod=$pod ***"
+              {
+                echo "<details>"
+                echo "<summary>- Namespace=$namespace Pod=$pod Logs</summary>"
+                echo "<pre>"
+              } | tee -a $tee_if_needed
+
               restarts=$(
                 kubectl get pod -n $namespace $pod -o jsonpath='{.status.containerStatuses[0].restartCount}' || echo '0'
               )
-              if [ "$restarts" -ne 0 ]; then
-                echo "CONTAINER RESTARTED $restarts TIME(S)"
-                echo "Previous logs:"
-                kubectl logs -n $namespace -p $pod || echo 'Error getting logs'
-                echo "Current logs:"
-                kubectl logs -n $namespace $pod || echo 'Error getting logs'
-              else
-                echo "Logs:"
-                kubectl logs -n $namespace $pod || echo 'Error getting logs'
-              fi
+              {
+                if [ "$restarts" -ne 0 ]; then
+                  echo "CONTAINER RESTARTED $restarts TIME(S)"
+                  echo "Previous logs:"
+                  kubectl logs -n $namespace -p $pod || echo 'Error getting logs'
+                  echo "Current logs:"
+                  kubectl logs -n $namespace $pod || echo 'Error getting logs'
+                else
+                  echo "Logs:"
+                  kubectl logs -n $namespace $pod || echo 'Error getting logs'
+                fi
+              } | tee -a $tee_if_needed
+              {
+                echo "</pre>"
+                echo "</details>"
+              } | tee -a $tee_if_needed
 
-              echo "Events:"
-              kubectl get events --namespace $namespace --field-selector involvedObject.name=$pod || echo 'Error getting events'
-              echo ""
+              {
+                echo "<details>"
+                echo "<summary>- Namespace=$namespace Pod=$pod Events</summary>"
+                echo "<pre>"
+              } | tee -a $tee_if_needed
+
+              (kubectl get events --namespace $namespace --field-selector involvedObject.name=$pod || echo 'Error getting events') | tee -a $tee_if_needed
+
+              {
+                echo "</pre>"
+                echo "</pre>"
+                echo "</details>"
+              } | tee -a $tee_if_needed
             done
+
+            echo "</details>" | tee -a $tee_if_needed
           done
 
       - name: Cleanup


### PR DESCRIPTION
This PR attaches logs from `neonvm-system` and `kuttl-test-*` namespaces to GitHub Step Summary. 
Here's an example: https://github.com/neondatabase/autoscaling/actions/runs/6960120849?pr=597#summary-18938907450

GitHub Step Summary is limited by 1Mb, so if we have more logs then we won't be able to display it. I guess we can truncate it by 1MB, but it can be done later, for `neonvm-system` and `kuttl-test-*` namespaces 1MB is enough.

All the information is still available in the regular job output (in addition to logs and events from other namespaces)

Note that currently `kuttl-test-*` namespace got deleted automatically by `kuttl`, this will be changed in https://github.com/neondatabase/autoscaling/pull/635
