### PR TITLE
CI: run vm-kernel pipeline on bigger GitHub-hosted runner

### DIFF
--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -43,7 +43,7 @@ jobs:
           context: neonvm/hack
           platforms: linux/amd64
           # Push only if this is a scheduled run or if the workflow_dispatch input push is set to true
-          push: ${{ github.event_name == 'schedule' && 'true' || ( github.event_name == 'workflow_dispatch' && inputs.push || 'do not know if we should push or not, it will fail' ) }}
+          push: ${{ github.event_name == 'schedule' && 'true' || ( github.event_name == 'workflow_dispatch' && inputs.push || 'false' ) }}
           pull: true
           no-cache: true
           file: neonvm/hack/Dockerfile.kernel-builder

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   vm-kernel:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, gen3, large ]
     steps:
 
       - name: git checkout

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -19,7 +19,8 @@ env:
 
 jobs:
   vm-kernel:
-    runs-on: [ self-hosted, gen3, large ]
+    # Use the biggest GitHub Hosted runner
+    runs-on: kernel-builder
     steps:
 
       - name: git checkout


### PR DESCRIPTION
Testing this in manually-triggered run https://github.com/neondatabase/autoscaling/actions/runs/6870946818

Doesn't work because of credential error.