### PR TITLE
CI: Use the latest kernel in e2e tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_call:
+    inputs:
+      kernel-image:
+        type: string
+        description: 'The kernel image to use for the VMs'
+        required: false
 
 jobs:
   e2e-tests:
@@ -42,6 +48,7 @@ jobs:
           docker buildx version
 
       - name: Build Linux kernel
+        if: inputs.kernel-image == ''
         uses: docker/build-push-action@v3
         with:
           build-args: KERNEL_VERSION=${{ env.VM_KERNEL_VERSION }}
@@ -59,7 +66,14 @@ jobs:
 
       - name: Load VM kernel
         run: |
-          ID=$(docker create ${VM_KERNEL_IMAGE}:${VM_KERNEL_VERSION}-${{ matrix.cluster }}-${{ github.run_id}}-${{ github.run_attempt }} true)
+          if [ -z "${{ inputs.kernel-image }}" ]; then
+            IMAGE="${VM_KERNEL_IMAGE}:${VM_KERNEL_VERSION}-${{ matrix.cluster }}-${{ github.run_id}}-${{ github.run_attempt }}"
+          else
+            IMAGE="${{ inputs.kernel-image }}"
+            docker pull --quiet $IMAGE
+          fi
+
+          ID=$(docker create ${IMAGE} true)
           docker cp ${ID}:/vmlinuz neonvm/hack/vmlinuz
           docker rm -f ${ID}
         env:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      kernel-image:
+        type: string
+        description: 'The kernel image to use for the VMs. If not specified, a kernel will be built from source'
+        required: false
   workflow_call:
     inputs:
       kernel-image:
@@ -61,7 +67,7 @@ jobs:
           file: neonvm/hack/Dockerfile.kernel-builder
           tags: ${{ env.VM_KERNEL_IMAGE }}:${{ env.VM_KERNEL_VERSION }}-${{ matrix.cluster }}-${{ github.run_id}}-${{ github.run_attempt }}
         env:
-          VM_KERNEL_IMAGE:   "neondatabase/vm-kernel-do-not-push"
+          VM_KERNEL_IMAGE:   "neondatabase/local-vm-kernel"
           VM_KERNEL_VERSION: "6.1.63"
 
       - name: Load VM kernel
@@ -77,7 +83,7 @@ jobs:
           docker cp ${ID}:/vmlinuz neonvm/hack/vmlinuz
           docker rm -f ${ID}
         env:
-          VM_KERNEL_IMAGE:   "neondatabase/vm-kernel-do-not-push"
+          VM_KERNEL_IMAGE:   "neondatabase/local-vm-kernel"
           VM_KERNEL_VERSION: "6.1.63"
 
       # our docker builds use the output of 'git describe' for embedding git information

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -41,15 +41,29 @@ jobs:
           docker version
           docker buildx version
 
-      # To save some time use prebuilt vm kernel instead of running `make kernel` (see .github/workflows/release.yaml)
+      - name: Build Linux kernel
+        uses: docker/build-push-action@v3
+        with:
+          build-args: KERNEL_VERSION=${{ env.VM_KERNEL_VERSION }}
+          context: neonvm/hack
+          platforms: linux/amd64
+          push: false
+          load: true
+          pull: true
+          no-cache: true
+          file: neonvm/hack/Dockerfile.kernel-builder
+          tags: ${{ env.VM_KERNEL_IMAGE }}:${{ env.VM_KERNEL_VERSION }}-${{ matrix.cluster }}-${{ github.run_id}}-${{ github.run_attempt }}
+        env:
+          VM_KERNEL_IMAGE:   "neondatabase/vm-kernel-do-not-push"
+          VM_KERNEL_VERSION: "6.1.63"
+
       - name: Load VM kernel
         run: |
-          docker pull --quiet ${VM_KERNEL_IMAGE}:${VM_KERNEL_VERSION}
-          ID=$(docker create ${VM_KERNEL_IMAGE}:${VM_KERNEL_VERSION} true)
+          ID=$(docker create ${VM_KERNEL_IMAGE}:${VM_KERNEL_VERSION}-${{ matrix.cluster }}-${{ github.run_id}}-${{ github.run_attempt }} true)
           docker cp ${ID}:/vmlinuz neonvm/hack/vmlinuz
           docker rm -f ${ID}
         env:
-          VM_KERNEL_IMAGE: "neondatabase/vm-kernel"
+          VM_KERNEL_IMAGE:   "neondatabase/vm-kernel-do-not-push"
           VM_KERNEL_VERSION: "6.1.63"
 
       # our docker builds use the output of 'git describe' for embedding git information

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -19,6 +19,9 @@ env:
 
 jobs:
   vm-kernel:
+    outputs:
+      image: ${{ fromJSON(steps.build-linux-kernel.outputs.metadata)['image.name'] }}@${{ steps.build-linux-kernel.outputs.digest }}
+
     # Use the biggest GitHub Hosted runner
     runs-on: gha-ubuntu-22.04-64cores
     steps:
@@ -37,6 +40,7 @@ jobs:
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
       - name: build linux kernel
+        id: build-linux-kernel
         uses: docker/build-push-action@v3
         with:
           build-args: KERNEL_VERSION=${{ env.VM_KERNEL_VERSION }}
@@ -49,3 +53,9 @@ jobs:
           file: neonvm/hack/Dockerfile.kernel-builder
           # Tag the image with the tag from the workflow_dispatch input or the VM_KERNEL_VERSION env var
           tags: ${{ env.VM_KERNEL_IMAGE }}:${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || env.VM_KERNEL_VERSION }}
+
+  e2e-tests:
+    needs: vm-kernel
+    uses: ./.github/workflows/e2e-test.yaml
+    with:
+      kernel-image: ${{ needs.vm-kernel.outputs.image }}


### PR DESCRIPTION
- Build VM Kernel for e2e tests (the naive approach without caches takes ~3m)
- Make `vm-kernel` job to trigger e2e with this freshly built kernel
- Allow to trigger e2e tests with specified kernel

Things to improve (in the future PRs):
- `e2e-tests:` Use cached kernel version if it has no changes
- `vm-kernel`: Do not push kernel image if e2e tests with it fails