### PR TITLE
neonvm/controller: Remove noisy webhook validation log lines

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
@@ -127,7 +127,6 @@ func (r *VirtualMachine) ValidateCreate() error {
 
 	// validate .spec.guest.ports[].name
 	for _, port := range r.Spec.Guest.Ports {
-		virtualmachinelog.Info("validate port ", "name", port.Name)
 		if len(port.Name) != 0 && port.Name == "qmp" {
 			return errors.New("'qmp' is reserved name for .spec.guest.ports[].name")
 		}

--- a/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
@@ -110,7 +110,6 @@ func (r *VirtualMachine) ValidateCreate() error {
 
 	// validate .spec.disk names
 	for _, disk := range r.Spec.Disks {
-		virtualmachinelog.Info("validate disk", "name", disk.Name)
 		if disk.Name == "virtualmachineimages" {
 			return errors.New("'virtualmachineimages' is reserved name for .spec.disks[].name")
 		}


### PR DESCRIPTION
Noticed this while debugging something unrelated. It doesn't even include the VM name. For example, I saw log lines like this:

```
{"level":"info","ts":"2023-11-04T00:48:59.556Z","logger":"virtualmachine-resource","msg":"validate port ","name":""}
{"level":"info","ts":"2023-11-04T00:48:59.556Z","logger":"virtualmachine-resource","msg":"validate port ","name":""}
{"level":"info","ts":"2023-11-04T00:48:59.556Z","logger":"virtualmachine-resource","msg":"validate port ","name":""}
{"level":"info","ts":"2023-11-04T00:48:59.556Z","logger":"virtualmachine-resource","msg":"validate port ","name":""}
```

---

Todo before merging:

- [x] Check for other, similar log lines in prod (maybe other log lines that should be improved or removed)