### PR TITLE
billing: Don't hard-code usage_events suffix

### DIFF
--- a/pkg/agent/billing/send.go
+++ b/pkg/agent/billing/send.go
@@ -110,8 +110,9 @@ func (s eventSender) sendAllCurrentEvents(logger *zap.Logger) {
 
 		logger.Info(
 			"Pushing billing events",
-			zap.String("traceID", string(traceID)),
 			zap.Int("count", count),
+			zap.String("traceID", string(traceID)),
+			zap.String("url", s.client.URL),
 		)
 
 		reqStart := time.Now()
@@ -128,9 +129,10 @@ func (s eventSender) sendAllCurrentEvents(logger *zap.Logger) {
 			// events.
 			logger.Error(
 				"Failed to push billing events",
-				zap.String("traceID", string(traceID)),
 				zap.Int("count", count),
 				zap.Duration("after", reqDuration),
+				zap.String("traceID", string(traceID)),
+				zap.String("url", s.client.URL),
 				zap.Int("total", total),
 				zap.Duration("totalTime", time.Since(startTime)),
 				zap.Error(err),
@@ -159,9 +161,10 @@ func (s eventSender) sendAllCurrentEvents(logger *zap.Logger) {
 
 		logger.Info(
 			"Successfully pushed some billing events",
-			zap.String("traceID", string(traceID)),
 			zap.Int("count", count),
 			zap.Duration("after", reqDuration),
+			zap.String("traceID", string(traceID)),
+			zap.String("url", s.client.URL),
 			zap.Int("total", total),
 			zap.Duration("totalTime", currentTotalTime),
 		)

--- a/pkg/billing/client.go
+++ b/pkg/billing/client.go
@@ -24,7 +24,7 @@ func NewClient(url string, c *http.Client) Client {
 	if err != nil {
 		hostname = fmt.Sprintf("unknown-%d", rand.Intn(1000))
 	}
-	return Client{URL: fmt.Sprintf("%s/usage_events", url), httpc: c, hostname: hostname}
+	return Client{URL: url, httpc: c, hostname: hostname}
 }
 
 func (c Client) Hostname() string {

--- a/pkg/billing/client.go
+++ b/pkg/billing/client.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Client struct {
-	BaseURL  string
+	URL      string
 	httpc    *http.Client
 	hostname string
 }
@@ -24,7 +24,7 @@ func NewClient(url string, c *http.Client) Client {
 	if err != nil {
 		hostname = fmt.Sprintf("unknown-%d", rand.Intn(1000))
 	}
-	return Client{BaseURL: url, httpc: c, hostname: hostname}
+	return Client{URL: fmt.Sprintf("%s/usage_events", url), httpc: c, hostname: hostname}
 }
 
 func (c Client) Hostname() string {
@@ -70,7 +70,7 @@ func Send[E Event](ctx context.Context, client Client, traceID TraceID, events [
 		return JSONError{Err: err}
 	}
 
-	r, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/usage_events", client.BaseURL), bytes.NewReader(payload))
+	r, err := http.NewRequestWithContext(ctx, http.MethodPost, client.URL, bytes.NewReader(payload))
 	if err != nil {
 		return RequestError{Err: err}
 	}


### PR DESCRIPTION
**NOTE: This requires changing billing config when deploying!**

This commit removes the existing `/usage_events` suffix from the billing URL used, which means that values of the autoscaler-agent config's `.billing.url` must now add `/usage_events` to the end.

ref https://neondb.slack.com/archives/C03H1K0PGKH/p1702050181471839?thread_ts=1701881238.622479

**NB: This PR builds on #681 and must not be merged before it.**