### PR TITLE
[Autoscaler] autoscaler consumption to staging cplane in eu-west-1

### DIFF
--- a/dev-eu-west-1-zeta/autoscaler-agent.yaml
+++ b/dev-eu-west-1-zeta/autoscaler-agent.yaml
@@ -46,7 +46,7 @@ data:
     \   \"requestTimeoutSeconds\": 2,\n    \"requestAtLeastEverySeconds\": 5,\n  \
     \  \"retryFailedRequestSeconds\": 3,\n    \"retryDeniedUpscaleSeconds\": 2,\n\
     \    \"requestPort\": 10299\n  },\n  \"dumpState\": {\n    \"port\": 10300,\n\
-    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"https://vector-usage-tracking.beta.us-east-2.internal.aws.neon.build/v1\"\
+    \    \"timeoutSeconds\": 5\n  },\n  \"billing\": {\n    \"url\": \"http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1\"\
     ,\n    \"cpuMetricName\": \"effective_compute_seconds\",\n    \"activeTimeMetricName\"\
     : \"active_time_seconds\",\n    \"collectEverySeconds\": 4,\n    \"accumulateEverySeconds\"\
     : 24,\n    \"pushEverySeconds\": 30,\n    \"pushRequestTimeoutSeconds\": 30,\n\

--- a/patches.json
+++ b/patches.json
@@ -18,7 +18,9 @@
     "dev-eu-central-1-alpha": [
       { "path": ".billing", "value": null }
     ],
-    "dev-eu-west-1-zeta": [],
+    "dev-eu-west-1-zeta": [
+      { "path": ".billing.url", "value": "http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1/usage_events" }
+    ],
     "dev-us-east-2-beta": []
   },
   "autoscale-scheduler": {

--- a/patches.json
+++ b/patches.json
@@ -19,7 +19,7 @@
       { "path": ".billing", "value": null }
     ],
     "dev-eu-west-1-zeta": [
-      { "path": ".billing.url", "value": "http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1/usage_events" }
+      { "path": ".billing.url", "value": "http://neon-vector.neon-control-plane.svc.cluster.local:8082/v1" }
     ],
     "dev-us-east-2-beta": []
   },


### PR DESCRIPTION
This configures autoscaler to send consumption to cplane instead of directly to console in staging region eu-west-1.

https://github.com/neondatabase/cloud/issues/7144