### PR TITLE
vm-builder: Use same output format as `docker build`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/vishvananda/netlink v1.1.1-0.20220125195016-0639e7e787ba
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
+	golang.org/x/term v0.13.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.11
 	k8s.io/apimachinery v0.25.11
@@ -136,6 +137,7 @@ require (
 	github.com/moby/term v0.0.0-20221205130635-1aeaba878587 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
@@ -171,7 +173,6 @@ require (
 	golang.org/x/oauth2 v0.4.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
-	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect
 	golang.org/x/tools v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -366,6 +366,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
+github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -523,8 +523,11 @@ func main() {
 
 	defer buildResp.Body.Close()
 
-	out := os.Stdout
-	err = jsonmessage.DisplayJSONMessagesStream(buildResp.Body, out, out.Fd(), term.IsTerminal(int(out.Fd())), nil)
+	out := io.Writer(os.Stdout)
+	if *quiet {
+		out = io.Discard
+	}
+	err = jsonmessage.DisplayJSONMessagesStream(buildResp.Body, out, os.Stdout.Fd(), term.IsTerminal(int(os.Stdout.Fd())), nil)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"archive/tar"
-	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -20,6 +18,8 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 )
 
@@ -293,28 +293,6 @@ type dockerMessage struct {
 	Error  string `json:"error"`
 }
 
-func printReader(reader io.ReadCloser) error {
-	scanner := bufio.NewScanner(reader)
-	for scanner.Scan() {
-		candidateJSON := scanner.Bytes()
-		var msg dockerMessage
-		if err := json.Unmarshal(candidateJSON, &msg); err != nil || msg.Stream == "" {
-			if msg.Error != "" {
-				return errors.New(msg.Error)
-			}
-
-			log.Println(string(candidateJSON))
-			continue
-		}
-
-		log.Print(msg.Stream)
-	}
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-	return nil
-}
-
 func AddTemplatedFileToTar(tw *tar.Writer, tmplArgs any, filename string, tmplString string) error {
 	tmpl, err := template.New(filename).Parse(tmplString)
 	if err != nil {
@@ -543,10 +521,11 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	// do quiet build - discard output
-	//io.Copy(io.Discard, buildResp.Body)
+	defer buildResp.Body.Close()
 
-	if err = printReader(buildResp.Body); err != nil {
+	out := os.Stdout
+	err = jsonmessage.DisplayJSONMessagesStream(buildResp.Body, out, out.Fd(), term.IsTerminal(int(out.Fd())), nil)
+	if err != nil {
 		log.Fatalln(err)
 	}
 


### PR DESCRIPTION
We've periodically opened PRs to slightly improve the output of vm-builder by handling more message types (#280, #599). But the actual implementation that `docker build` uses is available for us, so we might as well use that instead.

In the future, it'd be cool to use buildkit here to mimic the better styling from `docker buildx build`, but its source code is much harder to navigate.

---

Tested locally and validated that this works as expected under normal circumstances - greatly improves output, particularly while building vm-monitor.

TODO:

- [x] Check that vm-builder still exits with nonzero status on build failure
- [x] Adapt this PR to respect `-quiet`

---

**This PR builds on #600 and must not be merged before it.**