### PR TITLE
neonvm/whereabouts: Require amd64 to fix issues with ARM nodes

### DIFF
--- a/neonvm/config/default-vxlan/whereabouts/daemonset_patch.yaml
+++ b/neonvm/config/default-vxlan/whereabouts/daemonset_patch.yaml
@@ -1,0 +1,24 @@
+# patch the DaemonSet so that it's only running on nodes that we'd support
+#
+# The image we're is a linux amd64 image; it doesn't work on ARM or non-Linux.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: whereabouts
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux

--- a/neonvm/config/default-vxlan/whereabouts/kustomization.yaml
+++ b/neonvm/config/default-vxlan/whereabouts/kustomization.yaml
@@ -7,6 +7,9 @@ bases:
 - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/v0.6.2/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
 - https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/v0.6.2/doc/crds/daemonset-install.yaml
 
+patchesStrategicMerge:
+- daemonset_patch.yaml
+
 images:
 - name: ghcr.io/k8snetworkplumbingwg/whereabouts
   newTag: v0.6.2-amd64


### PR DESCRIPTION
The upgrade from whereabouts v0.6.1 -> v0.6.2 removed the node affinity that prevented the daemonset from trying to run on ARM nodes.

During deploy of v0.20.0 (which contained this upgrade, via #636), we hit issues in one staging region which had an ARM node and had to rollback whereabouts.

ref https://neondb.slack.com/archives/C039YKBRZB4/p1702083096619049

---

Notes for review: I basically just copied the multus patch we have. The diff is as expected:

```diff
220a221,233
>       affinity:
>         nodeAffinity:
>           requiredDuringSchedulingIgnoredDuringExecution:
>             nodeSelectorTerms:
>             - matchExpressions:
>               - key: kubernetes.io/arch
>                 operator: In
>                 values:
>                 - amd64
>               - key: kubernetes.io/os
>                 operator: In
>                 values:
>                 - linux
```