### PR TITLE
[DON'T MERGE] [Autoscaler] autoscaler sends consumption to cplane

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -4,7 +4,7 @@
       {
         "path": ".billing",
         "value": {
-          "url": "https://vector-usage-tracking.service.us-east-2.internal.aws.neon.tech/v1",
+          "url": "http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1/usage_events",
           "cpuMetricName": "effective_compute_seconds",
           "activeTimeMetricName": "active_time_seconds",
           "collectEverySeconds": 4,

--- a/patches.json
+++ b/patches.json
@@ -4,7 +4,7 @@
       {
         "path": ".billing",
         "value": {
-          "url": "http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1/usage_events",
+          "url": "http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1",
           "cpuMetricName": "effective_compute_seconds",
           "activeTimeMetricName": "active_time_seconds",
           "collectEverySeconds": 4,

--- a/prod-ap-southeast-1-epsilon/autoscaler-agent.yaml
+++ b/prod-ap-southeast-1-epsilon/autoscaler-agent.yaml
@@ -45,7 +45,7 @@ data:
     : \"autoscale-scheduler\",\n    \"requestTimeoutSeconds\": 2,\n    \"requestAtLeastEverySeconds\"\
     : 5,\n    \"retryFailedRequestSeconds\": 3,\n    \"retryDeniedUpscaleSeconds\"\
     : 2,\n    \"requestPort\": 10299\n  },\n  \"dumpState\": {\n    \"port\": 10300,\n\
-    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"https://vector-usage-tracking.service.us-east-2.internal.aws.neon.tech/v1\"\
+    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1\"\
     ,\n    \"cpuMetricName\": \"effective_compute_seconds\",\n    \"activeTimeMetricName\"\
     : \"active_time_seconds\",\n    \"collectEverySeconds\": 4,\n    \"accumulateEverySeconds\"\
     : 24,\n    \"pushEverySeconds\": 30,\n    \"pushRequestTimeoutSeconds\": 30,\n\

--- a/prod-eu-central-1-gamma/autoscaler-agent.yaml
+++ b/prod-eu-central-1-gamma/autoscaler-agent.yaml
@@ -45,7 +45,7 @@ data:
     : \"autoscale-scheduler\",\n    \"requestTimeoutSeconds\": 2,\n    \"requestAtLeastEverySeconds\"\
     : 5,\n    \"retryFailedRequestSeconds\": 3,\n    \"retryDeniedUpscaleSeconds\"\
     : 2,\n    \"requestPort\": 10299\n  },\n  \"dumpState\": {\n    \"port\": 10300,\n\
-    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"https://vector-usage-tracking.service.us-east-2.internal.aws.neon.tech/v1\"\
+    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1\"\
     ,\n    \"cpuMetricName\": \"effective_compute_seconds\",\n    \"activeTimeMetricName\"\
     : \"active_time_seconds\",\n    \"collectEverySeconds\": 4,\n    \"accumulateEverySeconds\"\
     : 24,\n    \"pushEverySeconds\": 30,\n    \"pushRequestTimeoutSeconds\": 30,\n\

--- a/prod-il-central-1-iota/autoscaler-agent.yaml
+++ b/prod-il-central-1-iota/autoscaler-agent.yaml
@@ -45,7 +45,7 @@ data:
     : \"autoscale-scheduler\",\n    \"requestTimeoutSeconds\": 2,\n    \"requestAtLeastEverySeconds\"\
     : 5,\n    \"retryFailedRequestSeconds\": 3,\n    \"retryDeniedUpscaleSeconds\"\
     : 2,\n    \"requestPort\": 10299\n  },\n  \"dumpState\": {\n    \"port\": 10300,\n\
-    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"https://vector-usage-tracking.service.us-east-2.internal.aws.neon.tech/v1\"\
+    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1\"\
     ,\n    \"cpuMetricName\": \"effective_compute_seconds\",\n    \"activeTimeMetricName\"\
     : \"active_time_seconds\",\n    \"collectEverySeconds\": 4,\n    \"accumulateEverySeconds\"\
     : 24,\n    \"pushEverySeconds\": 30,\n    \"pushRequestTimeoutSeconds\": 30,\n\

--- a/prod-us-east-1-theta/autoscaler-agent.yaml
+++ b/prod-us-east-1-theta/autoscaler-agent.yaml
@@ -45,7 +45,7 @@ data:
     : \"autoscale-scheduler\",\n    \"requestTimeoutSeconds\": 2,\n    \"requestAtLeastEverySeconds\"\
     : 5,\n    \"retryFailedRequestSeconds\": 3,\n    \"retryDeniedUpscaleSeconds\"\
     : 2,\n    \"requestPort\": 10299\n  },\n  \"dumpState\": {\n    \"port\": 10300,\n\
-    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"https://vector-usage-tracking.service.us-east-2.internal.aws.neon.tech/v1\"\
+    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1\"\
     ,\n    \"cpuMetricName\": \"effective_compute_seconds\",\n    \"activeTimeMetricName\"\
     : \"active_time_seconds\",\n    \"collectEverySeconds\": 4,\n    \"accumulateEverySeconds\"\
     : 24,\n    \"pushEverySeconds\": 30,\n    \"pushRequestTimeoutSeconds\": 30,\n\

--- a/prod-us-east-2-delta/autoscaler-agent.yaml
+++ b/prod-us-east-2-delta/autoscaler-agent.yaml
@@ -45,7 +45,7 @@ data:
     : \"autoscale-scheduler\",\n    \"requestTimeoutSeconds\": 2,\n    \"requestAtLeastEverySeconds\"\
     : 5,\n    \"retryFailedRequestSeconds\": 3,\n    \"retryDeniedUpscaleSeconds\"\
     : 2,\n    \"requestPort\": 10299\n  },\n  \"dumpState\": {\n    \"port\": 10300,\n\
-    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"https://vector-usage-tracking.service.us-east-2.internal.aws.neon.tech/v1\"\
+    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1\"\
     ,\n    \"cpuMetricName\": \"effective_compute_seconds\",\n    \"activeTimeMetricName\"\
     : \"active_time_seconds\",\n    \"collectEverySeconds\": 4,\n    \"accumulateEverySeconds\"\
     : 24,\n    \"pushEverySeconds\": 30,\n    \"pushRequestTimeoutSeconds\": 30,\n\

--- a/prod-us-west-2-eta/autoscaler-agent.yaml
+++ b/prod-us-west-2-eta/autoscaler-agent.yaml
@@ -45,7 +45,7 @@ data:
     : \"autoscale-scheduler\",\n    \"requestTimeoutSeconds\": 2,\n    \"requestAtLeastEverySeconds\"\
     : 5,\n    \"retryFailedRequestSeconds\": 3,\n    \"retryDeniedUpscaleSeconds\"\
     : 2,\n    \"requestPort\": 10299\n  },\n  \"dumpState\": {\n    \"port\": 10300,\n\
-    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"https://vector-usage-tracking.service.us-east-2.internal.aws.neon.tech/v1\"\
+    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1\"\
     ,\n    \"cpuMetricName\": \"effective_compute_seconds\",\n    \"activeTimeMetricName\"\
     : \"active_time_seconds\",\n    \"collectEverySeconds\": 4,\n    \"accumulateEverySeconds\"\
     : 24,\n    \"pushEverySeconds\": 30,\n    \"pushRequestTimeoutSeconds\": 30,\n\


### PR DESCRIPTION
This must be merged after autoscaler is configured in the same way for staging `eu-west-1`. 

This configures autoscaler to send consumption to cplane instead of directly to console.

https://github.com/neondatabase/cloud/issues/7144