### PR TITLE
CI: use self-hosted runner for vm-kernel workflow

### DIFF
--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -26,29 +26,22 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v3
 
+      # Use custom DOCKER_CONFIG directory to avoid conflicts with default settings
+      # The default value is ~/.docker
       - name: set custom docker config directory
         run: |
           mkdir -p .docker-custom
           echo DOCKER_CONFIG=$(pwd)/.docker-custom >> $GITHUB_ENV
-      - name: login to docker hub
-        run: |
-          DOCKERHUB_AUTH=$(echo -n "${{ secrets.NEON_DOCKERHUB_USERNAME }}:${{ secrets.NEON_DOCKERHUB_PASSWORD }}" | base64)
-          echo "::add-mask::${DOCKERHUB_AUTH}"
-
-          cat <<-EOF > .docker-custom/config.json
-            {
-              "auths": {
-                "https://index.docker.io/v1/": {
-                  "auth": "${DOCKERHUB_AUTH}"
-                }
-              }
-            }
-          EOF
 
       - name: docker - install qemu
         uses: docker/setup-qemu-action@v2
       - name: docker - setup buildx
         uses: docker/setup-buildx-action@v2
+      - name: login to docker hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
       - name: get kernel version
         id: get-kernel-version

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -23,20 +23,19 @@ jobs:
 
     runs-on: [ self-hosted, gen3, large ]
     steps:
-
       - name: git checkout
         uses: actions/checkout@v3
 
-      - name: docker - install qemu
-        uses: docker/setup-qemu-action@v2
-      - name: docker - setup buildx
-        uses: docker/setup-buildx-action@v2
+      - name: set custom docker config directory
+        run: |
+          mkdir -p .docker-custom
+          echo DOCKER_CONFIG=$(pwd)/.docker-custom >> $GITHUB_ENV
       - name: login to docker hub
         run: |
           DOCKERHUB_AUTH=$(echo -n "${{ secrets.NEON_DOCKERHUB_USERNAME }}:${{ secrets.NEON_DOCKERHUB_PASSWORD }}" | base64)
           echo "::add-mask::${DOCKERHUB_AUTH}"
 
-          cat <<-EOF > ~/.docker/config.json
+          cat <<-EOF > .docker-custom/config.json
             {
               "auths": {
                 "https://index.docker.io/v1/": {
@@ -45,6 +44,11 @@ jobs:
               }
             }
           EOF
+
+      - name: docker - install qemu
+        uses: docker/setup-qemu-action@v2
+      - name: docker - setup buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: get kernel version
         id: get-kernel-version
@@ -68,10 +72,10 @@ jobs:
           # Tag the image with the tag from the workflow_dispatch input or the VM_KERNEL_VERSION from linux-config-* file
           tags: ${{ env.VM_KERNEL_IMAGE }}:${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || steps.get-kernel-version.outputs.VM_KERNEL_VERSION }}
 
-      - name: logout from docker hub
+      - name: remove custom docker config directory
         if: always()
         run: |
-          rm -f ~/.docker/config.json
+          rm -rf .docker-custom
 
   e2e-tests:
     needs: vm-kernel

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -21,8 +21,7 @@ jobs:
     outputs:
       image: ${{ fromJSON(steps.build-linux-kernel.outputs.metadata)['image.name'] }}@${{ steps.build-linux-kernel.outputs.digest }}
 
-    # Use the biggest GitHub Hosted runner
-    runs-on: gha-ubuntu-22.04-64cores
+    runs-on: [ self-hosted, gen3, large ]
     steps:
 
       - name: git checkout
@@ -50,7 +49,8 @@ jobs:
           no-cache: true
           file: neonvm/hack/Dockerfile.kernel-builder
           # Tag the image with the tag from the workflow_dispatch input or the VM_KERNEL_VERSION env var
-          tags: ${{ env.VM_KERNEL_IMAGE }}:${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || env.VM_KERNEL_VERSION }}
+          # tags: ${{ env.VM_KERNEL_IMAGE }}:${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || env.VM_KERNEL_VERSION }}
+          tags: ${{ env.VM_KERNEL_IMAGE }}:test
 
   e2e-tests:
     needs: vm-kernel

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -32,10 +32,19 @@ jobs:
       - name: docker - setup buildx
         uses: docker/setup-buildx-action@v2
       - name: login to docker hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
+        run: |
+          DOCKERHUB_AUTH=$(echo -n "${{ secrets.NEON_DOCKERHUB_USERNAME }}:${{ secrets.NEON_DOCKERHUB_PASSWORD }}" | base64)
+          echo "::add-mask::${DOCKERHUB_AUTH}"
+
+          cat <<-EOF > ~/.docker/config.json
+            {
+              "auths": {
+                "https://index.docker.io/v1/": {
+                  "auth": "${DOCKERHUB_AUTH}"
+                }
+              }
+            }
+          EOF
 
       - name: build linux kernel
         id: build-linux-kernel
@@ -49,8 +58,12 @@ jobs:
           no-cache: true
           file: neonvm/hack/Dockerfile.kernel-builder
           # Tag the image with the tag from the workflow_dispatch input or the VM_KERNEL_VERSION env var
-          # tags: ${{ env.VM_KERNEL_IMAGE }}:${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || env.VM_KERNEL_VERSION }}
-          tags: ${{ env.VM_KERNEL_IMAGE }}:test
+          tags: ${{ env.VM_KERNEL_IMAGE }}:${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || env.VM_KERNEL_VERSION }}
+
+      - name: logout from docker hub
+        if: always()
+        run: |
+          rm -f ~/.docker/config.json
 
   e2e-tests:
     needs: vm-kernel

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -46,6 +46,14 @@ jobs:
             }
           EOF
 
+      - name: get kernel version
+        id: get-kernel-version
+        run: |
+          linux_config=$(ls neonvm/hack/linux-config-*)  # returns something like "neonvm/hack/linux-config-6.1.63"
+          kernel_version=${linux_config##*-}             # returns something like "6.1.63"
+
+          echo VM_KERNEL_VERSION=$kernel_version >> $GITHUB_OUTPUT
+
       - name: build linux kernel
         id: build-linux-kernel
         uses: docker/build-push-action@v3
@@ -57,8 +65,8 @@ jobs:
           pull: true
           no-cache: true
           file: neonvm/hack/Dockerfile.kernel-builder
-          # Tag the image with the tag from the workflow_dispatch input or the VM_KERNEL_VERSION env var
-          tags: ${{ env.VM_KERNEL_IMAGE }}:${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || env.VM_KERNEL_VERSION }}
+          # Tag the image with the tag from the workflow_dispatch input or the VM_KERNEL_VERSION from linux-config-* file
+          tags: ${{ env.VM_KERNEL_IMAGE }}:${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || steps.get-kernel-version.outputs.VM_KERNEL_VERSION }}
 
       - name: logout from docker hub
         if: always()


### PR DESCRIPTION
Switch from GitHub's `gha-ubuntu-22.04-64cores` runner to self-hosted `large` runner (32 cores / RAM 128 GiB).
- Before: 2m 21s total (1m 38s 'build-linux kernel' step) [a link](https://github.com/neondatabase/autoscaling/actions/runs/7014316396/job/19081849534)
- After: 1m 85s total (1m 43s 'build-linux kernel' step) [a link](https://github.com/neondatabase/autoscaling/actions/runs/7072729343/job/19251884151)

Also, fix `env. VM_KERNEL_VERSION` usage, because we don't have this variable anymore, get it from parsing `neonvm/hack/linux-config-*` (maybe we should get it from another place?)

Part of https://github.com/neondatabase/autoscaling/issues/660