### PR TITLE
qmp: unify up/down memory scaling 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/digitalocean/go-qemu v0.0.0-20220826173844-d5f5e3ceed89
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20210525090646-64b7a4574d14
+	github.com/go-logr/logr v1.2.3
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/k8snetworkplumbingwg/whereabouts v0.6.1
 	github.com/kdomanski/iso9660 v0.3.3
@@ -106,7 +107,6 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -655,55 +655,31 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		}
 
 		// do hotplug/unplug Memory
-		// firstly get current state from QEMU
-		memoryDevices, err := QmpQueryMemoryDevices(QmpAddr(virtualmachine))
-		memoryPluggedSlots := *virtualmachine.Spec.Guest.MemorySlots.Min + int32(len(memoryDevices))
-		if err != nil {
-			log.Error(err, "Failed to get Memory details from VirtualMachine", "VirtualMachine", virtualmachine.Name)
+		memSlotsMin := *virtualmachine.Spec.Guest.MemorySlots.Min
+		targetSlotCount := int(*virtualmachine.Spec.Guest.MemorySlots.Use - memSlotsMin)
+
+		realSlots, err := QmpSetMemorySlots(ctx, virtualmachine, targetSlotCount, r.Recorder)
+		if realSlots < 0 {
 			return err
 		}
-		// compare guest spec and count of plugged
-		if *virtualmachine.Spec.Guest.MemorySlots.Use > memoryPluggedSlots {
-			// going to plug one Memory Slot
-			log.Info("Plug one more Memory module into VM")
-			if err := QmpPlugMemory(virtualmachine); err != nil {
+
+		if realSlots != int(targetSlotCount) {
+			log.Info("Couldn't achieve desired memory slot count, will modify .spec.guest.memorySlots.use instead", "details", err)
+			// firstly re-fetch VM
+			if err := r.Get(ctx, types.NamespacedName{Name: virtualmachine.Name, Namespace: virtualmachine.Namespace}, virtualmachine); err != nil {
+				log.Error(err, "Unable to re-fetch VirtualMachine")
 				return err
 			}
-			r.Recorder.Event(virtualmachine, "Normal", "ScaleUp",
-				fmt.Sprintf("One more DIMM was plugged into VM %s",
-					virtualmachine.Name))
-		} else if *virtualmachine.Spec.Guest.MemorySlots.Use < memoryPluggedSlots {
-			// going to unplug one Memory Slot
-			log.Info("Unplug one Memory module from VM")
-			if err := QmpUnplugMemory(QmpAddr(virtualmachine)); err != nil {
-				// special case !
-				// error means VM hadn't memory devices available for unplug
-				// need set .memorySlots.Use back to real value
-				log.Info("All memory devices busy, unable to unplug any, will modify .spec.guest.memorySlots.use instead", "details", err)
-				// firstly re-fetch VM
-				if err := r.Get(ctx, types.NamespacedName{Name: virtualmachine.Name, Namespace: virtualmachine.Namespace}, virtualmachine); err != nil {
-					log.Error(err, "Unable to re-fetch VirtualMachine")
-					return err
-				}
-				memorySlotsUseInSpec := *virtualmachine.Spec.Guest.MemorySlots.Use
-				virtualmachine.Spec.Guest.MemorySlots.Use = &memoryPluggedSlots
-				if err := r.tryUpdateVM(ctx, virtualmachine); err != nil {
-					log.Error(err,
-						"Failed to update .spec.guest.memorySlots.use",
-						"old value", memorySlotsUseInSpec,
-						"new value", memoryPluggedSlots)
-					return err
-				}
-				r.Recorder.Event(virtualmachine, "Warning", "ScaleDown",
-					fmt.Sprintf("Unable unplug DIMM from VM %s, all memory devices are busy",
-						virtualmachine.Name))
-			} else {
-				r.Recorder.Event(virtualmachine, "Normal", "ScaleDown",
-					fmt.Sprintf("One DIMM was unplugged from VM %s",
-						virtualmachine.Name))
+			memorySlotsUseInSpec := *virtualmachine.Spec.Guest.MemorySlots.Use
+			memoryPluggedSlots := memSlotsMin + int32(realSlots)
+			*virtualmachine.Spec.Guest.MemorySlots.Use = memoryPluggedSlots
+			if err := r.tryUpdateVM(ctx, virtualmachine); err != nil {
+				log.Error(err, "Failed to update .spec.guest.memorySlots.use",
+					"old value", memorySlotsUseInSpec,
+					"new value", memoryPluggedSlots)
+				return err
 			}
 		} else {
-			// seems already plugged correctly
 			ramScaled = true
 		}
 

--- a/neonvm/controllers/virtualmachine_qmp_queries.go
+++ b/neonvm/controllers/virtualmachine_qmp_queries.go
@@ -343,12 +343,16 @@ func QmpQueryMemoryBackendIds(mon *qmp.SocketMonitor) (map[int]struct{}, error) 
 	return backends, nil
 }
 
+type QMPRunner interface {
+	Run([]byte) ([]byte, error)
+}
+
 // QmpAddMemoryBackend adds a single memory slot to the VM with the given size.
 //
 // The memory slot does nothing until a corresponding "device" is added to the VM for the same memory slot.
 // See QmpAddMemoryDevice for more.
 // When unplugging, QmpDelMemoryDevice must be called before QmpDelMemoryBackend.
-func QmpAddMemoryBackend(mon *qmp.SocketMonitor, idx int, sizeBytes int64) error {
+func QmpAddMemoryBackend(mon QMPRunner, idx int, sizeBytes int64) error {
 	cmd := []byte(fmt.Sprintf(
 		`{"execute": "object-add",
 		  "arguments": {"id": "memslot%d",

--- a/neonvm/controllers/virtualmachine_qmp_queries.go
+++ b/neonvm/controllers/virtualmachine_qmp_queries.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -56,6 +58,15 @@ type QmpMemoryDevice struct {
 		Node         int64  `json:"node"`
 		Id           string `json:"id"`
 	} `json:"data"`
+}
+
+type QmpObjects struct {
+	Return []QmpObject `json:"return"`
+}
+
+type QmpObject struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 type QmpMigrationInfo struct {
@@ -269,6 +280,105 @@ func QmpQueryMemoryDevices(ip string, port int32) ([]QmpMemoryDevice, error) {
 	return result.Return, nil
 }
 
+func QmpMatchName(reg *regexp.Regexp, name string) (int, bool) {
+	// extracts the id from the name
+	matches := reg.FindStringSubmatch(name)
+	if len(matches) < 2 {
+		return 0, false
+	}
+	id, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, false
+	}
+	return id, true
+}
+
+var memBackendRegexp = regexp.MustCompile(`memslot(\d+)`)
+
+func QmpMatchMemBackend(name string) (int, error) {
+	// "/objects/memslot3" -> 3
+	name = strings.ReplaceAll(name, "/objects/", "")
+	idx, ok := QmpMatchName(memBackendRegexp, name)
+	if !ok {
+		return 0, fmt.Errorf("failed to parse memory device id: %s", name)
+	}
+	return idx, nil
+}
+
+func QmpQueryMemoryBackendIds(mon *qmp.SocketMonitor) (map[int]struct{}, error) {
+	cmd := []byte(`{"execute": "qom-list", "arguments": {"path": "/objects"}}`)
+	raw, err := mon.Run(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var result QmpObjects
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("error unmarshaling json: %w", err)
+	}
+	backends := map[int]struct{}{}
+	for _, o := range result.Return {
+		if o.Name == "pc.ram" { // Non-hotplugged memory
+			continue
+		}
+		if o.Type != "child<memory-backend-ram>" {
+			continue
+		}
+
+		idx, err := QmpMatchMemBackend(o.Name)
+		if err != nil {
+			return nil, err
+		}
+		backends[idx] = struct{}{}
+	}
+	return backends, nil
+}
+
+// QmpAddMemoryBackend adds a single memory slot to the VM with the given size.
+//
+// The memory slot does nothing until a corresponding "device" is added to the VM for the same memory slot.
+// See QmpAddMemoryDevice for more.
+// When unplugging, QmpDelMemoryDevice must be called before QmpDelMemoryBackend.
+func QmpAddMemoryBackend(mon *qmp.SocketMonitor, idx int, sizeBytes int64) error {
+	cmd := []byte(fmt.Sprintf(
+		`{"execute": "object-add",
+		  "arguments": {"id": "memslot%d",
+						"size": %d,
+						"qom-type": "memory-backend-ram"}}`, idx, sizeBytes,
+	))
+	_, err := mon.Run(cmd)
+	return err
+}
+
+func QmpDelMemoryBackend(mon *qmp.SocketMonitor, idx int) error {
+	cmd := []byte(fmt.Sprintf(
+		`{"execute": "object-del",
+		  "arguments": {"id": "memslot%d"}}`, idx,
+	))
+	_, err := mon.Run(cmd)
+	return err
+}
+
+func QmpAddMemoryDevice(mon *qmp.SocketMonitor, idx int) error {
+	cmd := []byte(fmt.Sprintf(
+		`{"execute": "device_add",
+		  "arguments": {"id": "dimm%d",
+						"driver": "pc-dimm",
+						"memdev": "memslot%d"}}`, idx, idx,
+	))
+	_, err := mon.Run(cmd)
+	return err
+}
+
+func QmpDelMemoryDevice(mon *qmp.SocketMonitor, idx int) error {
+	cmd := []byte(fmt.Sprintf(
+		`{"execute": "device_del",
+		  "arguments": {"id": "dimm%d"}}`, idx,
+	))
+	_, err := mon.Run(cmd)
+	return err
+}
+
 func QmpPlugMemory(virtualmachine *vmv1.VirtualMachine) error {
 	// slots - number of pluggable memory slots (Max - Min)
 	slots := *virtualmachine.Spec.Guest.MemorySlots.Max - *virtualmachine.Spec.Guest.MemorySlots.Min
@@ -291,29 +401,28 @@ func QmpPlugMemory(virtualmachine *vmv1.VirtualMachine) error {
 	defer mon.Disconnect() //nolint:errcheck // nothing to do with error when deferred. TODO: log it?
 
 	// try to find empty slot
-	var slot int32
-	for slot = 1; slot <= slots; slot++ {
-		cmd := []byte(fmt.Sprintf(`{"execute": "qom-list", "arguments": {"path": "/objects/memslot%d"}}`, slot))
-		_, err = mon.Run(cmd)
-		if err != nil {
+	backends, err := QmpQueryMemoryBackendIds(mon)
+	if err != nil {
+		return err
+	}
+	var slot int
+	for slot = 1; slot <= int(slots); slot++ {
+		_, ok := backends[slot]
+		if !ok {
 			// that mean such object wasn't found, or by other words slot is empty
 			break
 		}
 	}
 
-	// add memdev object
-	cmd := []byte(fmt.Sprintf(`{"execute": "object-add", "arguments": {"id": "memslot%d", "size": %d, "qom-type": "memory-backend-ram"}}`, slot, virtualmachine.Spec.Guest.MemorySlotSize.Value()))
-	_, err = mon.Run(cmd)
+	err = QmpAddMemoryBackend(mon, slot, virtualmachine.Spec.Guest.MemorySlotSize.Value())
 	if err != nil {
 		return err
 	}
 	// now add pc-dimm device
-	cmd = []byte(fmt.Sprintf(`{"execute": "device_add", "arguments": {"id": "dimm%d", "driver": "pc-dimm", "memdev": "memslot%d"}}`, slot, slot))
-	_, err = mon.Run(cmd)
+	err = QmpAddMemoryDevice(mon, slot)
 	if err != nil {
 		// device_add command failed... so try remove object that we just created
-		cmd = []byte(fmt.Sprintf(`{"execute": "object-del", "arguments": {"id": "memslot%d"}}`, slot))
-		mon.Run(cmd) //nolint:errcheck // already have one error, ignoring the second.
+		_ = QmpDelMemoryBackend(mon, slot)
 		return err
 	}
 
@@ -350,33 +459,19 @@ func QmpSyncMemoryToTarget(vm *vmv1.VirtualMachine, migration *vmv1.VirtualMachi
 			continue
 		}
 		// add memdev object
-		memdevId := strings.ReplaceAll(m.Data.Memdev, "/objects/", "")
-		cmd := []byte(fmt.Sprintf(`{
-			"execute": "object-add",
-			"arguments": {
-				"id": %q,
-				"size": %d,
-				"qom-type": "memory-backend-ram"
-			}
-		}`, memdevId, m.Data.Size))
-		_, err = target.Run(cmd)
+		memdevIdx, err := QmpMatchMemBackend(m.Data.Memdev)
+		if err != nil {
+			return err
+		}
+		err = QmpAddMemoryBackend(target, memdevIdx, m.Data.Size)
 		if err != nil {
 			return err
 		}
 		// now add pc-dimm device
-		cmd = []byte(fmt.Sprintf(`{
-			"execute": "device_add",
-			"arguments": {
-				"id": %q,
-				"driver": "pc-dimm",
-				"memdev": "%s"
-			}
-		}`, m.Data.Id, memdevId))
-		_, err = target.Run(cmd)
+		err = QmpAddMemoryDevice(target, memdevIdx)
 		if err != nil {
 			// device_add command failed... so try remove object that we just created
-			cmd = []byte(fmt.Sprintf(`{"execute": "object-del", "arguments": {"id": %q}}`, m.Data.Memdev))
-			target.Run(cmd) //nolint:errcheck // already have one error, ignoring the second.
+			_ = QmpDelMemoryBackend(target, memdevIdx)
 			return err
 		}
 	}
@@ -405,8 +500,11 @@ func QmpUnplugMemory(ip string, port int32) error {
 	var merr error
 	for i = plugged - 1; i >= 0; i-- {
 		// remove pc-dimm device
-		cmd := []byte(fmt.Sprintf(`{"execute": "device_del", "arguments": {"id": %q}}`, memoryDevices[i].Data.Id))
-		_, err = mon.Run(cmd)
+		idx, err := QmpMatchMemBackend(memoryDevices[i].Data.Memdev)
+		if err != nil {
+			merr = errors.Join(merr, err)
+		}
+		err = QmpDelMemoryDevice(mon, idx)
 		if err != nil {
 			merr = errors.Join(merr, err)
 			continue
@@ -415,11 +513,7 @@ func QmpUnplugMemory(ip string, port int32) error {
 		time.Sleep(time.Second)
 
 		// remove corresponding memdev object
-		cmd = []byte(fmt.Sprintf(`{
-			"execute": "object-del",
-			"arguments": {"id": %q}
-		}`, strings.ReplaceAll(memoryDevices[i].Data.Memdev, "/objects/", "")))
-		_, err = mon.Run(cmd)
+		err = QmpDelMemoryBackend(mon, idx)
 		if err != nil {
 			merr = errors.Join(merr, err)
 			continue

--- a/neonvm/controllers/vm_qmp_test.go
+++ b/neonvm/controllers/vm_qmp_test.go
@@ -1,0 +1,55 @@
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type qmpEvent struct {
+	Arg    string
+	Result string
+}
+
+type QMPMock struct {
+	Events chan qmpEvent
+}
+
+func NewQMPMock() *QMPMock {
+	return &QMPMock{
+		Events: make(chan qmpEvent, 100),
+	}
+}
+
+func (r *QMPMock) Expect(arg, result string) {
+	r.Events <- qmpEvent{
+		Arg:    arg,
+		Result: result,
+	}
+}
+
+func (r *QMPMock) Run(arg []byte) ([]byte, error) {
+	expected := <-r.Events
+	Expect(arg).Should(MatchJSON(expected.Arg))
+	return []byte(expected.Result), nil
+}
+
+func (r *QMPMock) Done() {
+	Expect(r.Events).To(BeEmpty())
+}
+
+var _ = Describe("VM QMP interaction", func() {
+	Context("QMP test", func() {
+		It("should support basic QMP operations", func() {
+			By("adding memslot")
+			qmp := NewQMPMock()
+			defer qmp.Done()
+			qmp.Expect(`
+				{"execute": "object-add",
+				 "arguments": {"id": "memslot1",
+						"size": 100,
+						"qom-type": "memory-backend-ram"}}`, `{}`)
+			err := QmpAddMemoryBackend(qmp, 1, 100)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+	})
+})


### PR DESCRIPTION
The new implementation has several advantages over the previous one:
1. It handles the case, when there are leftover memory backends from
previous incomplete unplugs (see #451). Those backends are reused for
new DIMM devices.
2. It allows for simultaneous addition/removal of multiple devices.
3. It adds symmetrical k8s event reporting for both memory backends
and DIMM devices.

Fixes #451
