### PR TITLE
CI: increase timeout and disable cache for actions/setup-go

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
         # Sometimes setup-go gets stuck. Without this, it'll keep going until the job gets killed
-        timeout-minutes: 5
+        timeout-minutes: 10
 
       - uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -34,6 +34,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          # Disable cache on self-hosted runners to avoid /usr/bin/tar errors, see https://github.com/actions/setup-go/issues/403
+          cache: false
         # Sometimes setup-go gets stuck. Without this, it'll keep going until the job gets killed
         timeout-minutes: 10
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
   check-go-mod-tidy:
     name: check go mod tidy
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+        timeout-minutes: 10
 
       - name: check everything builds
         run: go build ./...

--- a/.github/workflows/vm-example.yaml
+++ b/.github/workflows/vm-example.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+        timeout-minutes: 10
 
       - name: build vm-builder
         run:  make bin/vm-builder


### PR DESCRIPTION
Sometimes 5 minutes is insufficient for `actions/setup-go` to finish. Increase timeout to 10 minutes.
An example: https://github.com/neondatabase/autoscaling/actions/runs/6947476796/job/18901335316?pr=641

On self-hosted runners, `actions/setup-go` doesn't play nice with cache, so the action takes ~1.5m, due to a lot of errors from `/usr/bin/tar`. Disable cache for self-hosted runners to avoid these warnings and speed up the action call on self-hosted runners (with disabled cache it takes less than 10s).
An example: https://github.com/neondatabase/autoscaling/actions/runs/7070592454/job/19247430600

Part of https://github.com/neondatabase/autoscaling/issues/660
