### PR TITLE
lint: Fix import ordering in pkg/agent/watch.go

### DIFF
--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -8,10 +8,9 @@ import (
 	"slices"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/prometheus/client_golang/prometheus"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"


### PR DESCRIPTION
This shows up when I run golangci-lint locally. I guess it doesn't show up in CI because we're running '--fix' there?.

See also #718.

Edit: Didn't realize this was already included in #718, oops. Happy to merge either one.