### PR TITLE
Makefile: Set KERNEL_VERSION from linux-config filename

### DIFF
--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -55,7 +55,7 @@ jobs:
         id: build-linux-kernel
         uses: docker/build-push-action@v3
         with:
-          build-args: KERNEL_VERSION=6.1.63 # Temporary: Will be overridden by #662.
+          build-args: KERNEL_VERSION=${{ steps.get-kernel-version.outputs.VM_KERNEL_VERSION }}
           context: neonvm/hack
           platforms: linux/amd64
           # Push only if this is a scheduled run or if the workflow_dispatch input push is set to true

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -55,6 +55,7 @@ jobs:
         id: build-linux-kernel
         uses: docker/build-push-action@v3
         with:
+          build-args: KERNEL_VERSION=6.1.63 # Temporary: Will be overridden by #662.
           context: neonvm/hack
           platforms: linux/amd64
           # Push only if this is a scheduled run or if the workflow_dispatch input push is set to true

--- a/Makefile
+++ b/Makefile
@@ -224,9 +224,12 @@ endif
 .PHONY: kernel
 kernel: ## Build linux kernel.
 	rm -f neonvm/hack/vmlinuz; \
+	linux_config=$$(ls neonvm/hack/linux-config-*) \
+	kernel_version=$${linux_config##*-} \
 	iidfile=$$(mktemp /tmp/iid-XXXXXX); \
 	trap "rm $$iidfile" EXIT; \
 	docker buildx build \
+	    --build-arg KERNEL_VERSION=$$kernel_version \
 		--platform linux/amd64 \
 		--pull \
 		--load \

--- a/neonvm/README.md
+++ b/neonvm/README.md
@@ -96,7 +96,7 @@ make kernel
 To adjust the kernel config:
 
 ```
-docker build --platform linux/x86_64 --target build-deps -t kernel-build-deps -f Dockerfile.kernel-builder   .
+docker build --build-arg KERNEL_VERSION=6.1.63 --platform linux/x86_64 --target build-deps -t kernel-build-deps -f Dockerfile.kernel-builder   .
 docker run --rm -v $PWD:/host --name kernel-build -it kernel-build-deps bash
 # inside that bash shell, do the menuconfig, then copy-out the config to /host
 ```

--- a/neonvm/hack/Dockerfile.kernel-builder
+++ b/neonvm/hack/Dockerfile.kernel-builder
@@ -1,5 +1,3 @@
-ARG KERNEL_VERSION=6.1.63
-
 FROM ubuntu:23.10 AS build-deps
 
 ARG KERNEL_VERSION


### PR DESCRIPTION
Copying the method used from #662.

Also, remove the default value of the ARG from the top of the Dockerfile, so that the `linux-config-*` filename is the authoritative source for the kernel version we're using.

See also #652, which this PR _partially_ reverts in order to move the source of the kernel version back out of the Dockerfile.

---

Note for review: Not entirely sure that this is the right way to do it, but after seeing the technique in #662, I figured it might make sense to go all-in on that way. At some point in the future, we _might_ want to switch from `${linux_config##*-}` to `${linux_config#*linux-config-}`, but it probably doesn't matter _too_ too much.