### PR TITLE
CI: fix vm-example job

### DIFF
--- a/.github/workflows/vm-example.yaml
+++ b/.github/workflows/vm-example.yaml
@@ -18,8 +18,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: build vm-builder-generic
-        run:  make bin/vm-builder-generic
+      - name: build vm-builder
+        run:  make bin/vm-builder
 
       - name: docker - install qemu
         uses: docker/setup-qemu-action@v2
@@ -32,26 +32,26 @@ jobs:
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
       - name: build vm-alpine:3.16
-        run:  bin/vm-builder-generic -src alpine:3.16 -dst neondatabase/vm-alpine:3.16
+        run:  bin/vm-builder -src alpine:3.16 -dst neondatabase/vm-alpine:3.16
       - name: push vm-alpine:3.16
         run:  docker push -q neondatabase/vm-alpine:3.16
 
       - name: build vm-ubuntu:22.04
-        run:  bin/vm-builder-generic -src ubuntu:22.04 -dst neondatabase/vm-ubuntu:22.04
+        run:  bin/vm-builder -src ubuntu:22.04 -dst neondatabase/vm-ubuntu:22.04
       - name: push  vm-ubuntu:22.04
         run:  docker push -q neondatabase/vm-ubuntu:22.04
 
       - name: build vm-debian:11
-        run:  bin/vm-builder-generic -src debian:11 -dst neondatabase/vm-debian:11
+        run:  bin/vm-builder -src debian:11 -dst neondatabase/vm-debian:11
       - name: push  vm-debian:11
         run:  docker push -q neondatabase/vm-debian:11
 
       - name: build vm-postgres:14-alpine
-        run:  bin/vm-builder-generic -src postgres:14-alpine -dst neondatabase/vm-postgres:14-alpine
+        run:  bin/vm-builder -src postgres:14-alpine -dst neondatabase/vm-postgres:14-alpine
       - name: push vm-postgres:14-alpine
         run:  docker push -q neondatabase/vm-postgres:14-alpine
 
       - name: build vm-postgres:15-alpine
-        run:  bin/vm-builder-generic -src postgres:15-alpine -dst neondatabase/vm-postgres:15-alpine
+        run:  bin/vm-builder -src postgres:15-alpine -dst neondatabase/vm-postgres:15-alpine
       - name: push vm-postgres:15-alpine
         run:  docker push -q neondatabase/vm-postgres:15-alpine


### PR DESCRIPTION
Fix `vm-example` job that has leftovers usages of `vm-builder-generic`

A CI run of fixed workflow: https://github.com/neondatabase/autoscaling/actions/runs/6947480644