### PR TITLE
agent/execbridge: Fix plugin approved resource metrics

### DIFF
--- a/pkg/agent/execbridge.go
+++ b/pkg/agent/execbridge.go
@@ -86,7 +86,7 @@ func (h *execPluginHandle) Request(
 	resp, err := h.scheduler.DoRequest(ctx, logger, target, metrics)
 
 	if err == nil && lastPermit != nil {
-		h.runner.recordResourceChange(*lastPermit, target, h.runner.global.metrics.schedulerApprovedChange)
+		h.runner.recordResourceChange(*lastPermit, resp.Permit, h.runner.global.metrics.schedulerApprovedChange)
 	}
 
 	return resp, err


### PR DESCRIPTION
In short: Regardless what the response was, we recorded metrics as if the plugin had approved everything up to the target, which was not necessarily true. It's more correct to use the actual response.