### PR TITLE
Update to Rust 1.74

### DIFF
--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -51,7 +51,7 @@ files:
 
 build: |
   # Build vm-monitor
-  FROM rust:1.72-alpine as monitor-builder
+  FROM rust:1.74-alpine as monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev

--- a/vm-examples/pg14-disk-test/image-spec.yaml
+++ b/vm-examples/pg14-disk-test/image-spec.yaml
@@ -43,7 +43,7 @@ files:
     hostPath: cgconfig.conf
 build: |
   # Build vm-monitor
-  FROM rust:1.72-alpine as monitor-builder
+  FROM rust:1.74-alpine as monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev


### PR DESCRIPTION
Right now, this is only used to build vm-builder from `neondatabase/neon`, for the testing images.

I don't _think_ there's ordering requirements here with neondatabase/build#73 or neondatabase/neon#5873 (seems like no backwards-incompatible changes), but cc @arpad-m just in case.