### PR TITLE
Revert "neonvm/controller: Close QMP connection if Connect() fails"

### DIFF
--- a/neonvm/controllers/virtualmachine_qmp_queries.go
+++ b/neonvm/controllers/virtualmachine_qmp_queries.go
@@ -91,8 +91,6 @@ func QmpConnect(ip string, port int32) (*qmp.SocketMonitor, error) {
 		return nil, err
 	}
 	if err := mon.Connect(); err != nil {
-		// qmp.NewSocketMonitor() opens a connection; if Connect() fails, we need to make sure to close it.
-		_ = mon.Disconnect()
 		return nil, err
 	}
 


### PR DESCRIPTION
Reverts neondatabase/autoscaling#527.

Seems to be causing migration e2e tests to fail consistently. Not sure why, tbh. An example here: https://github.com/neondatabase/autoscaling/actions/runs/6722147149