### PR TITLE
Replace ADD with COPY where possible

### DIFF
--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -10,7 +10,7 @@ ARG CA_GIT_TAG
 RUN git clone --depth=1 -b $CA_GIT_TAG https://github.com/kubernetes/autoscaler
 
 # Only ADD the patch after downloading, to avoid wrecking the cache
-ADD ca.patch ca.patch
+COPY ca.patch ca.patch
 RUN git -C autoscaler apply ../ca.patch
 
 RUN cd autoscaler/cluster-autoscaler \

--- a/neonvm/tools/vm-builder/files/Dockerfile.img
+++ b/neonvm/tools/vm-builder/files/Dockerfile.img
@@ -62,12 +62,12 @@ RUN set -e \
     | tar xzvf - --strip-components 3 -C /neonvm/bin/ ./vector-x86_64-unknown-linux-musl/bin/vector
 
 # init scripts
-ADD inittab   /neonvm/bin/inittab
-ADD vminit    /neonvm/bin/vminit
-ADD vmstart   /neonvm/bin/vmstart
-ADD vmshutdown /neonvm/bin/vmshutdown
-ADD vmacpi    /neonvm/acpi/vmacpi
-ADD vector.yaml /neonvm/config/vector.yaml
+COPY inittab     /neonvm/bin/inittab
+COPY vminit      /neonvm/bin/vminit
+COPY vmstart     /neonvm/bin/vmstart
+COPY vmshutdown  /neonvm/bin/vmshutdown
+COPY vmacpi      /neonvm/acpi/vmacpi
+COPY vector.yaml /neonvm/config/vector.yaml
 RUN chmod +rx /neonvm/bin/vminit /neonvm/bin/vmstart /neonvm/bin/vmshutdown
 
 FROM vm-runtime AS builder

--- a/vm-examples/pg14-disk-test/image-spec.yaml
+++ b/vm-examples/pg14-disk-test/image-spec.yaml
@@ -73,12 +73,12 @@ build: |
 merge: |
   RUN adduser vm-monitor --disabled-password --no-create-home
 
-  ADD cgconfig.conf         /etc/cgconfig.conf
-  ADD postgresql.conf       /etc/postgresql.conf
-  ADD pg_hba.conf           /etc/pg_hba.conf
-  ADD sshd_config           /etc/ssh/sshd_config
-  ADD ssh_id_rsa.pub        /etc/ssh/authorized_keys
-  ADD generate-sshd-keys.sh /bin/generate-sshd-keys.sh
+  COPY cgconfig.conf         /etc/cgconfig.conf
+  COPY postgresql.conf       /etc/postgresql.conf
+  COPY pg_hba.conf           /etc/pg_hba.conf
+  COPY sshd_config           /etc/ssh/sshd_config
+  COPY ssh_id_rsa.pub        /etc/ssh/authorized_keys
+  COPY generate-sshd-keys.sh /bin/generate-sshd-keys.sh
 
   # General tools
   RUN set -e \


### PR DESCRIPTION
Got some complaints from the arnica bot while moving things around (https://github.com/neondatabase/autoscaling/pull/603#discussion_r1379479661), figured I'd resolve it repo-wide.

IIUC the short explanation for "why COPY instead of ADD" is that COPY can only ever copy files on the system, whereas ADD can fetch from URLs, so it's fundamentally less secure.

**This PR builds on #603 and must not be merged before it.**