### PR TITLE
vm-builder: Set vector scrape interval from 15s to 1s

### DIFF
--- a/neonvm/tools/vm-builder/files/vector.yaml
+++ b/neonvm/tools/vm-builder/files/vector.yaml
@@ -14,6 +14,7 @@ sources:
       mountPoints:
         excludes: ["*/proc/sys/fs/binfmt_misc"]
     type: host_metrics
+    scrape_interval_secs: 4 # default is 15, but we scrape every 5s in autoscaler-agent
 sinks:
   prom_exporter:
     type: prometheus_exporter

--- a/neonvm/tools/vm-builder/files/vector.yaml
+++ b/neonvm/tools/vm-builder/files/vector.yaml
@@ -14,7 +14,7 @@ sources:
       mountPoints:
         excludes: ["*/proc/sys/fs/binfmt_misc"]
     type: host_metrics
-    scrape_interval_secs: 4 # default is 15, but we scrape every 5s in autoscaler-agent
+    scrape_interval_secs: 1 # default is 15, but we scrape every 5s in autoscaler-agent
 sinks:
   prom_exporter:
     type: prometheus_exporter


### PR DESCRIPTION
Per the comment: The [default interval is every 15s](https://vector.dev/docs/reference/configuration/sources/host_metrics/#scrape_interval_secs), but we fetch these every 5s from the autoscaler-agent.

This should have the net effect of making the scaling algorithm more responsive, because we should stop getting (as many) sequential responses that are exactly the same.

Unfortunately, load average is only recalculated every 5 seconds anyways, so we may still get repeated values there, but this should at least be an improvement.

---

Requested review because I'm not sure if there's something I'm missing that may make this a bad idea. Maybe we want to prune the list of exposed metrics, in case the scraping actually becomes intensive?