### PR TITLE
CI: call vm-kernel from release and e2e-test workflows

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -17,18 +17,21 @@ on:
           - k3d
           - kind
         default: k3d
-  workflow_call:
-    inputs:
-      kernel-image:
-        type: string
-        description: 'The kernel image to use for the VMs'
-        required: false
 
 env:
   PRESERVE_RUNNER_PODS: "true"
 
 jobs:
+  vm-kernel:
+    uses: ./.github/workflows/vm-kernel.yaml
+    with:
+      push: true
+      tag: ${{ github.run_id }}
+      kernel-image-tag-override: ${{ inputs.kernel-image }}
+    secrets: inherit
+
   e2e-tests:
+    needs: vm-kernel
     strategy:
       fail-fast: false
       matrix:
@@ -64,38 +67,14 @@ jobs:
           docker version
           docker buildx version
 
-      - name: Build Linux kernel
-        if: inputs.kernel-image == ''
-        uses: docker/build-push-action@v3
-        with:
-          build-args: KERNEL_VERSION=${{ env.VM_KERNEL_VERSION }}
-          context: neonvm/hack
-          platforms: linux/amd64
-          push: false
-          load: true
-          pull: true
-          no-cache: true
-          file: neonvm/hack/Dockerfile.kernel-builder
-          tags: ${{ env.VM_KERNEL_IMAGE }}:${{ env.VM_KERNEL_VERSION }}-${{ matrix.cluster }}-${{ github.run_id}}-${{ github.run_attempt }}
-        env:
-          VM_KERNEL_IMAGE:   "neondatabase/local-vm-kernel"
-          VM_KERNEL_VERSION: "6.1.63"
-
       - name: Load VM kernel
+        env:
+          IMAGE: ${{ needs.vm-kernel.outputs.image }}
         run: |
-          if [ -z "${{ inputs.kernel-image }}" ]; then
-            IMAGE="${VM_KERNEL_IMAGE}:${VM_KERNEL_VERSION}-${{ matrix.cluster }}-${{ github.run_id}}-${{ github.run_attempt }}"
-          else
-            IMAGE="${{ inputs.kernel-image }}"
-            docker pull --quiet $IMAGE
-          fi
-
-          ID=$(docker create ${IMAGE} true)
+          docker pull --quiet $IMAGE
+          ID=$(docker create $IMAGE true)
           docker cp ${ID}:/vmlinuz neonvm/hack/vmlinuz
           docker rm -f ${ID}
-        env:
-          VM_KERNEL_IMAGE:   "neondatabase/local-vm-kernel"
-          VM_KERNEL_VERSION: "6.1.63"
 
       # our docker builds use the output of 'git describe' for embedding git information
       - run: git describe --long --dirty

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,18 @@ env:
   IMG_VXLAN:                "neondatabase/neonvm-vxlan-controller"
   IMG_RUNNER:               "neondatabase/neonvm-runner"
   VM_KERNEL_IMAGE:          "neondatabase/vm-kernel"
-  VM_KERNEL_VERSION:        "6.1.63"
 
   CLUSTER_AUTOSCALER_IMAGE: "neondatabase/cluster-autoscaler-neonvm"
 
 jobs:
+  vm-kernel:
+    uses: ./.github/workflows/vm-kernel.yaml
+    with:
+      push: true
+      tag: ${{ github.ref_name }}
+
   release:
+    needs: vm-kernel
     runs-on: gha-ubuntu-22.04-64cores
     steps:
       - name: git checkout
@@ -64,9 +70,11 @@ jobs:
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
       - name: load vm kernel
+        env:
+          IMAGE: ${{ needs.vm-kernel.outputs.image }}
         run: |
-          docker pull --quiet ${{ env.VM_KERNEL_IMAGE }}:${{ env.VM_KERNEL_VERSION }}
-          ID=$(docker create ${{ env.VM_KERNEL_IMAGE }}:${{ env.VM_KERNEL_VERSION }} true)
+          docker pull --quiet $IMAGE
+          ID=$(docker create $IMAGE true)
           docker cp ${ID}:/vmlinuz neonvm/hack/vmlinuz
           docker rm -f ${ID}
 

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -99,7 +99,7 @@ jobs:
           build-args: KERNEL_VERSION=${{ steps.get-kernel-version.outputs.VM_KERNEL_VERSION }}
           context: neonvm/hack
           platforms: linux/amd64
-          # Push kernel image only for schedules builds or if workflow_dispatch/workflow_call input is true
+          # Push kernel image only for scheduled builds or if workflow_dispatch/workflow_call input is true
           push: ${{ github.event_name == 'schedule' && 'true' || ( inputs.push || 'false' ) }}
           pull: true
           no-cache: true

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -11,13 +11,54 @@ on:
         default: false
       tag:
         description: 'Tag to use for Docker image'
+        type: string
         required: false
+  workflow_call:
+    inputs:
+      push:
+        description: 'Push to Docker Hub'
+        type: boolean
+        default: false
+      tag:
+        description: 'Tag to use for Docker image'
+        type: string
+        required: false
+      kernel-image-tag-override:
+        description: 'If set, the workflow return the full image name for this tag'
+        type: string
+        required: false
+        default: ''
+    outputs:
+      image:
+        description: 'vm-kernel Docker image'
+        value: ${{ jobs.check-kernel-image-override.outputs.image || jobs.vm-kernel.outputs.image }}
 
 env:
   VM_KERNEL_IMAGE: "neondatabase/vm-kernel"
 
 jobs:
+  check-kernel-image-override:
+    outputs:
+      image: ${{ steps.check-kernel-image-override.outputs.image }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: check-kernel-image-override
+        env:
+          OVERRIDE_TAG: ${{ inputs.kernel-image-tag-override }}
+        run: |
+          if [ -n "${OVERRIDE_TAG}" ]; then
+            DIGEST=$(docker manifest inspect ${VM_KERNEL_IMAGE}:${OVERRIDE_TAG} -v | jq -r '.Descriptor.digest')
+            IMAGE="${VM_KERNEL_IMAGE}:${OVERRIDE_TAG}@${DIGEST}"
+          else
+            IMAGE=""
+          fi
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+
   vm-kernel:
+    needs: check-kernel-image-override
+    if: needs.check-kernel-image-override.outputs.image == ''
     outputs:
       image: ${{ fromJSON(steps.build-linux-kernel.outputs.metadata)['image.name'] }}@${{ steps.build-linux-kernel.outputs.digest }}
 
@@ -58,21 +99,14 @@ jobs:
           build-args: KERNEL_VERSION=${{ steps.get-kernel-version.outputs.VM_KERNEL_VERSION }}
           context: neonvm/hack
           platforms: linux/amd64
-          # Push only if this is a scheduled run or if the workflow_dispatch input push is set to true
-          push: ${{ github.event_name == 'schedule' && 'true' || ( github.event_name == 'workflow_dispatch' && inputs.push || 'false' ) }}
+          # Push kernel image only for schedules builds or if workflow_dispatch/workflow_call input is true
+          push: ${{ github.event_name == 'schedule' && 'true' || ( inputs.push || 'false' ) }}
           pull: true
           no-cache: true
           file: neonvm/hack/Dockerfile.kernel-builder
-          # Tag the image with the tag from the workflow_dispatch input or the VM_KERNEL_VERSION from linux-config-* file
-          tags: ${{ env.VM_KERNEL_IMAGE }}:${{ (github.event_name == 'workflow_dispatch' && inputs.tag != '') && inputs.tag || steps.get-kernel-version.outputs.VM_KERNEL_VERSION }}
-
+          # Tag kernel image with workflow_dispatch/workflow_call input or with the kernel version by default
+          tags: ${{ env.VM_KERNEL_IMAGE }}:${{ inputs.tag || steps.get-kernel-version.outputs.VM_KERNEL_VERSION }}
       - name: remove custom docker config directory
         if: always()
         run: |
           rm -rf .docker-custom
-
-  e2e-tests:
-    needs: vm-kernel
-    uses: ./.github/workflows/e2e-test.yaml
-    with:
-      kernel-image: ${{ needs.vm-kernel.outputs.image }}


### PR DESCRIPTION
Make `vm-kernel` a reusable workflow and call it from `e2e-test` and `release` workflows.

Other changes:
- add `kernel-image-tag-override` to `vm-kernel` to make it possible reuse previously built kernel.
- do not trigger `e2e-test` from `vm-kernel`: since now it happens the other way around

Caching kernel image is going to be the next PR.

The PR supersedes #651.