### PR TITLE
agent/core: Send monitor requests in 1 CU increments

### DIFF
--- a/deploy/agent/config_map.yaml
+++ b/deploy/agent/config_map.yaml
@@ -24,7 +24,6 @@ data:
           "unhealthyStartupGracePeriodSeconds": 20,
           "maxHealthCheckSequentialFailuresSeconds": 30,
           "retryDeniedDownscaleSeconds": 5,
-          "deniedDownscaleFollowUpWaitSeconds": 1,
           "requestedUpscaleValidSeconds": 10,
           "retryFailedRequestSeconds": 3
       },

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -47,9 +47,6 @@ type MonitorConfig struct {
 	// RetryDeniedDownscaleSeconds gives the duration, in seconds, that we must wait before retrying
 	// a downscale request that was previously denied
 	RetryDeniedDownscaleSeconds uint `json:"retryDeniedDownscaleSeconds"`
-	// DeniedDownscaleFollowUpWaitSeconds gives the duration, in seconds, that we must wait before
-	// making another downscale request after one was just denied.
-	DeniedDownscaleFollowUpWaitSeconds uint `json:"deniedDownscaleFollowUpWaitSeconds"`
 	// RequestedUpscaleValidSeconds gives the duration, in seconds, that requested upscaling should
 	// be respected for, before allowing re-downscaling.
 	RequestedUpscaleValidSeconds uint `json:"requestedUpscaleValidSeconds"`
@@ -170,7 +167,6 @@ func (c *Config) validate() error {
 	erc.Whenf(ec, c.Monitor.MaxHealthCheckSequentialFailuresSeconds == 0, zeroTmpl, ".monitor.maxHealthCheckSequentialFailuresSeconds")
 	erc.Whenf(ec, c.Monitor.RetryFailedRequestSeconds == 0, zeroTmpl, ".monitor.retryFailedRequestSeconds")
 	erc.Whenf(ec, c.Monitor.RetryDeniedDownscaleSeconds == 0, zeroTmpl, ".monitor.retryDeniedDownscaleSeconds")
-	erc.Whenf(ec, c.Monitor.DeniedDownscaleFollowUpWaitSeconds == 0, zeroTmpl, ".monitor.deniedDownscaleFollowUpWaitSeconds")
 	erc.Whenf(ec, c.Monitor.RequestedUpscaleValidSeconds == 0, zeroTmpl, ".monitor.requestedUpscaleValidSeconds")
 	// add all errors if there are any: https://github.com/neondatabase/autoscaling/pull/195#discussion_r1170893494
 	ec.Add(c.Scaling.DefaultConfig.Validate())

--- a/pkg/agent/core/state_test.go
+++ b/pkg/agent/core/state_test.go
@@ -475,8 +475,8 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	a := helpers.NewAssert(t)
 	clock := helpers.NewFakeClock(t)
 	clockTickDuration := duration("0.1s")
-	clockTick := func() helpers.Elapsed {
-		return clock.Inc(clockTickDuration)
+	clockTick := func() {
+		clock.Inc(clockTickDuration)
 	}
 	resForCU := DefaultComputeUnit.Mul
 

--- a/pkg/agent/core/state_test.go
+++ b/pkg/agent/core/state_test.go
@@ -115,7 +115,6 @@ func Test_DesiredResourcesFromMetricsOrRequestedUpscaling(t *testing.T) {
 				PluginRequestTick:                  time.Second,
 				PluginRetryWait:                    time.Second,
 				PluginDeniedRetryWait:              time.Second,
-				MonitorDownscaleFollowUpWait:       time.Second,
 				MonitorDeniedDownscaleCooldown:     time.Second,
 				MonitorRequestedUpscaleValidPeriod: time.Second,
 				MonitorRetryWait:                   time.Second,
@@ -186,7 +185,6 @@ var DefaultInitialStateConfig = helpers.InitialStateConfig{
 		PluginRequestTick:                  5 * time.Second,
 		PluginRetryWait:                    3 * time.Second,
 		PluginDeniedRetryWait:              2 * time.Second,
-		MonitorDownscaleFollowUpWait:       1 * time.Second,
 		MonitorDeniedDownscaleCooldown:     5 * time.Second,
 		MonitorRequestedUpscaleValidPeriod: 10 * time.Second,
 		MonitorRetryWait:                   3 * time.Second,
@@ -490,7 +488,6 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 		helpers.WithConfigSetting(func(c *core.Config) {
 			// values close to the default, so request timing works out a little better.
 			c.PluginRequestTick = duration("7s")
-			c.MonitorDownscaleFollowUpWait = duration("0.2s")
 			c.MonitorDeniedDownscaleCooldown = duration("4s")
 		}),
 	)
@@ -504,7 +501,7 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	doInitialPluginRequest(a, state, clock, duration("0.1s"), nil, resForCU(6))
 
 	// Set metrics
-	clockTick().AssertEquals(duration("0.2s"))
+	clockTick()
 	metrics := api.Metrics{
 		LoadAverage1Min:  0.0,
 		LoadAverage5Min:  0.0,
@@ -522,7 +519,7 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	// This behavior results in linear retry passes.
 	//
 	// For this test, we:
-	// 1. Deny all requests in the first pass
+	// 1. Deny any request in the first pass
 	// 2. Approve only down to 3 CU on the second pass
 	//    a. triggers NeonVM request
 	//    b. triggers plugin request
@@ -533,79 +530,65 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	//
 	// ----
 	//
-	// First pass: deny all requests. Should try from 1 to 5 CU.
-	clock.Elapsed().AssertEquals(duration("0.2s"))
-	currentPluginWait := duration("6.8s")
-	for cu := uint16(1); cu <= 5; cu += 1 {
-		a.Call(nextActions).Equals(core.ActionSet{
-			Wait: &core.ActionWait{Duration: currentPluginWait},
-			MonitorDownscale: &core.ActionMonitorDownscale{
-				Current: resForCU(6),
-				Target:  resForCU(cu),
-			},
-		})
-		// Do the request:
-		a.Do(state.Monitor().StartingDownscaleRequest, clock.Now(), resForCU(cu))
-		a.Call(nextActions).Equals(core.ActionSet{
-			Wait: &core.ActionWait{Duration: currentPluginWait},
-		})
-		clockTick()
-		currentPluginWait -= clockTickDuration
-		a.Do(state.Monitor().DownscaleRequestDenied, clock.Now())
-		if cu < 5 {
-			a.
-				WithWarnings("Wanted to send vm-monitor downscale request but too soon after previously denied downscaling").
-				Call(nextActions).
-				Equals(core.ActionSet{
-					Wait: &core.ActionWait{Duration: duration("0.2s")},
-				})
-			clock.Inc(duration("0.2s"))
-			currentPluginWait -= duration("0.2s")
-		}
-	}
+	// First pass: deny downscaling.
+	clock.Elapsed()
+
+	a.Call(nextActions).Equals(core.ActionSet{
+		Wait: &core.ActionWait{Duration: duration("6.8s")},
+		MonitorDownscale: &core.ActionMonitorDownscale{
+			Current: resForCU(6),
+			Target:  resForCU(5),
+		},
+	})
+	a.Do(state.Monitor().StartingDownscaleRequest, clock.Now(), resForCU(5))
+	clockTick()
+	a.Do(state.Monitor().DownscaleRequestDenied, clock.Now())
+
 	// At the end, we should be waiting to retry downscaling:
 	a.Call(nextActions).Equals(core.ActionSet{
 		// Taken from DefaultInitialStateConfig.Core.MonitorDeniedDownscaleCooldown
-		Wait: &core.ActionWait{Duration: duration("4s")},
+		Wait: &core.ActionWait{Duration: duration("4.0s")},
 	})
 
-	clock.Inc(duration("4s")).AssertEquals(duration("5.5s"))
-	currentPluginWait = duration("1.5s")
+	clock.Inc(duration("4s"))
+	currentPluginWait := duration("2.7s")
 
 	// Second pass: Approve only down to 3 CU, then NeonVM & plugin requests.
-	for cu := uint16(1); cu <= 3; cu += 1 {
+	for cu := uint16(5); cu >= 2; cu -= 1 {
+		var expectedNeonVMRequest *core.ActionNeonVMRequest
+		if cu < 5 {
+			expectedNeonVMRequest = &core.ActionNeonVMRequest{
+				Current: resForCU(6),
+				Target:  resForCU(cu + 1),
+			}
+		}
+
 		a.Call(nextActions).Equals(core.ActionSet{
 			Wait: &core.ActionWait{Duration: currentPluginWait},
 			MonitorDownscale: &core.ActionMonitorDownscale{
-				Current: resForCU(6),
+				Current: resForCU(cu + 1),
 				Target:  resForCU(cu),
 			},
+			NeonVMRequest: expectedNeonVMRequest,
 		})
 		a.Do(state.Monitor().StartingDownscaleRequest, clock.Now(), resForCU(cu))
 		a.Call(nextActions).Equals(core.ActionSet{
-			Wait: &core.ActionWait{Duration: currentPluginWait},
+			Wait:          &core.ActionWait{Duration: currentPluginWait},
+			NeonVMRequest: expectedNeonVMRequest,
 		})
 		clockTick()
 		currentPluginWait -= clockTickDuration
-		if cu < 3 /* deny up to 3 */ {
-			a.Do(state.Monitor().DownscaleRequestDenied, clock.Now())
-			a.
-				WithWarnings("Wanted to send vm-monitor downscale request but too soon after previously denied downscaling").
-				Call(nextActions).
-				Equals(core.ActionSet{
-					Wait: &core.ActionWait{Duration: duration("0.2s")},
-				})
-			clock.Inc(duration("0.2s"))
-			currentPluginWait -= duration("0.2s")
-		} else {
+		if cu >= 3 /* allow down to 3 */ {
 			a.Do(state.Monitor().DownscaleRequestAllowed, clock.Now())
+		} else {
+			a.Do(state.Monitor().DownscaleRequestDenied, clock.Now())
 		}
 	}
 	// At this point, waiting 3.7s for next attempt to downscale below 3 CU (last request was
 	// successful, but the one before it wasn't), and 0.8s for plugin tick.
 	// Also, because downscaling was approved, we should want to make a NeonVM request to do that.
 	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("0.8s")},
+		Wait: &core.ActionWait{Duration: duration("2.3s")},
 		NeonVMRequest: &core.ActionNeonVMRequest{
 			Current: resForCU(6),
 			Target:  resForCU(3),
@@ -614,14 +597,14 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	// Make the request:
 	a.Do(state.NeonVM().StartingRequest, time.Now(), resForCU(3))
 	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("0.8s")},
+		Wait: &core.ActionWait{Duration: duration("2.3s")},
 	})
-	clockTick().AssertEquals(duration("6.3s"))
+	clockTick()
 	a.Do(state.NeonVM().RequestSuccessful, time.Now())
 	// Successfully scaled down, so we should now inform the plugin. But also, we'll want to retry
 	// the downscale request to vm-monitor once the retry is up:
 	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("3.6s")},
+		Wait: &core.ActionWait{Duration: duration("3.9s")},
 		PluginRequest: &core.ActionPluginRequest{
 			LastPermit: ptr(resForCU(6)),
 			Target:     resForCU(3),
@@ -630,9 +613,9 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	})
 	a.Do(state.Plugin().StartingRequest, clock.Now(), resForCU(3))
 	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("3.6s")},
+		Wait: &core.ActionWait{Duration: duration("3.9s")},
 	})
-	clockTick().AssertEquals(duration("6.4s"))
+	clockTick()
 	a.NoError(state.Plugin().RequestSuccessful, clock.Now(), api.PluginResponse{
 		Permit:      resForCU(3),
 		Migrate:     nil,
@@ -640,48 +623,30 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	})
 	// ... And *now* there's nothing left to do but wait until downscale wait expires:
 	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("3.5s")},
+		Wait: &core.ActionWait{Duration: duration("3.8s")},
 	})
 
 	// so, wait for that:
-	clock.Inc(duration("3.5s")).AssertEquals(duration("9.9s"))
+	clock.Inc(duration("3.8s"))
 
-	// Third pass: deny all requests.
-	currentPluginWait = duration("3.4s")
-	for cu := uint16(1); cu <= 2; cu += 1 {
-		a.Call(nextActions).Equals(core.ActionSet{
-			Wait: &core.ActionWait{Duration: currentPluginWait},
-			MonitorDownscale: &core.ActionMonitorDownscale{
-				Current: resForCU(3),
-				Target:  resForCU(cu),
-			},
-		})
-		a.Do(state.Monitor().StartingDownscaleRequest, clock.Now(), resForCU(cu))
-		a.Call(nextActions).Equals(core.ActionSet{
-			Wait: &core.ActionWait{Duration: currentPluginWait},
-		})
-		clockTick()
-		currentPluginWait -= clockTickDuration
-		a.Do(state.Monitor().DownscaleRequestDenied, clock.Now())
-		if cu < 2 {
-			a.
-				WithWarnings("Wanted to send vm-monitor downscale request but too soon after previously denied downscaling").
-				Call(nextActions).
-				Equals(core.ActionSet{
-					Wait: &core.ActionWait{Duration: duration("0.2s")},
-				})
-			clock.Inc(duration("0.2s"))
-			currentPluginWait -= duration("0.2s")
-		}
-	}
-	clock.Elapsed().AssertEquals(duration("10.3s"))
+	// Third pass: deny requested downscaling.
+	a.Call(nextActions).Equals(core.ActionSet{
+		Wait: &core.ActionWait{Duration: duration("3.1s")},
+		MonitorDownscale: &core.ActionMonitorDownscale{
+			Current: resForCU(3),
+			Target:  resForCU(2),
+		},
+	})
+	a.Do(state.Monitor().StartingDownscaleRequest, clock.Now(), resForCU(2))
+	clockTick()
+	a.Do(state.Monitor().DownscaleRequestDenied, clock.Now())
 	// At the end, we should be waiting to retry downscaling (but actually, the regular plugin
 	// request is coming up sooner).
 	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("3s")},
+		Wait: &core.ActionWait{Duration: duration("3.0s")},
 	})
 	// ... so, wait for that plugin request/response, and then wait to retry downscaling:
-	clock.Inc(duration("3s")).AssertEquals(duration("13.3s"))
+	clock.Inc(duration("3s"))
 	a.Call(nextActions).Equals(core.ActionSet{
 		Wait: &core.ActionWait{Duration: duration("1s")}, // still want to retry vm-monitor downscaling
 		PluginRequest: &core.ActionPluginRequest{
@@ -694,7 +659,7 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	a.Call(nextActions).Equals(core.ActionSet{
 		Wait: &core.ActionWait{Duration: duration("1s")}, // still waiting on retrying vm-monitor downscaling
 	})
-	clockTick().AssertEquals(duration("13.4s"))
+	clockTick()
 	a.NoError(state.Plugin().RequestSuccessful, clock.Now(), api.PluginResponse{
 		Permit:      resForCU(3),
 		Migrate:     nil,
@@ -704,26 +669,40 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 		Wait: &core.ActionWait{Duration: duration("0.9s")}, // yep, still waiting on retrying vm-monitor downscaling
 	})
 
-	clock.Inc(duration("0.9s")).AssertEquals(duration("14.3s"))
+	clock.Inc(duration("0.9s"))
 
-	// Fourth pass: approve down to 1 CU
-	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("6s")}, // waiting for plugin request tick
-		MonitorDownscale: &core.ActionMonitorDownscale{
-			Current: resForCU(3),
-			Target:  resForCU(1),
-		},
-	})
-	a.Do(state.Monitor().StartingDownscaleRequest, clock.Now(), resForCU(1))
-	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("6s")}, // still waiting on plugin
-	})
-	clockTick().AssertEquals(duration("14.4s"))
-	a.Do(state.Monitor().DownscaleRequestAllowed, clock.Now())
+	// Fourth pass: approve down to 1 CU - wait to do the NeonVM requests until the end
+	currentPluginWait = duration("6.0s")
+	for cu := uint16(2); cu >= 1; cu -= 1 {
+		var expectedNeonVMRequest *core.ActionNeonVMRequest
+		if cu < 2 {
+			expectedNeonVMRequest = &core.ActionNeonVMRequest{
+				Current: resForCU(3),
+				Target:  resForCU(cu + 1),
+			}
+		}
+
+		a.Call(nextActions).Equals(core.ActionSet{
+			Wait: &core.ActionWait{Duration: currentPluginWait},
+			MonitorDownscale: &core.ActionMonitorDownscale{
+				Current: resForCU(cu + 1),
+				Target:  resForCU(cu),
+			},
+			NeonVMRequest: expectedNeonVMRequest,
+		})
+		a.Do(state.Monitor().StartingDownscaleRequest, clock.Now(), resForCU(cu))
+		a.Call(nextActions).Equals(core.ActionSet{
+			Wait:          &core.ActionWait{Duration: currentPluginWait},
+			NeonVMRequest: expectedNeonVMRequest,
+		})
+		clockTick()
+		currentPluginWait -= clockTickDuration
+		a.Do(state.Monitor().DownscaleRequestAllowed, clock.Now())
+	}
 	// Still waiting on plugin request tick, but we can make a NeonVM request to enact the
 	// downscaling right away !
 	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("5.9s")},
+		Wait: &core.ActionWait{Duration: duration("5.8s")},
 		NeonVMRequest: &core.ActionNeonVMRequest{
 			Current: resForCU(3),
 			Target:  resForCU(1),
@@ -731,9 +710,9 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	})
 	a.Do(state.NeonVM().StartingRequest, time.Now(), resForCU(1))
 	a.Call(nextActions).Equals(core.ActionSet{
-		Wait: &core.ActionWait{Duration: duration("5.9s")}, // yep, still waiting on the plugin
+		Wait: &core.ActionWait{Duration: duration("5.8s")}, // yep, still waiting on the plugin
 	})
-	clockTick().AssertEquals(duration("14.5s"))
+	clockTick()
 	a.Do(state.NeonVM().RequestSuccessful, time.Now())
 	// Successfully downscaled, so now we should inform the plugin. Not waiting on any retries.
 	a.Call(nextActions).Equals(core.ActionSet{
@@ -747,7 +726,7 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	a.Call(nextActions).Equals(core.ActionSet{
 		// not waiting on anything!
 	})
-	clockTick().AssertEquals(duration("14.6s"))
+	clockTick()
 	a.NoError(state.Plugin().RequestSuccessful, clock.Now(), api.PluginResponse{
 		Permit:      resForCU(1),
 		Migrate:     nil,
@@ -1408,7 +1387,7 @@ func TestMetricsConcurrentUpdatedDuringDownscale(t *testing.T) {
 		// unassigned pooled VMs created by the control plane are first assigned and endpoint and
 		// must immediately scale down.
 		helpers.WithMinMaxCU(1, 2),
-		helpers.WithCurrentCU(4),
+		helpers.WithCurrentCU(3),
 	)
 	nextActions := func() core.ActionSet {
 		return state.NextActions(clock.Now())
@@ -1421,14 +1400,14 @@ func TestMetricsConcurrentUpdatedDuringDownscale(t *testing.T) {
 		Equals(core.ActionSet{
 			PluginRequest: &core.ActionPluginRequest{
 				LastPermit: nil,
-				Target:     resForCU(4),
+				Target:     resForCU(3),
 				Metrics:    nil,
 			},
 		})
-	a.Do(state.Plugin().StartingRequest, clock.Now(), resForCU(4))
+	a.Do(state.Plugin().StartingRequest, clock.Now(), resForCU(3))
 	clockTick()
 	a.NoError(state.Plugin().RequestSuccessful, clock.Now(), api.PluginResponse{
-		Permit:      resForCU(4),
+		Permit:      resForCU(3),
 		Migrate:     nil,
 		ComputeUnit: nil,
 	})
@@ -1441,7 +1420,7 @@ func TestMetricsConcurrentUpdatedDuringDownscale(t *testing.T) {
 	a.Call(nextActions).Equals(core.ActionSet{
 		Wait: &core.ActionWait{Duration: duration("4.8s")},
 		MonitorDownscale: &core.ActionMonitorDownscale{
-			Current: resForCU(4),
+			Current: resForCU(3),
 			Target:  resForCU(2),
 		},
 	})
@@ -1459,14 +1438,9 @@ func TestMetricsConcurrentUpdatedDuringDownscale(t *testing.T) {
 	a.Do(state.UpdateMetrics, metrics)
 
 	// nothing to do yet, until the existing vm-monitor request finishes
-	a.
-		WithWarnings(
-			"Wanted to send vm-monitor downscale request, but waiting on other ongoing downscale request (for different resources)",
-		).
-		Call(nextActions).
-		Equals(core.ActionSet{
-			Wait: &core.ActionWait{Duration: duration("4.7s")}, // plugin request tick wait
-		})
+	a.Call(nextActions).Equals(core.ActionSet{
+		Wait: &core.ActionWait{Duration: duration("4.7s")}, // plugin request tick wait
+	})
 
 	clockTick()
 
@@ -1477,7 +1451,7 @@ func TestMetricsConcurrentUpdatedDuringDownscale(t *testing.T) {
 	a.Call(nextActions).Equals(core.ActionSet{
 		Wait: &core.ActionWait{Duration: duration("4.6s")}, // plugin request tick wait
 		NeonVMRequest: &core.ActionNeonVMRequest{
-			Current: resForCU(4),
+			Current: resForCU(3),
 			Target:  resForCU(2),
 		},
 		MonitorDownscale: &core.ActionMonitorDownscale{
@@ -1513,7 +1487,7 @@ func TestMetricsConcurrentUpdatedDuringDownscale(t *testing.T) {
 			// incorrectly for 1 CU, rather than 2 CU. So, the rest of this test case is mostly just
 			// rounding out the rest of the scale-down routine.
 			PluginRequest: &core.ActionPluginRequest{
-				LastPermit: ptr(resForCU(4)),
+				LastPermit: ptr(resForCU(3)),
 				Target:     resForCU(2),
 				Metrics:    &metrics,
 			},

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -201,7 +201,6 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger, vmInfoUpdated util
 			PluginRetryWait:                    time.Second * time.Duration(r.global.config.Scheduler.RetryFailedRequestSeconds),
 			PluginDeniedRetryWait:              time.Second * time.Duration(r.global.config.Scheduler.RetryDeniedUpscaleSeconds),
 			MonitorDeniedDownscaleCooldown:     time.Second * time.Duration(r.global.config.Monitor.RetryDeniedDownscaleSeconds),
-			MonitorDownscaleFollowUpWait:       time.Second * time.Duration(r.global.config.Monitor.DeniedDownscaleFollowUpWaitSeconds),
 			MonitorRequestedUpscaleValidPeriod: time.Second * time.Duration(r.global.config.Monitor.RequestedUpscaleValidSeconds),
 			MonitorRetryWait:                   time.Second * time.Duration(r.global.config.Monitor.RetryFailedRequestSeconds),
 			Log: core.LogConfig{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -242,6 +242,23 @@ func (r Resources) Max(cmp Resources) Resources {
 	}
 }
 
+// Add returns the result of adding the two Resources
+func (r Resources) Add(other Resources) Resources {
+	return Resources{
+		VCPU: r.VCPU + other.VCPU,
+		Mem:  r.Mem + other.Mem,
+	}
+}
+
+// SaturatingSub returns the result of subtracting r - other, with values that *would* underflow
+// instead set to zero.
+func (r Resources) SaturatingSub(other Resources) Resources {
+	return Resources{
+		VCPU: util.SaturatingSub(r.VCPU, other.VCPU),
+		Mem:  util.SaturatingSub(r.Mem, other.Mem),
+	}
+}
+
 // Mul returns the result of multiplying each resource by factor
 func (r Resources) Mul(factor uint16) Resources {
 	return Resources{


### PR DESCRIPTION
Before, we would request the "full" downscaling or upscaling that we desired - for downscaling, we'd retry with a higher amount if the initial request was denied.

To reduce load, it's better to only request decreasing by 1 CU at a time. Also, bounding the size of changes from vm-monitor requests will also help with managing uncertainty (see #680).

Fixes #615, building towards #350.

~~**NB: This PR builds on #707 and must not be merged before it.**~~