### PR TITLE
agent/executor: Fix use of plugin in DoMonitorUpscales

### DIFF
--- a/pkg/agent/executor/exec_monitor.go
+++ b/pkg/agent/executor/exec_monitor.go
@@ -123,7 +123,7 @@ func (c *ExecutorCoreWithClients) DoMonitorUpscales(ctx context.Context, logger 
 
 	// must be called while holding c's lock
 	generationUnchanged := func(since MonitorHandle) bool {
-		return since.Generation() == c.clients.Plugin.CurrentGeneration()
+		return since.Generation() == c.clients.Monitor.CurrentGeneration()
 	}
 
 	for {


### PR DESCRIPTION
Because of this issue, if the scheduler restarted while an upscale request was ongoing, the agent would incorrectly believe that this upscale request was permanently ongoing and never try to make another upscale or downscale request to the vm-monitor.