### PR TITLE
lint: delete --fix from golangci-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           # Required: the version of golangci-lint is required and
           # should be specified with patch version.
           version: v1.55.2
-          args: --timeout 5m --fix
+          args: --timeout 5m
           github-token: ${{ secrets.github_token }}
           # caching issues, see: https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052190775
           skip-pkg-cache: true


### PR DESCRIPTION
--fix is not supposed to be used in CI.

It just silently fixes the issue and doesn't commit it.