### PR TITLE
agent: Separate memory and cpu metrics

### DIFF
--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -299,3 +299,19 @@ func makePerVMMetrics() (PerVMMetrics, *prometheus.Registry) {
 
 	return metrics, reg
 }
+
+// vmMetric is a data object that represents a single metric
+// (either CPU or memory) for a VM.
+type vmMetric struct {
+	labels prometheus.Labels
+	value  float64
+}
+
+func makeLabels(namespace string, vmName string, endpointID string, valueType vmResourceValueType) prometheus.Labels {
+	return prometheus.Labels{
+		"vm_namespace": namespace,
+		"vm_name":      vmName,
+		"endpoint_id":  endpointID,
+		"value":        string(valueType),
+	}
+}

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -254,15 +254,9 @@ func makeGlobalMetrics() (GlobalMetrics, *prometheus.Registry) {
 }
 
 type PerVMMetrics struct {
-	vmResources *prometheus.GaugeVec
+	cpu    *prometheus.GaugeVec
+	memory *prometheus.GaugeVec
 }
-
-type vmResource string
-
-const (
-	vmResourceCPU vmResource = "cpu"
-	vmResourceMem vmResource = "mem"
-)
 
 type vmResourceValueType string
 
@@ -277,16 +271,27 @@ func makePerVMMetrics() (PerVMMetrics, *prometheus.Registry) {
 	reg := prometheus.NewRegistry()
 
 	metrics := PerVMMetrics{
-		vmResources: util.RegisterMetric(reg, prometheus.NewGaugeVec(
+		cpu: util.RegisterMetric(reg, prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "autoscaling_vm_resources",
-				Help: "Amount of CPU or memory for a VM: min, max, spec using, or status using",
+				Name: "autoscaling_vm_cpu_cores",
+				Help: "Number of CPUs for a VM: min, max, spec using, or status using",
 			},
 			[]string{
 				"vm_namespace", // .metadata.namespace
 				"vm_name",      // .metadata.name
 				"endpoint_id",  // .metadata.labels["neon/endpoint-id"]
-				"resource",     // vmResource: "cpu" or "mem"
+				"value",        // vmResourceValue: min, spec_use, status_use, max
+			},
+		)),
+		memory: util.RegisterMetric(reg, prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "autoscaling_vm_memory_bytes",
+				Help: "Amount of memory in bytes for a VM: min, max, spec using, or status using",
+			},
+			[]string{
+				"vm_namespace", // .metadata.namespace
+				"vm_name",      // .metadata.name
+				"endpoint_id",  // .metadata.labels["neon/endpoint-id"]
 				"value",        // vmResourceValue: min, spec_use, status_use, max
 			},
 		)),

--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -300,18 +300,18 @@ func makePerVMMetrics() (PerVMMetrics, *prometheus.Registry) {
 	return metrics, reg
 }
 
-// vmMetric is a data object that represents a single metric
-// (either CPU or memory) for a VM.
-type vmMetric struct {
-	labels prometheus.Labels
-	value  float64
-}
-
-func makeLabels(namespace string, vmName string, endpointID string, valueType vmResourceValueType) prometheus.Labels {
+func makePerVMMetricsLabels(namespace string, vmName string, endpointID string, valueType vmResourceValueType) prometheus.Labels {
 	return prometheus.Labels{
 		"vm_namespace": namespace,
 		"vm_name":      vmName,
 		"endpoint_id":  endpointID,
 		"value":        string(valueType),
 	}
+}
+
+// vmMetric is a data object that represents a single metric
+// (either CPU or memory) for a VM.
+type vmMetric struct {
+	labels prometheus.Labels
+	value  float64
 }

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -228,10 +228,10 @@ func setVMMetrics(vm *vmapi.VirtualMachine, nodeName string, perVMMetrics *PerVM
 			perVMMetrics.cpu.WithLabelValues(append(commonLabelValues, string(t.key))...).Set(t.value.AsFloat64())
 		}
 	}
-
 	if vm.Status.CPUs != nil {
 		perVMMetrics.cpu.WithLabelValues(append(commonLabelValues, string(vmResourceValueStatusUse))...).Set(vm.Status.CPUs.AsFloat64())
 	}
+
 	// Memory metrics derived from spec
 	specMem := []kv[vmResourceValueType, *int32]{
 		{key: vmResourceValueMin, value: vm.Spec.Guest.MemorySlots.Min},
@@ -243,6 +243,10 @@ func setVMMetrics(vm *vmapi.VirtualMachine, nodeName string, perVMMetrics *PerVM
 			memValue := float64(vm.Spec.Guest.MemorySlotSize.Value() * int64(*t.value))
 			perVMMetrics.memory.WithLabelValues(append(commonLabelValues, string(t.key))...).Set(memValue)
 		}
+	}
+	if vm.Status.MemorySize != nil {
+		memValue := float64(vm.Status.MemorySize.Value())
+		perVMMetrics.memory.WithLabelValues(append(commonLabelValues, string(vmResourceValueStatusUse))...).Set(memValue)
 	}
 }
 

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -283,6 +283,8 @@ func setVMMetrics(perVMMetrics *PerVMMetrics, vm *vmapi.VirtualMachine, nodeName
 
 func updateVMMetrics(perVMMetrics *PerVMMetrics, oldVM, newVM *vmapi.VirtualMachine, nodeName string) {
 	if newVM.Status.Node != nodeName || oldVM.Status.Node != nodeName {
+		// this case we don't need an in-place metric update. Either we just have
+		// to add the new metrics, or delete the old ones, or nothing!
 		deleteVMMetrics(perVMMetrics, oldVM, nodeName)
 		setVMMetrics(perVMMetrics, newVM, nodeName)
 		return

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -210,7 +210,7 @@ func makeVMCPUMetrics(vm *vmapi.VirtualMachine) []vmMetric {
 		if val == nil {
 			return
 		}
-		labels := makeLabels(vm.Namespace, vm.Name, vm.Labels[endpointLabel], resValType)
+		labels := makePerVMMetricsLabels(vm.Namespace, vm.Name, vm.Labels[endpointLabel], resValType)
 		metrics = append(metrics, vmMetric{
 			labels: labels,
 			value:  val.AsFloat64(),
@@ -231,7 +231,7 @@ func makeVMMemMetrics(vm *vmapi.VirtualMachine) []vmMetric {
 		if val == nil {
 			return
 		}
-		labels := makeLabels(vm.Namespace, vm.Name, vm.Labels[endpointLabel], resValType)
+		labels := makePerVMMetricsLabels(vm.Namespace, vm.Name, vm.Labels[endpointLabel], resValType)
 		metrics = append(metrics, vmMetric{
 			labels: labels,
 			value:  float64(*val),

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -85,7 +85,7 @@ func startVMWatcher(
 		metav1.ListOptions{},
 		watch.HandlerFuncs[*vmapi.VirtualMachine]{
 			AddFunc: func(vm *vmapi.VirtualMachine, preexisting bool) {
-				setMetricsFromVM(vm, nodeName, &perVMMetrics)
+				setVMMetrics(vm, nodeName, &perVMMetrics)
 
 				if vmIsOurResponsibility(vm, config, nodeName) {
 					event, err := makeVMEvent(logger, vm, vmEventAdded)
@@ -100,8 +100,8 @@ func startVMWatcher(
 				}
 			},
 			UpdateFunc: func(oldVM, newVM *vmapi.VirtualMachine) {
-				deleteMetricsfromVM(oldVM, nodeName, &perVMMetrics)
-				setMetricsFromVM(newVM, nodeName, &perVMMetrics)
+				deleteVMMetrics(oldVM, nodeName, &perVMMetrics)
+				setVMMetrics(newVM, nodeName, &perVMMetrics)
 
 				oldIsOurs := vmIsOurResponsibility(oldVM, config, nodeName)
 				newIsOurs := vmIsOurResponsibility(newVM, config, nodeName)
@@ -136,7 +136,7 @@ func startVMWatcher(
 				submitEvent(event)
 			},
 			DeleteFunc: func(vm *vmapi.VirtualMachine, maybeStale bool) {
-				deleteMetricsfromVM(vm, nodeName, &perVMMetrics)
+				deleteVMMetrics(vm, nodeName, &perVMMetrics)
 
 				if vmIsOurResponsibility(vm, config, nodeName) {
 					event, err := makeVMEvent(logger, vm, vmEventDeleted)
@@ -206,7 +206,7 @@ type kv[K any, V any] struct {
 	value V
 }
 
-func setMetricsFromVM(vm *vmapi.VirtualMachine, nodeName string, perVMMetrics *PerVMMetrics) {
+func setVMMetrics(vm *vmapi.VirtualMachine, nodeName string, perVMMetrics *PerVMMetrics) {
 	if vm.Status.Node != nodeName {
 		return
 	}
@@ -246,7 +246,7 @@ func setMetricsFromVM(vm *vmapi.VirtualMachine, nodeName string, perVMMetrics *P
 	}
 }
 
-func deleteMetricsfromVM(vm *vmapi.VirtualMachine, nodeName string, perVMMetrics *PerVMMetrics) {
+func deleteVMMetrics(vm *vmapi.VirtualMachine, nodeName string, perVMMetrics *PerVMMetrics) {
 	if vm.Status.Node != nodeName {
 		return
 	}


### PR DESCRIPTION
Following common prometheus-style metric conventions [1]:
 * a metric "should represent the same logical thing-being-measured across all label dimensions"
 * It is also helpful to suffix the metric name with a unit type hint where applicable. Here memory has unit type bytes, while cpu has number of cores.

Therefore I think it's better to have separate metrics for different resource types.

[1] https://prometheus.io/docs/practices/naming/