### PR TITLE
plugin: Remove `(*nodeState).totalReservable{CPU,MemSlots}`

### DIFF
--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -106,8 +106,8 @@ type pluginStateDump struct {
 	VMPods    []podNameAndPointer `json:"vmPods"`
 	OtherPods []podNameAndPointer `json:"otherPods"`
 
-	MaxTotalReservableCPU      vmapi.MilliCPU `json:"maxTotalReservableCPU"`
-	MaxTotalReservableMemSlots uint16         `json:"maxTotalReservableMemSlots"`
+	MaxTotalCPU      vmapi.MilliCPU `json:"maxTotalReservableCPU"`
+	MaxTotalMemSlots uint16         `json:"maxTotalReservableMemSlots"`
 
 	Conf Config `json:"config"`
 }
@@ -200,13 +200,13 @@ func (s *pluginState) dump(ctx context.Context) (*pluginStateDump, error) {
 	sortSliceByPodName(ongoingMigrationDeletions, func(kv keyed[util.NamespacedName, int]) util.NamespacedName { return kv.Key })
 
 	return &pluginStateDump{
-		OngoingMigrationDeletions:  ongoingMigrationDeletions,
-		Nodes:                      nodes,
-		VMPods:                     vmPods,
-		OtherPods:                  otherPods,
-		MaxTotalReservableCPU:      s.maxTotalReservableCPU,
-		MaxTotalReservableMemSlots: s.maxTotalReservableMemSlots,
-		Conf:                       *s.conf,
+		OngoingMigrationDeletions: ongoingMigrationDeletions,
+		Nodes:                     nodes,
+		VMPods:                    vmPods,
+		OtherPods:                 otherPods,
+		MaxTotalCPU:               s.maxTotalCPU,
+		MaxTotalMemSlots:          s.maxTotalMemSlots,
+		Conf:                      *s.conf,
 	}, nil
 }
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -686,8 +686,8 @@ func (e *AutoscaleEnforcer) Score(
 
 	cpuFraction := 1 - cpuRemaining.AsFloat64()/cpuTotal.AsFloat64()
 	memFraction := 1 - float64(memRemaining)/float64(memTotal)
-	cpuScale := node.vCPU.Total.AsFloat64() / e.state.maxTotalReservableCPU.AsFloat64()
-	memScale := float64(node.memSlots.Total) / float64(e.state.maxTotalReservableMemSlots)
+	cpuScale := node.vCPU.Total.AsFloat64() / e.state.maxTotalCPU.AsFloat64()
+	memScale := float64(node.memSlots.Total) / float64(e.state.maxTotalMemSlots)
 
 	nodeConf := e.state.conf.forNode(nodeName)
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -530,9 +530,6 @@ func (e *AutoscaleEnforcer) Filter(
 		logger.Warn("Some known Pods weren't included in Filter NodeInfo", zap.Objects("missedPods", missedPodsList))
 	}
 
-	nodeTotalReservableCPU := node.totalReservableCPU()
-	nodeTotalReservableMemSots := node.totalReservableMemSlots()
-
 	var kind string
 	if vmInfo != nil {
 		kind = "VM"
@@ -553,44 +550,44 @@ func (e *AutoscaleEnforcer) Filter(
 
 	if vmInfo != nil {
 		var cpuCompare string
-		if totalNodeVCPU+vmInfo.Cpu.Use > nodeTotalReservableCPU {
+		if totalNodeVCPU+vmInfo.Cpu.Use > node.vCPU.Total {
 			cpuCompare = ">"
 			allowing = false
 		} else {
 			cpuCompare = "<="
 		}
-		cpuMsg = makeMsg("vCPU", cpuCompare, totalNodeVCPU, vmInfo.Cpu.Use, nodeTotalReservableCPU)
+		cpuMsg = makeMsg("vCPU", cpuCompare, totalNodeVCPU, vmInfo.Cpu.Use, node.vCPU.Total)
 
 		var memCompare string
-		if totalNodeMem+vmInfo.Mem.Use > nodeTotalReservableMemSots {
+		if totalNodeMem+vmInfo.Mem.Use > node.memSlots.Total {
 			memCompare = ">"
 			allowing = false
 		} else {
 			memCompare = "<="
 		}
-		memMsg = makeMsg("memSlots", memCompare, totalNodeMem, vmInfo.Mem.Use, nodeTotalReservableMemSots)
+		memMsg = makeMsg("memSlots", memCompare, totalNodeMem, vmInfo.Mem.Use, node.memSlots.Total)
 	} else {
 		newRes := otherResources.addPod(&e.state.conf.MemSlotSize, otherPodInfo)
 		cpuIncr := newRes.ReservedCPU - otherResources.ReservedCPU
 		memIncr := newRes.ReservedMemSlots - otherResources.ReservedMemSlots
 
 		var cpuCompare string
-		if totalNodeVCPU+cpuIncr > nodeTotalReservableCPU {
+		if totalNodeVCPU+cpuIncr > node.vCPU.Total {
 			cpuCompare = ">"
 			allowing = false
 		} else {
 			cpuCompare = "<="
 		}
-		cpuMsg = makeMsg("vCPU", cpuCompare, totalNodeVCPU, cpuIncr, nodeTotalReservableCPU)
+		cpuMsg = makeMsg("vCPU", cpuCompare, totalNodeVCPU, cpuIncr, node.vCPU.Total)
 
 		var memCompare string
-		if totalNodeMem+memIncr > nodeTotalReservableMemSots {
+		if totalNodeMem+memIncr > node.memSlots.Total {
 			memCompare = ">"
 			allowing = false
 		} else {
 			memCompare = "<="
 		}
-		memMsg = makeMsg("memSlots", memCompare, totalNodeMem, memIncr, nodeTotalReservableMemSots)
+		memMsg = makeMsg("memSlots", memCompare, totalNodeMem, memIncr, node.memSlots.Total)
 	}
 
 	var message string
@@ -683,14 +680,14 @@ func (e *AutoscaleEnforcer) Score(
 	}
 
 	cpuRemaining := node.remainingReservableCPU()
-	cpuTotal := node.totalReservableCPU()
+	cpuTotal := node.vCPU.Total
 	memRemaining := node.remainingReservableMemSlots()
-	memTotal := node.totalReservableMemSlots()
+	memTotal := node.memSlots.Total
 
 	cpuFraction := 1 - cpuRemaining.AsFloat64()/cpuTotal.AsFloat64()
 	memFraction := 1 - float64(memRemaining)/float64(memTotal)
-	cpuScale := node.totalReservableCPU().AsFloat64() / e.state.maxTotalReservableCPU.AsFloat64()
-	memScale := float64(node.totalReservableMemSlots()) / float64(e.state.maxTotalReservableMemSlots)
+	cpuScale := node.vCPU.Total.AsFloat64() / e.state.maxTotalReservableCPU.AsFloat64()
+	memScale := float64(node.memSlots.Total) / float64(e.state.maxTotalReservableMemSlots)
 
 	nodeConf := e.state.conf.forNode(nodeName)
 
@@ -923,11 +920,11 @@ func (e *AutoscaleEnforcer) Reserve(
 
 			cpuVerdict := fmt.Sprintf(
 				"need %v (%v -> %v raw), %v of %v used, so %v available (%s)",
-				addCpu, &oldNodeRes.RawCPU, &newNodeRes.RawCPU, node.vCPU.Reserved, node.totalReservableCPU(), node.remainingReservableCPU(), cpuShortVerdict,
+				addCpu, &oldNodeRes.RawCPU, &newNodeRes.RawCPU, node.vCPU.Reserved, node.vCPU.Total, node.remainingReservableCPU(), cpuShortVerdict,
 			)
 			memVerdict := fmt.Sprintf(
 				"need %v (%v -> %v raw), %v of %v used, so %v available (%s)",
-				addMem, &oldNodeRes.RawMemory, &newNodeRes.RawMemory, node.memSlots.Reserved, node.totalReservableMemSlots(), node.remainingReservableMemSlots(), memShortVerdict,
+				addMem, &oldNodeRes.RawMemory, &newNodeRes.RawMemory, node.memSlots.Reserved, node.memSlots.Total, node.remainingReservableMemSlots(), memShortVerdict,
 			)
 
 			logger.Error(
@@ -1006,11 +1003,11 @@ func (e *AutoscaleEnforcer) Reserve(
 
 		cpuVerdict := fmt.Sprintf(
 			"need %v, %v of %v used, so %v available (%s)",
-			vmInfo.Cpu.Use, node.vCPU.Reserved, node.totalReservableCPU(), node.remainingReservableCPU(), cpuShortVerdict,
+			vmInfo.Cpu.Use, node.vCPU.Reserved, node.vCPU.Total, node.remainingReservableCPU(), cpuShortVerdict,
 		)
 		memVerdict := fmt.Sprintf(
 			"need %v, %v of %v used, so %v available (%s)",
-			vmInfo.Mem.Use, node.memSlots.Reserved, node.totalReservableMemSlots(), node.remainingReservableMemSlots(), memShortVerdict,
+			vmInfo.Mem.Use, node.memSlots.Reserved, node.memSlots.Total, node.remainingReservableMemSlots(), memShortVerdict,
 		)
 
 		logger.Error(

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -40,12 +40,11 @@ type pluginState struct {
 	// otherPods stores information about non-VM pods
 	otherPods map[util.NamespacedName]*otherPodState
 
-	// maxTotalReservableCPU stores the maximum value of any node's vCPU.Total, so that we
-	// can appropriately scale our scoring
-	maxTotalReservableCPU vmapi.MilliCPU
-	// maxTotalReservableMemSlots is the same as maxTotalReservableCPU, but for memory slots instead
-	// of CPU
-	maxTotalReservableMemSlots uint16
+	// maxTotalCPU stores the maximum value of any node's vCPU.Total, so that we can appropriately
+	// scale our scoring
+	maxTotalCPU vmapi.MilliCPU
+	// maxTotalMemSlots is the same as maxTotalReservableCPU, but for memory slots instead of CPU
+	maxTotalMemSlots uint16
 	// conf stores the current configuration, and is nil if the configuration has not yet been set
 	//
 	// Proper initialization of the plugin guarantees conf is not nil.
@@ -543,11 +542,11 @@ func (s *pluginState) getOrFetchNodeState(
 	}
 
 	// update maxTotalReservableCPU and maxTotalReservableMemSlots if there's new maxima
-	if n.vCPU.Total > s.maxTotalReservableCPU {
-		s.maxTotalReservableCPU = n.vCPU.Total
+	if n.vCPU.Total > s.maxTotalCPU {
+		s.maxTotalCPU = n.vCPU.Total
 	}
-	if n.memSlots.Total > s.maxTotalReservableMemSlots {
-		s.maxTotalReservableMemSlots = n.memSlots.Total
+	if n.memSlots.Total > s.maxTotalMemSlots {
+		s.maxTotalMemSlots = n.memSlots.Total
 	}
 
 	n.updateMetrics(metrics, s.memSlotSizeBytes())
@@ -1264,7 +1263,7 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context, logger *zap.Lo
 
 	// Check that all fields are equal to their zero value, per the function documentation.
 	hasNonNilField := p.state.nodeMap != nil || p.state.podMap != nil || p.state.otherPods != nil ||
-		p.state.maxTotalReservableCPU != 0 || p.state.maxTotalReservableMemSlots != 0
+		p.state.maxTotalCPU != 0 || p.state.maxTotalMemSlots != 0
 
 	if hasNonNilField {
 		panic(errors.New("readClusterState called with non-nil pluginState field"))


### PR DESCRIPTION
Since #399, "total reservable CPU/memory" has just been equal to the value of nodeResourceState.Total, so these methods haven't been doing anything.

Split out from #653.