### PR TITLE
ip acquirization fix

### DIFF
--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -304,10 +304,10 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 				log.Error(err, "fail to acquire IP")
 				return err
 			}
-			virtualmachine.Status.ExtraNetIP = ip.IP.String()
-			virtualmachine.Status.ExtraNetMask = fmt.Sprintf("%d.%d.%d.%d", ip.Mask[0], ip.Mask[1], ip.Mask[2], ip.Mask[3])
 			message := fmt.Sprintf("Acquired IP %s for overlay network interface", ip.String())
 			log.Info(message)
+			virtualmachine.Status.ExtraNetIP = ip.IP.String()
+			virtualmachine.Status.ExtraNetMask = fmt.Sprintf("%d.%d.%d.%d", ip.Mask[0], ip.Mask[1], ip.Mask[2], ip.Mask[3])
 			r.Recorder.Event(virtualmachine, "Normal", "OverlayNet", message)
 		}
 		// VirtualMachine just created, change Phase to "Pending"

--- a/neonvm/pkg/ipam/ipam.go
+++ b/neonvm/pkg/ipam/ipam.go
@@ -233,8 +233,17 @@ func (i *IPAM) acquireORrelease(ctx context.Context, vmName string, vmNamespace 
 	case <-leCtx.Done():
 		err = fmt.Errorf("context got timeout while waiting to become leader")
 	}
+	if err != nil {
+		return ip, err
+	}
 
 	wg.Wait()
+
+	// if ip.String() still <nil> then probably something wrong with leader election
+	if len(ip.String()) == 0 {
+		return ip, fmt.Errorf("something wrong, probably with leader election")
+	}
+
 	return ip, ipamerr
 }
 

--- a/neonvm/pkg/ipam/ipam.go
+++ b/neonvm/pkg/ipam/ipam.go
@@ -239,8 +239,8 @@ func (i *IPAM) acquireORrelease(ctx context.Context, vmName string, vmNamespace 
 
 	wg.Wait()
 
-	// if ip.String() still <nil> then probably something wrong with leader election
-	if len(ip.String()) == 0 {
+	// ip.String() returns string "<nil>" on errors in ip struct parsing or if *ip is nil
+	if ip.String() == "<nil>" {
 		return ip, fmt.Errorf("something wrong, probably with leader election")
 	}
 


### PR DESCRIPTION
This PR:

- avoid situation when `ipam.AcquireIP` return `<nil>` as result and `<nil>` as error to prevent controller crash.