### PR TITLE
plugin: Make compute unit config global

### DIFF
--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -26,10 +26,10 @@ data:
   autoscale-enforcer-config.json: |
     {
       "memBlockSize": "1Gi",
+      "computeUnit": { "vCPUs": 0.25, "mem": 1 },
       "nodeConfig": {
         "cpu": { "watermark": 0.9 },
         "memory": { "watermark": 0.9 },
-        "computeUnit": { "vCPUs": 0.25, "mem": 1 },
         "minUsageScore": 0.5,
         "maxUsageScore": 0,
         "scorePeak": 0.8

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -21,6 +21,9 @@ import (
 //////////////////
 
 type Config struct {
+	// ComputeUnit is the desired ratio between CPU and memory that autoscaler-agents should uphold
+	//
+	// This value is sent to autoscaler-agents in every response, as part of api.PluginResponse.
 	ComputeUnit api.Resources `json:"computeUnit"`
 
 	// NodeConfig defines our policies around node resources and scoring

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -21,6 +21,8 @@ import (
 //////////////////
 
 type Config struct {
+	ComputeUnit api.Resources `json:"computeUnit"`
+
 	// NodeConfig defines our policies around node resources and scoring
 	NodeConfig nodeConfig `json:"nodeConfig"`
 	// MemSlotSize is the smallest unit of memory that the scheduler plugin will reserve for a VM,
@@ -77,9 +79,8 @@ type Config struct {
 }
 
 type nodeConfig struct {
-	Cpu         resourceConfig `json:"cpu"`
-	Memory      resourceConfig `json:"memory"`
-	ComputeUnit api.Resources  `json:"computeUnit"`
+	Cpu    resourceConfig `json:"cpu"`
+	Memory resourceConfig `json:"memory"`
 
 	// Details about node scoring:
 	// See also: https://www.desmos.com/calculator/wg8s0yn63s
@@ -131,6 +132,10 @@ func (c *Config) validate() (string, error) {
 		return fmt.Sprintf("nodeConfig.%s", path), err
 	}
 
+	if err := c.ComputeUnit.ValidateNonZero(); err != nil {
+		return "computeUnit", err
+	}
+
 	if c.MemSlotSize.Value() <= 0 {
 		return "memBlockSize", errors.New("value must be > 0")
 	} else if c.MemSlotSize.Value() <= math.MaxInt64/1000 && c.MemSlotSize.MilliValue()%1000 != 0 {
@@ -160,9 +165,6 @@ func (c *nodeConfig) validate() (string, error) {
 	}
 	if path, err := c.Memory.validate(); err != nil {
 		return fmt.Sprintf("memory.%s", path), err
-	}
-	if err := c.ComputeUnit.ValidateNonZero(); err != nil {
-		return "computeUnit", err
 	}
 
 	if c.MinUsageScore < 0 || c.MinUsageScore > 1 {

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -197,16 +197,15 @@ func (e *AutoscaleEnforcer) handleAgentRequest(
 	resp := api.PluginResponse{
 		Permit:      permit,
 		Migrate:     migrateDecision,
-		ComputeUnit: getComputeUnitForResponse(node, supportsFractionalCPU),
+		ComputeUnit: getComputeUnitForResponse(e.state.conf.ComputeUnit, supportsFractionalCPU),
 	}
-	pod.mostRecentComputeUnit = node.computeUnit // refer to common allocation
+	pod.mostRecentComputeUnit = &e.state.conf.ComputeUnit
 	return &resp, 200, nil
 }
 
 // getComputeUnitForResponse tries to return compute unit that the agent supports
 // if we have a fractional CPU but the agent does not support it we multiply the result
-func getComputeUnitForResponse(node *nodeState, supportsFractional bool) api.Resources {
-	computeUnit := *node.computeUnit
+func getComputeUnitForResponse(computeUnit api.Resources, supportsFractional bool) api.Resources {
 	if !supportsFractional {
 		initialCU := computeUnit
 		for i := uint16(2); computeUnit.VCPU%1000 != 0; i++ {

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -72,8 +72,6 @@ type nodeState struct {
 	// memSlots tracks the state of memory slots -- what's available and how
 	memSlots nodeResourceState[uint16]
 
-	computeUnit *api.Resources
-
 	// pods tracks all the VM pods assigned to this node
 	//
 	// This includes both bound pods (i.e., pods fully committed to the node) and reserved pods
@@ -645,8 +643,7 @@ func buildInitialNodeState(logger *zap.Logger, node *corev1.Node, conf *Config) 
 			MarginCPU:        marginCpu,
 			MarginMemory:     marginMemory,
 		},
-		computeUnit: &conf.NodeConfig.ComputeUnit,
-		mq:          migrationQueue{},
+		mq: migrationQueue{},
 	}
 
 	type resourceInfo[T any] struct {


### PR DESCRIPTION
Another change split out from #653.

In short: More cleanup of something that was unnecessarily configurable.

**NB: This PR builds on #654 and must not be merged before it.**