### PR TITLE
vm-builder: fail on docker errors

### DIFF
--- a/neonvm/tools/vm-builder-generic/main.go
+++ b/neonvm/tools/vm-builder-generic/main.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -242,6 +243,7 @@ var (
 
 type dockerMessage struct {
 	Stream string `json:"stream"`
+	Error  string `json:"error"`
 }
 
 func printReader(reader io.ReadCloser) error {
@@ -250,6 +252,10 @@ func printReader(reader io.ReadCloser) error {
 		candidateJSON := scanner.Bytes()
 		var msg dockerMessage
 		if err := json.Unmarshal(candidateJSON, &msg); err != nil || msg.Stream == "" {
+			if msg.Error != "" {
+				return errors.New(msg.Error)
+			}
+
 			log.Println(string(candidateJSON))
 			continue
 		}

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -399,6 +400,7 @@ var (
 
 type dockerMessage struct {
 	Stream string `json:"stream"`
+	Error  string `json:"error"`
 }
 
 func printReader(reader io.ReadCloser) error {
@@ -407,6 +409,10 @@ func printReader(reader io.ReadCloser) error {
 		candidateJSON := scanner.Bytes()
 		var msg dockerMessage
 		if err := json.Unmarshal(candidateJSON, &msg); err != nil || msg.Stream == "" {
+			if msg.Error != "" {
+				return errors.New(msg.Error)
+			}
+
 			log.Println(string(candidateJSON))
 			continue
 		}


### PR DESCRIPTION
`vm-builder` doesn't fail if it can't build Dockerfile:

```
bayandin@mbp autoscaling % make example-vms 
CGO_ENABLED=0 go build -o bin/vm-builder -ldflags "-X main.Version=v0.18.5-0-g053b34c -X main.VMMonitor=vm-monitor:dev" neonvm/tools/vm-builder/main.go
./bin/vm-builder -src postgres:15-bullseye -dst vm-postgres:15-bullseye -enable-monitor
2023/10/31 16:57:48 Setup docker connection
2023/10/31 16:57:48 Build docker image for virtual machine (disk size 1G): vm-postgres:15-bullseye
2023/10/31 16:57:51 Step 1/46 : FROM vm-monitor:dev as monitor
2023/10/31 16:57:51 
2023/10/31 16:57:52 {"errorDetail":{"message":"pull access denied for vm-monitor, repository does not exist or may require 'docker login'"},"error":"pull access denied for vm-monitor, repository does not exist or may require 'docker login'"}
bayandin@mbp autoscaling % echo $?
0
```

Here's an example on CI: https://github.com/neondatabase/autoscaling/actions/runs/6705251204/job/18219291009#step:11:124

I remember we had such a problem a couple of times in `neondatabase/neon` repo as well.


After changes from this PR:
```
bayandin@mbp autoscaling % make example-vms                                      
CGO_ENABLED=0 go build -o bin/vm-builder -ldflags "-X main.Version=v0.18.5-1-g24fc476 -X main.VMMonitor=vm-monitor:dev" neonvm/tools/vm-builder/main.go
./bin/vm-builder -src postgres:15-bullseye -dst vm-postgres:15-bullseye -enable-monitor
2023/10/31 17:02:10 Setup docker connection
2023/10/31 17:02:10 Build docker image for virtual machine (disk size 1G): vm-postgres:15-bullseye
2023/10/31 17:02:10 Step 1/46 : FROM vm-monitor:dev as monitor
2023/10/31 17:02:10 
2023/10/31 17:02:11 pull access denied for vm-monitor, repository does not exist or may require 'docker login'
make: *** [docker-build-examples] Error 1
```