### PR TITLE
neonvm/controller: Don't delete runner pods in CI

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -17,6 +17,9 @@ on:
         description: 'The kernel image to use for the VMs'
         required: false
 
+env:
+  E2E: "true"
+
 jobs:
   e2e-tests:
     strategy:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -18,7 +18,7 @@ on:
         required: false
 
 env:
-  E2E: "true"
+  PRESERVE_RUNNER_PODS: "true"
 
 jobs:
   e2e-tests:

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ docker-push: docker-build ## Push docker images to docker registry
 
 .PHONY: docker-build-controller
 docker-build-controller: ## Build docker image for NeonVM controller
-	docker build --build-arg VM_RUNNER_IMAGE=$(IMG_RUNNER) --build-arg BUILDTAGS=$(if $(E2E),nodelete) -t $(IMG_CONTROLLER) -f neonvm/Dockerfile .
+	docker build --build-arg VM_RUNNER_IMAGE=$(IMG_RUNNER) --build-arg BUILDTAGS=$(if $(PRESERVE_RUNNER_PODS),nodelete) -t $(IMG_CONTROLLER) -f neonvm/Dockerfile .
 
 .PHONY: docker-build-runner
 docker-build-runner: ## Build docker image for NeonVM runner

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ docker-push: docker-build ## Push docker images to docker registry
 
 .PHONY: docker-build-controller
 docker-build-controller: ## Build docker image for NeonVM controller
-	docker build --build-arg VM_RUNNER_IMAGE=$(IMG_RUNNER) -t $(IMG_CONTROLLER) -f neonvm/Dockerfile .
+	docker build --build-arg VM_RUNNER_IMAGE=$(IMG_RUNNER) --build-arg BUILDTAGS=$(if $(E2E),nodelete) -t $(IMG_CONTROLLER) -f neonvm/Dockerfile .
 
 .PHONY: docker-build-runner
 docker-build-runner: ## Build docker image for NeonVM runner

--- a/neonvm/Dockerfile
+++ b/neonvm/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.21 as builder
 ARG TARGETOS
 ARG TARGETARCH
+ARG BUILDTAGS
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -26,7 +27,7 @@ COPY pkg/util pkg/util
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager neonvm/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -tags=${BUILDTAGS} -o manager neonvm/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/neonvm/controllers/buildtag/nodelete_false.go
+++ b/neonvm/controllers/buildtag/nodelete_false.go
@@ -1,0 +1,5 @@
+//go:build !nodelete
+
+package buildtag
+
+const NeverDeleteRunnerPods = false

--- a/neonvm/controllers/buildtag/nodelete_true.go
+++ b/neonvm/controllers/buildtag/nodelete_true.go
@@ -1,0 +1,13 @@
+//go:build nodelete
+
+package buildtag
+
+// NeverDeleteRunnerPods is enabled by the 'nodelete' build tag only in CI, and if enabled, causes
+// the neonvm-controller to leave the original VM runner pods around when they otherwise would be
+// deleted and recreated in order to (a) restart the VM or (b) finish a VM migration.
+//
+// Please note that this does not affect behavior when the VM/VMM object is deleted! When that
+// happens, all pods owned by it will still be deleted!
+//
+// For more information and motivation for this flag, see <https://github.com/neondatabase/autoscaling/issues/634>.
+const NeverDeleteRunnerPods = true

--- a/neonvm/controllers/buildtag/tagnames.go
+++ b/neonvm/controllers/buildtag/tagnames.go
@@ -1,0 +1,3 @@
+package buildtag
+
+const TagnameNeverDeleteRunnerPods = "nodelete"

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	"github.com/neondatabase/autoscaling/neonvm/controllers/buildtag"
 )
 
 const virtualmachinemigrationFinalizer = "vm.neon.tech/finalizer"
@@ -530,14 +531,20 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 				log.Error(err, "Failed to get source runner Pod for deletion")
 				return ctrl.Result{}, err
 			}
-			if err := r.Delete(ctx, sourceRunner); err != nil {
-				log.Error(err, "Failed to delete source runner Pod")
-				return ctrl.Result{}, err
+			var msg, eventReason string
+			if buildtag.NeverDeleteRunnerPods {
+				msg = fmt.Sprintf("Source runner pod deletion was skipped due to '%s' build tag", buildtag.TagnameNeverDeleteRunnerPods)
+				eventReason = "DeleteSkipped"
+			} else {
+				if err := r.Delete(ctx, sourceRunner); err != nil {
+					log.Error(err, "Failed to delete source runner Pod")
+					return ctrl.Result{}, err
+				}
+				msg = "Source runner was deleted"
+				eventReason = "Deleted"
 			}
-			sourceRunnerPodName := migration.Status.SourcePodName
-			message := fmt.Sprintf("Source runner (%s) was deleted", sourceRunnerPodName)
-			log.Info(message)
-			r.Recorder.Event(migration, "Normal", "Deleted", message)
+			log.Info(msg, "Pod.Namespace", sourceRunner.Namespace, "Pod.Name", sourceRunner.Name)
+			r.Recorder.Event(migration, "Normal", eventReason, fmt.Sprintf("%s: %s", msg, sourceRunner.Name))
 			migration.Status.SourcePodName = ""
 			migration.Status.SourcePodIP = ""
 			return r.updateMigrationStatus(ctx, migration)
@@ -615,6 +622,9 @@ func (r *VirtualMachineMigrationReconciler) doFinalizerOperationsForVirtualMachi
 				// pod already deleted ?
 				return nil
 			}
+			// NB: here, we ignore buildtag.NeverDeleteRunnerPods because we delete runner pods on
+			// VM object deletion with the tag anyways, so it's more consistent to keep the same
+			// behavior for VMMs.
 			if err := r.Delete(ctx, pod); err != nil {
 				log.Error(err, "Failed to delete target runner Pod")
 				return err


### PR DESCRIPTION
This is implemented by adding a build tag 'nodelete', which disables deletion of VM runner pods - at least, while the VM or VMM object exists.

We *could* have actually kept the runner pods around even if the VM/VMM is deleted, but there's already ways to keep the objects around after e2e tests end (see #635), and this way the results would be a little less catastrophic if we accidentally released it.

The 'nodelete' tag is enabled by the Makefile based on the `E2E` env var.

Part of #634.

---

Note for review: I was going to use the `CI` env var like #635, but it's set on all workflows and the point is to build images with different config for e2e tests only. I'm not sure that the new `E2E` env var is the right name; open to suggestions there or alternate solutions (maybe something to do with "debug" / "test"?)

Tested both ways locally, but not super thoroughly — at first glance, it appears to be working as intended.