### PR TITLE
plugin: refactor resource transition

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1076,9 +1076,9 @@ func (e *AutoscaleEnforcer) Unreserve(
 		// Mark the resources as no longer reserved
 
 		currentlyMigrating := false // Unreserve is never called on bound pods, so it can't be migrating.
-		vCPUVerdict := collectResourceTransition(&ps.node.vCPU, &ps.vCPU).
+		vCPUVerdict := makeResourceTransitioner(&ps.node.vCPU, &ps.vCPU).
 			handleDeleted(currentlyMigrating)
-		memVerdict := collectResourceTransition(&ps.node.memSlots, &ps.memSlots).
+		memVerdict := makeResourceTransitioner(&ps.node.memSlots, &ps.memSlots).
 			handleDeleted(currentlyMigrating)
 
 		// Delete our record of the pod

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -258,8 +258,8 @@ func (e *AutoscaleEnforcer) handleResources(
 		}
 	}
 
-	vCPUTransition := collectResourceTransition(&node.vCPU, &pod.vCPU)
-	memTransition := collectResourceTransition(&node.memSlots, &pod.memSlots)
+	vCPUTransition := makeResourceTransitioner(&node.vCPU, &pod.vCPU)
+	memTransition := makeResourceTransitioner(&node.memSlots, &pod.memSlots)
 
 	vCPUVerdict := vCPUTransition.handleRequested(req.VCPU, startingMigration, !supportsFractionalCPU)
 	memVerdict := memTransition.handleRequested(req.Mem, startingMigration, false)

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -841,9 +841,9 @@ func (e *AutoscaleEnforcer) handleVMDeletion(logger *zap.Logger, podName util.Na
 	// Mark the resources as no longer reserved
 	currentlyMigrating := pod.currentlyMigrating()
 
-	vCPUVerdict := collectResourceTransition(&pod.node.vCPU, &pod.vCPU).
+	vCPUVerdict := makeResourceTransitioner(&pod.node.vCPU, &pod.vCPU).
 		handleDeleted(currentlyMigrating)
-	memVerdict := collectResourceTransition(&pod.node.memSlots, &pod.memSlots).
+	memVerdict := makeResourceTransitioner(&pod.node.memSlots, &pod.memSlots).
 		handleDeleted(currentlyMigrating)
 
 	// Delete our record of the pod
@@ -882,9 +882,9 @@ func (e *AutoscaleEnforcer) handleVMDisabledScaling(logger *zap.Logger, podName 
 	logger = logger.With(zap.String("node", pod.node.name), zap.Object("virtualmachine", pod.vmName))
 
 	// Reset buffer to zero:
-	vCPUVerdict := collectResourceTransition(&pod.node.vCPU, &pod.vCPU).
+	vCPUVerdict := makeResourceTransitioner(&pod.node.vCPU, &pod.vCPU).
 		handleAutoscalingDisabled()
-	memVerdict := collectResourceTransition(&pod.node.memSlots, &pod.memSlots).
+	memVerdict := makeResourceTransitioner(&pod.node.memSlots, &pod.memSlots).
 		handleAutoscalingDisabled()
 
 	pod.node.updateMetrics(e.metrics, e.state.memSlotSizeBytes())
@@ -918,9 +918,9 @@ func (e *AutoscaleEnforcer) handlePodStartMigration(logger *zap.Logger, podName,
 	logger = logger.With(zap.String("node", pod.node.name), zap.Object("virtualmachine", pod.vmName))
 
 	// Reset buffer to zero, remove from migration queue (if in it), and set pod's migrationState
-	cpuVerdict := collectResourceTransition(&pod.node.vCPU, &pod.vCPU).
+	cpuVerdict := makeResourceTransitioner(&pod.node.vCPU, &pod.vCPU).
 		handleStartMigration(source)
-	memVerdict := collectResourceTransition(&pod.node.memSlots, &pod.memSlots).
+	memVerdict := makeResourceTransitioner(&pod.node.memSlots, &pod.memSlots).
 		handleStartMigration(source)
 
 	pod.node.mq.removeIfPresent(pod)
@@ -1055,9 +1055,9 @@ func (e *AutoscaleEnforcer) handleNonAutoscalingUsageChange(logger *zap.Logger, 
 		return
 	}
 
-	cpuVerdict := collectResourceTransition(&pod.node.vCPU, &pod.vCPU).
+	cpuVerdict := makeResourceTransitioner(&pod.node.vCPU, &pod.vCPU).
 		handleNonAutoscalingUsageChange(vm.Using().VCPU)
-	memVerdict := collectResourceTransition(&pod.node.memSlots, &pod.memSlots).
+	memVerdict := makeResourceTransitioner(&pod.node.memSlots, &pod.memSlots).
 		handleNonAutoscalingUsageChange(vm.Using().Mem)
 
 	pod.node.updateMetrics(e.metrics, e.state.memSlotSizeBytes())

--- a/pkg/plugin/trans.go
+++ b/pkg/plugin/trans.go
@@ -24,9 +24,9 @@ import (
 // resourceTransitioner maintains the current state of its resource and handles the transition
 // into a new state. A resource is associated with a pod, and the pod is associated with a node.
 type resourceTransitioner[T constraints.Unsigned] struct {
-	// node represents the current resource state of in the node
+	// node represents the current resource state of the node
 	node *nodeResourceState[T]
-	// pod represents the current resource state of in the pod.
+	// pod represents the current resource state of the pod.
 	// pod belongs to the node.
 	pod *podResourceState[T]
 }

--- a/pkg/plugin/trans.go
+++ b/pkg/plugin/trans.go
@@ -21,50 +21,36 @@ import (
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
-type resourceTransition[T constraints.Unsigned] struct {
-	node    *nodeResourceState[T]
-	oldNode struct {
-		reserved             T
-		buffer               T
-		capacityPressure     T
-		pressureAccountedFor T
-	}
-	pod    *podResourceState[T]
-	oldPod struct {
-		reserved         T
-		buffer           T
-		capacityPressure T
+// resourceTransitioner maintains the current state of its resource and handles the transition
+// into a new state. A resource is associated with a pod, and the pod is associated with a node.
+type resourceTransitioner[T constraints.Unsigned] struct {
+	// node represents the current resource state of in the node
+	node *nodeResourceState[T]
+	// pod represents the current resource state of in the pod.
+	// pod belongs to the node.
+	pod *podResourceState[T]
+}
+
+func makeResourceTransitioner[T constraints.Unsigned](
+	node *nodeResourceState[T], pod *podResourceState[T],
+) resourceTransitioner[T] {
+	return resourceTransitioner[T]{
+		node: node,
+		pod:  pod,
 	}
 }
 
-func collectResourceTransition[T constraints.Unsigned](
-	node *nodeResourceState[T],
-	pod *podResourceState[T],
-) resourceTransition[T] {
-	return resourceTransition[T]{
-		node: node,
-		oldNode: struct {
-			reserved             T
-			buffer               T
-			capacityPressure     T
-			pressureAccountedFor T
-		}{
-			reserved:             node.Reserved,
-			buffer:               node.Buffer,
-			capacityPressure:     node.CapacityPressure,
-			pressureAccountedFor: node.PressureAccountedFor,
-		},
-		pod: pod,
-		oldPod: struct {
-			reserved         T
-			buffer           T
-			capacityPressure T
-		}{
-			reserved:         pod.Reserved,
-			buffer:           pod.Buffer,
-			capacityPressure: pod.CapacityPressure,
-		},
-	}
+// resourceState represents a resource state in its pod and its node. This is not necessarily the
+// current state. It represents the resource state at a point in time.
+type resourceState[T constraints.Unsigned] struct {
+	node nodeResourceState[T]
+	pod  podResourceState[T]
+}
+
+// snapshotState snapshots the current state of the resource transitioner by making a copy of
+// its state.
+func (r resourceTransitioner[T]) snapshotState() resourceState[T] {
+	return resourceState[T]{*r.node, *r.pod}
 }
 
 // verdictSet represents a set of verdicts from some operation, for ease of logging
@@ -84,11 +70,13 @@ func (s verdictSet) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // what's possible given the remaining resources.
 //
 // A pretty-formatted summary of the outcome is returned as the verdict, for logging.
-func (r resourceTransition[T]) handleRequested(requested T, startingMigration bool, onlyThousands bool) (verdict string) {
+func (r resourceTransitioner[T]) handleRequested(requested T, startingMigration bool, onlyThousands bool) (verdict string) {
+	oldState := r.snapshotState()
+
 	totalReservable := r.node.Total
 	// note: it's possible to temporarily have reserved > totalReservable, after loading state or
 	// config change; we have to use SaturatingSub here to account for that.
-	remainingReservable := util.SaturatingSub(totalReservable, r.oldNode.reserved)
+	remainingReservable := util.SaturatingSub(totalReservable, oldState.node.Reserved)
 
 	// Note: The correctness of this function depends on the autoscaler-agents and previous
 	// scheduler being well-behaved. This function will fail to prevent overcommitting when:
@@ -109,7 +97,7 @@ func (r resourceTransition[T]) handleRequested(requested T, startingMigration bo
 		r.pod.Reserved = requested
 		// pressure is now zero, because the pod no longer wants to increase resources.
 		r.pod.CapacityPressure = 0
-		r.node.CapacityPressure -= r.oldPod.capacityPressure
+		r.node.CapacityPressure -= oldState.pod.CapacityPressure
 
 		// use shared verdict below.
 
@@ -119,7 +107,7 @@ func (r resourceTransition[T]) handleRequested(requested T, startingMigration bo
 		// But we _will_ add the pod's request to the node's pressure, noting that its migration
 		// will resolve it.
 		r.pod.CapacityPressure = requested - r.pod.Reserved
-		r.node.CapacityPressure = r.node.CapacityPressure + r.pod.CapacityPressure - r.oldPod.capacityPressure
+		r.node.CapacityPressure = r.node.CapacityPressure + r.pod.CapacityPressure - oldState.pod.CapacityPressure
 
 		// note: we don't need to handle buffer here because migration is never started as the first
 		// communication, so buffers will be zero already.
@@ -132,9 +120,9 @@ func (r resourceTransition[T]) handleRequested(requested T, startingMigration bo
 		verdict = fmt.Sprintf(
 			fmtString,
 			// Denying increase %d -> %d because ...
-			r.oldPod.reserved, requested,
+			oldState.pod.Reserved, requested,
 			// node capacityPressure %d -> %d (%d -> %d spoken for)
-			r.oldNode.capacityPressure, r.node.CapacityPressure, r.oldNode.pressureAccountedFor, r.node.PressureAccountedFor,
+			oldState.node.CapacityPressure, r.node.CapacityPressure, oldState.node.PressureAccountedFor, r.node.PressureAccountedFor,
 		)
 		return verdict
 	} else /* typical "request for increase" */ {
@@ -170,7 +158,7 @@ func (r resourceTransition[T]) handleRequested(requested T, startingMigration bo
 			r.pod.CapacityPressure = increase - maxIncrease
 			// adjust node pressure accordingly. We can have old < new or new > old, so we shouldn't
 			// directly += or -= (implicitly relying on overflow).
-			r.node.CapacityPressure = r.node.CapacityPressure - r.oldPod.capacityPressure + r.pod.CapacityPressure
+			r.node.CapacityPressure = r.node.CapacityPressure - oldState.pod.CapacityPressure + r.pod.CapacityPressure
 			increase = maxIncrease // cap at maxIncrease.
 		} else {
 			// If we're not capped by maxIncrease, relieve pressure coming from this pod
@@ -192,7 +180,7 @@ func (r resourceTransition[T]) handleRequested(requested T, startingMigration bo
 	var newNodeBuffer string
 	if r.pod.Buffer != 0 {
 		podBuffer = fmt.Sprintf(" [buffer %d]", r.pod.Buffer)
-		oldNodeBuffer = fmt.Sprintf(" [buffer %d]", r.oldNode.buffer)
+		oldNodeBuffer = fmt.Sprintf(" [buffer %d]", oldState.node.Buffer)
 
 		r.node.Buffer -= r.pod.Buffer
 		r.pod.Buffer = 0
@@ -208,11 +196,11 @@ func (r resourceTransition[T]) handleRequested(requested T, startingMigration bo
 	verdict = fmt.Sprintf(
 		fmtString,
 		// Register %d%s -> %d%s (pressure %d -> %d)
-		r.oldPod.reserved, podBuffer, r.pod.Reserved, wanted, r.oldPod.capacityPressure, r.pod.CapacityPressure,
+		oldState.pod.Reserved, podBuffer, r.pod.Reserved, wanted, oldState.pod.CapacityPressure, r.pod.CapacityPressure,
 		// node reserved %d%s -> %d%s (of %d)
-		r.oldNode.reserved, oldNodeBuffer, r.node.Reserved, newNodeBuffer, totalReservable,
+		oldState.node.Reserved, oldNodeBuffer, r.node.Reserved, newNodeBuffer, totalReservable,
 		// node capacityPressure %d -> %d (%d -> %d spoken for)
-		r.oldNode.capacityPressure, r.node.CapacityPressure, r.oldNode.pressureAccountedFor, r.node.PressureAccountedFor,
+		oldState.node.CapacityPressure, r.node.CapacityPressure, oldState.node.PressureAccountedFor, r.node.PressureAccountedFor,
 	)
 	return verdict
 }
@@ -220,7 +208,9 @@ func (r resourceTransition[T]) handleRequested(requested T, startingMigration bo
 // handleDeleted updates r.node with changes to match the removal of r.pod
 //
 // A pretty-formatted summary of the changes is returned as the verdict, for logging.
-func (r resourceTransition[T]) handleDeleted(currentlyMigrating bool) (verdict string) {
+func (r resourceTransitioner[T]) handleDeleted(currentlyMigrating bool) (verdict string) {
+	oldState := r.snapshotState()
+
 	r.node.Reserved -= r.pod.Reserved
 	r.node.CapacityPressure -= r.pod.CapacityPressure
 
@@ -235,7 +225,7 @@ func (r resourceTransition[T]) handleDeleted(currentlyMigrating bool) (verdict s
 		r.node.Buffer -= r.pod.Buffer
 
 		podBuffer = fmt.Sprintf(" [buffer %d]", r.pod.Buffer)
-		oldNodeBuffer = fmt.Sprintf(" [buffer %d]", r.oldNode.buffer)
+		oldNodeBuffer = fmt.Sprintf(" [buffer %d]", oldState.node.Buffer)
 		newNodeBuffer = fmt.Sprintf(" [buffer %d]", r.node.Buffer)
 	}
 
@@ -244,20 +234,22 @@ func (r resourceTransition[T]) handleDeleted(currentlyMigrating bool) (verdict s
 	verdict = fmt.Sprintf(
 		fmtString,
 		// pod had %d%s; node reserved %d%s -> %d%s
-		r.pod.Reserved, podBuffer, r.oldNode.reserved, oldNodeBuffer, r.node.Reserved, newNodeBuffer,
+		r.pod.Reserved, podBuffer, oldState.node.Reserved, oldNodeBuffer, r.node.Reserved, newNodeBuffer,
 		// node capacityPressure %d -> %d (%d -> %d spoken for)
-		r.oldNode.capacityPressure, r.node.CapacityPressure, r.oldNode.pressureAccountedFor, r.node.PressureAccountedFor,
+		oldState.node.CapacityPressure, r.node.CapacityPressure, oldState.node.PressureAccountedFor, r.node.PressureAccountedFor,
 	)
 	return verdict
 }
 
-func (r resourceTransition[T]) handleNonAutoscalingUsageChange(newUsage T) (verdict string) {
+func (r resourceTransitioner[T]) handleNonAutoscalingUsageChange(newUsage T) (verdict string) {
+	oldState := r.snapshotState()
+
 	diff := newUsage - r.pod.Reserved
 	r.pod.Reserved = newUsage
 	r.node.Reserved += diff
 	verdict = fmt.Sprintf(
 		"pod reserved (%v -> %v), node reserved (%v -> %v)",
-		r.oldPod.reserved, r.pod.Reserved, r.oldNode.reserved, r.node.Reserved,
+		oldState.pod.Reserved, r.pod.Reserved, oldState.node.Reserved, r.node.Reserved,
 	)
 	return verdict
 }
@@ -266,7 +258,9 @@ func (r resourceTransition[T]) handleNonAutoscalingUsageChange(newUsage T) (verd
 // from r.pod
 //
 // A pretty-formatted summary of the changes is returned as the verdict, for logging.
-func (r resourceTransition[T]) handleAutoscalingDisabled() (verdict string) {
+func (r resourceTransitioner[T]) handleAutoscalingDisabled() (verdict string) {
+	oldState := r.snapshotState()
+
 	// buffer is included in reserved, so we reduce everything by buffer.
 	buffer := r.pod.Buffer
 	valuesToReduce := []*T{&r.node.Reserved, &r.node.Buffer, &r.pod.Reserved, &r.pod.Buffer}
@@ -278,8 +272,8 @@ func (r resourceTransition[T]) handleAutoscalingDisabled() (verdict string) {
 	r.pod.CapacityPressure = 0
 
 	var nodeBufferChange string
-	if r.oldPod.buffer != 0 {
-		nodeBufferChange = fmt.Sprintf(" [buffer %d -> %d]", r.oldNode.buffer, r.node.Buffer)
+	if oldState.pod.Buffer != 0 {
+		nodeBufferChange = fmt.Sprintf(" [buffer %d -> %d]", oldState.node.Buffer, r.node.Buffer)
 	}
 
 	fmtString := "pod had buffer %d, capacityPressure %d; " +
@@ -287,9 +281,9 @@ func (r resourceTransition[T]) handleAutoscalingDisabled() (verdict string) {
 	verdict = fmt.Sprintf(
 		fmtString,
 		// pod had buffer %d, capacityPressure %d;
-		r.oldPod.buffer, r.oldPod.capacityPressure,
+		oldState.pod.Buffer, oldState.pod.CapacityPressure,
 		// node reserved %d -> %d%s, capacityPressure %d -> %d
-		r.oldNode.reserved, r.node.Reserved, nodeBufferChange, r.oldNode.capacityPressure, r.node.CapacityPressure,
+		oldState.node.Reserved, r.node.Reserved, nodeBufferChange, oldState.node.CapacityPressure, r.node.CapacityPressure,
 	)
 	return verdict
 }
@@ -301,10 +295,12 @@ func (r resourceTransition[T]) handleAutoscalingDisabled() (verdict string) {
 // to match the pod's resource usage.
 //
 //nolint:unparam // linter complains about 'source'. FIXME: needs more work to figure this out.
-func (r resourceTransition[T]) handleStartMigration(source bool) (verdict string) {
+func (r resourceTransitioner[T]) handleStartMigration(source bool) (verdict string) {
 	// This method is basically the same as handleAutoscalingDisabled, except we also update the
 	// node's PressureAccountedFor because any pressure generated by the pod will be resolved once
 	// the migration completes and the pod gets deleted.
+
+	oldState := r.snapshotState()
 
 	buffer := r.pod.Buffer
 	valuesToReduce := []*T{&r.node.Reserved, &r.node.Buffer, &r.pod.Reserved, &r.pod.Buffer}
@@ -322,9 +318,9 @@ func (r resourceTransition[T]) handleStartMigration(source bool) (verdict string
 	verdict = fmt.Sprintf(
 		fmtString,
 		// pod had buffer %d, capacityPressure %d;
-		r.oldPod.buffer, r.oldPod.capacityPressure,
+		oldState.pod.Buffer, oldState.pod.CapacityPressure,
 		// node reserved %d -> %d, capacityPressure %d -> %d
-		r.oldNode.reserved, r.node.Reserved, r.oldNode.capacityPressure, r.node.CapacityPressure, r.oldNode.pressureAccountedFor, r.node.PressureAccountedFor,
+		oldState.node.Reserved, r.node.Reserved, oldState.node.CapacityPressure, r.node.CapacityPressure, oldState.node.PressureAccountedFor, r.node.PressureAccountedFor,
 	)
 	return verdict
 }


### PR DESCRIPTION
- Rename `ResourceTransition` into `ResourceTransitioner` because it's not an object that represents a transition, but actually it performs transitions on a resource state.
- Now it's safe to call handle functions multiple times on `ResourceTransitioner`. We got this by removing `oldPod` and `oldNode` fields from the transitioner.