### PR TITLE
CI: run e2e tests only using k3d cluster

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -10,6 +10,13 @@ on:
         type: string
         description: 'The kernel image to use for the VMs. If not specified, a kernel will be built from source'
         required: false
+      cluster:
+        type: choice
+        description: 'The cluster to run the tests on'
+        options:
+          - k3d
+          - kind
+        default: k3d
   workflow_call:
     inputs:
       kernel-image:
@@ -26,8 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         cluster:
-          - k3d
-          - kind
+          - ${{ inputs.cluster || 'k3d' }}
     runs-on: [ self-hosted, gen3, large ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Since we started to run e2e tests using both `kind` and `k3d` (https://github.com/neondatabase/autoscaling/pull/340), I can't recall a case when tests failed only on one cluster (due to app changes and not a cluster configuration).

After switching to `large` self-hosted runners (in https://github.com/neondatabase/autoscaling/pull/661), there's a chance that e2e tests could fight for resources with other projects that use such runners. To make the build faster by using fewer runners. Given the message above, let's run the test only on a single cluster configuration but keep an alternative way (for those who are used to it).


It is still possible to trigger e2e tests on `kind` cluster manually ([an example](https://github.com/neondatabase/autoscaling/actions/runs/7131694851)): https://github.com/neondatabase/autoscaling/actions/workflows/e2e-test.yaml



<img width="375" alt="Screenshot 2023-12-07 at 17 17 20" src="https://github.com/neondatabase/autoscaling/assets/864213/8c0074d6-b0fc-4982-9e35-d2c44e05a440">