### PR TITLE
agent,plugin: Don't send ComputeUnit from plugin

### DIFF
--- a/deploy/agent/config_map.yaml
+++ b/deploy/agent/config_map.yaml
@@ -7,6 +7,7 @@ data:
   config.json: |
     {
       "scaling": {
+        "computeUnit": { "vCPUs": 0.25, "mem": 1 },
         "requestTimeoutSeconds": 10,
         "retryFailedRequestSeconds": 5,
         "defaultConfig": {

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -66,6 +66,9 @@ type DumpStateConfig struct {
 
 // ScalingConfig defines the scheduling we use for scaling up and down
 type ScalingConfig struct {
+	// ComputeUnit is the desired ratio between CPU and memory that the autoscaler-agent should
+	// uphold when making changes to a VM
+	ComputeUnit api.Resources `json:"computeUnit"`
 	// RequestTimeoutSeconds gives the timeout duration, in seconds, for VM patch requests
 	RequestTimeoutSeconds uint `json:"requestTimeoutSeconds"`
 	// RetryFailedRequestSeconds gives the duration, in seconds, that we must wait after a previous

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -157,6 +157,8 @@ func (c *Config) validate() error {
 	erc.Whenf(ec, c.Metrics.Port == 0, zeroTmpl, ".metrics.port")
 	erc.Whenf(ec, c.Metrics.LoadMetricPrefix == "", emptyTmpl, ".metrics.loadMetricPrefix")
 	erc.Whenf(ec, c.Metrics.SecondsBetweenRequests == 0, zeroTmpl, ".metrics.secondsBetweenRequests")
+	erc.Whenf(ec, c.Scaling.ComputeUnit.VCPU == 0, zeroTmpl, ".scaling.computeUnit.vCPUs")
+	erc.Whenf(ec, c.Scaling.ComputeUnit.Mem == 0, zeroTmpl, ".scaling.computeUnit.mem")
 	erc.Whenf(ec, c.Scaling.RequestTimeoutSeconds == 0, zeroTmpl, ".scaling.requestTimeoutSeconds")
 	erc.Whenf(ec, c.Scaling.RetryFailedRequestSeconds == 0, zeroTmpl, ".scaling.retryFailedRequestSeconds")
 	erc.Whenf(ec, c.Monitor.ResponseTimeoutSeconds == 0, zeroTmpl, ".monitor.responseTimeoutSeconds")

--- a/pkg/agent/core/dumpstate.go
+++ b/pkg/agent/core/dumpstate.go
@@ -47,7 +47,6 @@ func (s *State) Dump() StateDump {
 func (s *pluginState) deepCopy() pluginState {
 	return pluginState{
 		OngoingRequest: s.OngoingRequest,
-		ComputeUnit:    shallowCopy[api.Resources](s.ComputeUnit),
 		LastRequest:    shallowCopy[pluginRequested](s.LastRequest),
 		LastFailureAt:  shallowCopy[time.Time](s.LastFailureAt),
 		Permit:         shallowCopy[api.Resources](s.Permit),

--- a/pkg/agent/core/state.go
+++ b/pkg/agent/core/state.go
@@ -37,6 +37,10 @@ import (
 
 // Config represents some of the static configuration underlying the decision-making of State
 type Config struct {
+	// ComputeUnit is the desired ratio between CPU and memory, copied from the global
+	// autoscaler-agent config.
+	ComputeUnit api.Resources
+
 	// DefaultScalingConfig is just copied from the global autoscaler-agent config.
 	// If the VM's ScalingConfig is nil, we use this field instead.
 	DefaultScalingConfig api.ScalingConfig
@@ -120,9 +124,6 @@ type state struct {
 type pluginState struct {
 	// OngoingRequest is true iff there is currently an ongoing request to *this* scheduler plugin.
 	OngoingRequest bool
-	// ComputeUnit, if not nil, gives the value of the compute unit we most recently got from a
-	// PluginResponse
-	ComputeUnit *api.Resources
 	// LastRequest, if not nil, gives information about the most recently started request to the
 	// plugin (maybe unfinished!)
 	LastRequest *pluginRequested
@@ -208,7 +209,6 @@ func NewState(vm api.VmInfo, config Config) *State {
 			VM:     vm,
 			Plugin: pluginState{
 				OngoingRequest: false,
-				ComputeUnit:    nil,
 				LastRequest:    nil,
 				LastFailureAt:  nil,
 				Permit:         nil,
@@ -663,12 +663,6 @@ func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 	// 2. Cap the goal CU by min/max, etc
 	// 3. that's it!
 
-	// if we don't know what the compute unit is, don't do anything.
-	if s.Plugin.ComputeUnit == nil {
-		s.warn("Can't determine desired resources because compute unit hasn't been set yet")
-		return s.VM.Using(), nil
-	}
-
 	var goalCU uint32
 	if s.Metrics != nil {
 		// For CPU:
@@ -676,7 +670,7 @@ func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 		// average),
 		// which we can get by dividing LA by LAFT, and then dividing by the number of CPUs per CU
 		goalCPUs := float64(s.Metrics.LoadAverage1Min) / s.scalingConfig().LoadAverageFractionTarget
-		cpuGoalCU := uint32(math.Round(goalCPUs / s.Plugin.ComputeUnit.VCPU.AsFloat64()))
+		cpuGoalCU := uint32(math.Round(goalCPUs / s.Config.ComputeUnit.VCPU.AsFloat64()))
 
 		// For Mem:
 		// Goal compute unit is at the point where (Mem) * (MemoryUsageFractionTarget) == (Mem Usage)
@@ -685,7 +679,7 @@ func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 		//
 		// NOTE: use uint64 for calculations on bytes as uint32 can overflow
 		memGoalBytes := uint64(math.Round(float64(s.Metrics.MemoryUsageBytes) / s.scalingConfig().MemoryUsageFractionTarget))
-		bytesPerCU := uint64(int64(s.Plugin.ComputeUnit.Mem) * s.VM.Mem.SlotSize.Value())
+		bytesPerCU := uint64(int64(s.Config.ComputeUnit.Mem) * s.VM.Mem.SlotSize.Value())
 		memGoalCU := uint32(memGoalBytes / bytesPerCU)
 
 		goalCU = util.Max(cpuGoalCU, memGoalCU)
@@ -703,7 +697,7 @@ func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 	timeUntilRequestedUpscalingExpired := s.timeUntilRequestedUpscalingExpired(now)
 	requestedUpscalingInEffect := timeUntilRequestedUpscalingExpired > 0
 	if requestedUpscalingInEffect {
-		reqCU := s.requiredCUForRequestedUpscaling(*s.Plugin.ComputeUnit, *s.Monitor.RequestedUpscale)
+		reqCU := s.requiredCUForRequestedUpscaling(s.Config.ComputeUnit, *s.Monitor.RequestedUpscale)
 		if reqCU > initialGoalCU {
 			// FIXME: this isn't quite correct, because if initialGoalCU is already equal to the
 			// maximum goal CU we *could* have, this won't actually have an effect.
@@ -718,7 +712,7 @@ func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 	timeUntilDeniedDownscaleExpired := s.timeUntilDeniedDownscaleExpired(now)
 	deniedDownscaleInEffect := timeUntilDeniedDownscaleExpired > 0
 	if deniedDownscaleInEffect {
-		reqCU := s.requiredCUForDeniedDownscale(*s.Plugin.ComputeUnit, s.Monitor.DeniedDownscale.Requested)
+		reqCU := s.requiredCUForDeniedDownscale(s.Config.ComputeUnit, s.Monitor.DeniedDownscale.Requested)
 		if reqCU > initialGoalCU {
 			deniedDownscaleAffectedResult = true
 			goalCU = util.Max(goalCU, reqCU)
@@ -733,7 +727,7 @@ func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 	if s.Metrics == nil && goalCU == 0 {
 		goalResources = s.VM.Using()
 	} else {
-		goalResources = s.Plugin.ComputeUnit.Mul(uint16(goalCU))
+		goalResources = s.Config.ComputeUnit.Mul(uint16(goalCU))
 	}
 
 	// bound goalResources by the minimum and maximum resource amounts for the VM
@@ -755,7 +749,7 @@ func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 			s.warn("Can't decrease desired resources to within VM maximum because of vm-monitor previously denied downscale request")
 		}
 		preMaxResult := result
-		result = result.Max(s.minRequiredResourcesForDeniedDownscale(*s.Plugin.ComputeUnit, *s.Monitor.DeniedDownscale))
+		result = result.Max(s.minRequiredResourcesForDeniedDownscale(s.Config.ComputeUnit, *s.Monitor.DeniedDownscale))
 		if result != preMaxResult {
 			deniedDownscaleAffectedResult = true
 		}
@@ -974,9 +968,6 @@ func (h PluginHandle) RequestSuccessful(now time.Time, resp api.PluginResponse) 
 	if err := resp.Permit.ValidateNonZero(); err != nil {
 		return fmt.Errorf("Invalid permit: %w", err)
 	}
-	if err := resp.ComputeUnit.ValidateNonZero(); err != nil {
-		return fmt.Errorf("Invalid compute unit: %w", err)
-	}
 
 	// Errors from resp in connection with the prior request
 	if resp.Permit.HasFieldGreaterThan(h.s.Plugin.LastRequest.Resources) {
@@ -993,7 +984,9 @@ func (h PluginHandle) RequestSuccessful(now time.Time, resp api.PluginResponse) 
 
 	// All good - set everything.
 
-	h.s.Plugin.ComputeUnit = &resp.ComputeUnit
+	// NOTE: We don't set the compute unit, even though the plugin response contains it. We're in
+	// the process of moving the source of truth for ComputeUnit from the scheduler plugin to the
+	// autoscaler-agent.
 	h.s.Plugin.Permit = &resp.Permit
 	return nil
 }

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -45,7 +45,7 @@ import (
 //
 // Currently, each autoscaler-agent supports only one version at a time. In the future, this may
 // change.
-const PluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV2_1
+const PluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV3_0
 
 // Runner is per-VM Pod god object responsible for handling everything
 //
@@ -194,6 +194,7 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger, vmInfoUpdated util
 	executorCore := executor.NewExecutorCore(coreExecLogger, getVmInfo(), executor.Config{
 		OnNextActions: r.global.metrics.runnerNextActions.Inc,
 		Core: core.Config{
+			ComputeUnit:                        r.global.config.Scaling.ComputeUnit,
 			DefaultScalingConfig:               r.global.config.Scaling.DefaultConfig,
 			NeonVMRetryWait:                    time.Second * time.Duration(r.global.config.Scaling.RetryFailedRequestSeconds),
 			PluginRequestTick:                  time.Second * time.Duration(r.global.config.Scheduler.RequestAtLeastEverySeconds),

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -34,7 +34,7 @@ number.
 
 | Release | autoscaler-agent | Scheduler plugin |
 |---------|------------------|------------------|
-| _Current_ | v2.1 only | v1.0-v2.1 |
+| _Current_ | v3.0 only | v1.0-v3.0 |
 | v0.21.0 | v2.1 only | v1.0-v2.1 |
 | v0.20.0 | **v2.1 only** | **v1.0-v2.1** |
 | v0.19.0 | v2.0 only | v1.0-v2.0 |

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -60,7 +60,7 @@ const (
 	//
 	// * added AgentRequest.LastPermit
 	//
-	// Last used in release version <todo>.
+	// Last used in release version v0.21.0.
 	PluginProtoV2_1
 
 	// PluginProtoV3_0 represents v3.0 of the agent<->scheduler plugin protocol.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -58,8 +58,17 @@ const (
 	//
 	// * added AgentRequest.LastPermit
 	//
-	// Currently the latest version.
+	// Last used in release version <todo>.
 	PluginProtoV2_1
+
+	// PluginProtoV3_0 represents v3.0 of the agent<->scheduler plugin protocol.
+	//
+	// Changes from v2.1:
+	//
+	// * Removes PluginResponse.ComputeUnit (agent is now responsible for source of truth)
+	//
+	// Currently the latest version.
+	PluginProtoV3_0
 
 	// latestPluginProtoVersion represents the latest version of the agent<->scheduler plugin
 	// protocol
@@ -84,6 +93,8 @@ func (v PluginProtoVersion) String() string {
 		return "v2.0"
 	case PluginProtoV2_1:
 		return "v2.1"
+	case PluginProtoV3_0:
+		return "v3.0"
 	default:
 		diff := v - latestPluginProtoVersion
 		return fmt.Sprintf("<unknown = %v + %d>", latestPluginProtoVersion, diff)
@@ -105,6 +116,14 @@ func (v PluginProtoVersion) AllowsNilMetrics() bool {
 
 func (v PluginProtoVersion) SupportsFractionalCPU() bool {
 	return v >= PluginProtoV2_0
+}
+
+// PluginSendsComputeUnit returns whether this version of the protocol expects the scheduler plugin
+// to send the value of the Compute Unit in its PluginResponse.
+//
+// This is true for all versions below v3.0.
+func (v PluginProtoVersion) PluginSendsComputeUnit() bool {
+	return v < PluginProtoV3_0
 }
 
 // AgentRequest is the type of message sent from an autoscaler-agent to the scheduler plugin
@@ -277,7 +296,9 @@ type PluginResponse struct {
 	//
 	// This value may be different across nodes, and the scheduler expects that all AgentRequests
 	// will abide by the most recent ComputeUnit they've received.
-	ComputeUnit Resources `json:"resourceUnit"`
+	//
+	// THIS FIELD IS DEPRECATED: See https://github.com/neondatabase/autoscaling/issues/706
+	ComputeUnit *Resources `json:"resourceUnit,omitempty"`
 }
 
 // MigrateResponse, when provided, is a notification to the autsocaler-agent that it will migrate


### PR DESCRIPTION
Instead, define it in the autoscaler-agent config.

This change starts the removal process of ComputeUnit from PluginResponse, so that the new protocol version expects that it won't be set - but to preserve backwards-compatibility during the upgrade, we need to keep the old behavior for now (hence the field is `omitempty`).

A follow-up change will update the plugin so that it *never* sends ComputeUnit, removing the field and the plugin's config along with it.

Part of #706.

---

Notes for review: This overlaps _a little_ with #653 — I think it's _probably_ easier to merge this first, release, and then merge that one.

~~Marking as a draft for now, until I've tested that e2e tests pass with old agent + new scheduler.~~ Tested locally and it appears to work.