### PR TITLE
agent/billing: Log URL on billing requests

### DIFF
--- a/pkg/agent/billing/send.go
+++ b/pkg/agent/billing/send.go
@@ -110,8 +110,9 @@ func (s eventSender) sendAllCurrentEvents(logger *zap.Logger) {
 
 		logger.Info(
 			"Pushing billing events",
-			zap.String("traceID", string(traceID)),
 			zap.Int("count", count),
+			zap.String("traceID", string(traceID)),
+			zap.String("url", s.client.URL),
 		)
 
 		reqStart := time.Now()
@@ -128,9 +129,10 @@ func (s eventSender) sendAllCurrentEvents(logger *zap.Logger) {
 			// events.
 			logger.Error(
 				"Failed to push billing events",
-				zap.String("traceID", string(traceID)),
 				zap.Int("count", count),
 				zap.Duration("after", reqDuration),
+				zap.String("traceID", string(traceID)),
+				zap.String("url", s.client.URL),
 				zap.Int("total", total),
 				zap.Duration("totalTime", time.Since(startTime)),
 				zap.Error(err),
@@ -159,9 +161,10 @@ func (s eventSender) sendAllCurrentEvents(logger *zap.Logger) {
 
 		logger.Info(
 			"Successfully pushed some billing events",
-			zap.String("traceID", string(traceID)),
 			zap.Int("count", count),
 			zap.Duration("after", reqDuration),
+			zap.String("traceID", string(traceID)),
+			zap.String("url", s.client.URL),
 			zap.Int("total", total),
 			zap.Duration("totalTime", currentTotalTime),
 		)

--- a/pkg/billing/client.go
+++ b/pkg/billing/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Client struct {
-	BaseURL  string
+	URL      string
 	httpc    *http.Client
 	hostname string
 }
@@ -24,7 +24,7 @@ func NewClient(url string, c *http.Client) Client {
 	if err != nil {
 		hostname = fmt.Sprintf("unknown-%d", rand.Intn(1000))
 	}
-	return Client{BaseURL: url, httpc: c, hostname: hostname}
+	return Client{URL: fmt.Sprintf("%s/usage_events", url), httpc: c, hostname: hostname}
 }
 
 func (c Client) Hostname() string {
@@ -70,7 +70,7 @@ func Send[E Event](ctx context.Context, client Client, traceID TraceID, events [
 		return JSONError{Err: err}
 	}
 
-	r, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/usage_events", client.BaseURL), bytes.NewReader(payload))
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, client.URL, bytes.NewReader(payload))
 	if err != nil {
 		return RequestError{Err: err}
 	}


### PR DESCRIPTION
ref https://neondb.slack.com/archives/C03H1K0PGKH/p1702049320084879?thread_ts=1701881238.622479

To do this accurately, this commit renames `billing.Client.{BaseURL => URL}` and adds the `usage_events` suffix to `URL`, rather than during `billing.Send`.

This commit also reorders some of the log fields in the sending code (mostly just moving traceID), so that smaller items are at the start and similar items are grouped together.