### PR TITLE
README: Add note about supported OS/arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ For more information, refer to [ARCHITECTURE.md](./ARCHITECTURE.md).
 
 ## Building and running
 
+> [!NOTE]
+> NeonVM and Autoscaling are not expected to work outside Linux x86.
+
 Build NeonVM Linux kernel (it takes time, can be run only once)
 
 ```sh


### PR DESCRIPTION
This is a restriction that we don't make clear anywhere, but should.

For info on the markdown syntax, refer to the [github markdown docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).

Closes #473.