### PR TITLE
Enable golangci-lint on neonvm/

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,9 +2,6 @@
 run:
   deadline: 5m
   issues-exit-code: 1
-  # TODO: fix all the issues for neonvm and enable linter for it
-  skip-dirs:
-    - neonvm
 
 issues:
   exclude:
@@ -53,20 +50,37 @@ linters-settings:
   # see: <https://golangci-lint.run/usage/linters/#exhaustruct>
   exhaustruct:
     exclude:
+      - '^crypto/tls\.Config$'
       - '^net/http\.(Client|Server)'
-      - '^net\.TCPAddr$'
-      # metav1.{CreateOptions,GetOptions,ListOptions,WatchOptions,PatchOptions,DeleteOptions}
-      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.(Create|Get|List|Watch|Patch|Delete)Options$'
-      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.ObjectMeta$'
+      - '^net\.(Dialer|TCPAddr)$'
+      - '^archive/tar\.Header$'
+      - '^k8s\.io/api/core/v1\.\w+$'
       - '^k8s\.io/apimachinery/pkg/api/resource\.Quantity$'
-      - '^github.com/prometheus/client_golang/prometheus(/.*)?\.\w+Opts$'
+      # metav1.{CreateOptions,GetOptions,ListOptions,WatchOptions,PatchOptions,UpdateOptions,DeleteOptions}
+      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.(Create|Get|List|Watch|Patch|Update|Delete)Options$'
+      - '^k8s\.io/apimachinery/pkg/apis/meta/v1\.(Condition|LabelSelector|ObjectMeta)$'
+      - '^k8s\.io/client-go/tools/leaderelection/resourcelock\.ResourceLockConfig$'
+      - '^k8s\.io/client-go/tools/leaderelection\.(LeaderCallbacks|LeaderElectionConfig)$'
+      - '^sigs\.k8s\.io/controller-runtime/pkg/client\.Options$'
+      - '^sigs\.k8s\.io/controller-runtime/pkg/controller\.Options$'
+      - '^sigs\.k8s\.io/controller-runtime/pkg/envtest\.(Environment|WebhookInstallOptions)$'
+      - '^sigs\.k8s\.io/controller-runtime/pkg/manager\.Options$'
+      - '^sigs\.k8s\.io/controller-runtime/pkg/reconcile\.Result$'
+      - '^sigs\.k8s\.io/controller-runtime/pkg/scheme\.Builder$'
       - '^github\.com/containerd/cgroups/v3/cgroup2\.(Resources|Memory)'
+      - '^github\.com/containerd/cgroups/v3/cgroup2\.CPU$'
+      - '^github\.com/docker/docker/api/types/container\.Config$'
+      - '^github\.com/docker/docker/api/types\.\w+Options$'
+      - '^github\.com/opencontainers/runtime-spec/specs-go\.\w+$' # Exempt the entire package. Too many big structs.
+      - '^github\.com/prometheus/client_golang/prometheus(/.*)?\.\w+Opts$'
       - '^github\.com/tychoish/fun/pubsub\.BrokerOptions$'
-      - '^github\.com/neondatabase/autoscaling/pkg/util/patch\.Operation$'
-      - '^github\.com/neondatabase/autoscaling/pkg/util/watch\.HandlerFuncs$'
+      - '^github\.com/vishvananda/netlink\.\w+$' # Exempt the entire package. Too many big structs.
       # vmapi.{VirtualMachine,VirtualMachineSpec,VirtualMachineMigration,VirtualMachineMigrationSpec}
       - '^github\.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1\.VirtualMachine(Migration)?(Spec)?$'
+      - '^github\.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1\.IPPool$'
       - '^github\.com/neondatabase/autoscaling/pkg/agent/core\.ActionSet$'
+      - '^github\.com/neondatabase/autoscaling/pkg/util/patch\.Operation$'
+      - '^github\.com/neondatabase/autoscaling/pkg/util/watch\.HandlerFuncs$'
 
   # see: <https://golangci-lint.run/usage/linters/#gci>
   gci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,8 +77,6 @@ linters-settings:
       - default
       # k8s.io can be a large group; we want that visually distinguished
       - Prefix(k8s.io)
-      # neonvm is *kind of* local, but not really. Don't lump it in with 'default'
-      - Prefix(github.com/neondatabase/autoscaling/neonvm)
       - Prefix(github.com/neondatabase/autoscaling)
 
   # see: <https://golangci-lint.run/usage/linters/#gocritic>, <https://go-critic.com/overview>

--- a/cmd/autoscaler-agent/main.go
+++ b/cmd/autoscaler-agent/main.go
@@ -15,7 +15,6 @@ import (
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	vmclient "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
-
 	"github.com/neondatabase/autoscaling/pkg/agent"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )

--- a/neonvm/apis/neonvm/v1/groupversion_info.go
+++ b/neonvm/apis/neonvm/v1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var (

--- a/neonvm/apis/neonvm/v1/ippool_types.go
+++ b/neonvm/apis/neonvm/v1/ippool_types.go
@@ -42,5 +42,5 @@ type IPPoolList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IPPool{}, &IPPoolList{})
+	SchemeBuilder.Register(&IPPool{}, &IPPoolList{}) //nolint:exhaustruct // just being used to provide the types
 }

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -307,7 +307,7 @@ const (
 )
 
 type Disk struct {
-	//Disk's name.
+	// Disk's name.
 	// Must be a DNS_LABEL and unique within the virtual machine.
 	Name string `json:"name"`
 	// Mounted read-only if true, read-write otherwise (false or unspecified).
@@ -466,5 +466,5 @@ type VirtualMachineList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&VirtualMachine{}, &VirtualMachineList{})
+	SchemeBuilder.Register(&VirtualMachine{}, &VirtualMachineList{}) //nolint:exhaustruct // just being used to provide the types
 }

--- a/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // log is for logging in this package.

--- a/neonvm/apis/neonvm/v1/virtualmachinemigration_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachinemigration_types.go
@@ -177,5 +177,5 @@ type VirtualMachineMigrationList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&VirtualMachineMigration{}, &VirtualMachineMigrationList{})
+	SchemeBuilder.Register(&VirtualMachineMigration{}, &VirtualMachineMigrationList{}) //nolint:exhaustruct // just being used to provide the types
 }

--- a/neonvm/apis/neonvm/v1/virtualmachinemigration_webhook.go
+++ b/neonvm/apis/neonvm/v1/virtualmachinemigration_webhook.go
@@ -17,14 +17,11 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-)
 
-// log is for logging in this package.
-var virtualmachinemigrationlog = logf.Log.WithName("virtualmachinemigration-resource")
+	"k8s.io/apimachinery/pkg/runtime"
+)
 
 func (r *VirtualMachineMigration) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).

--- a/neonvm/apis/neonvm/v1/webhook_suite_test.go
+++ b/neonvm/apis/neonvm/v1/webhook_suite_test.go
@@ -27,16 +27,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	//+kubebuilder:scaffold:imports
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	//+kubebuilder:scaffold:imports
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/neonvm/controllers/suite_test.go
+++ b/neonvm/controllers/suite_test.go
@@ -22,16 +22,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -29,6 +29,13 @@ import (
 	"strconv"
 	"time"
 
+	nadapiv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -38,17 +45,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	nadapiv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/neonvm/controllers/buildtag"
 	"github.com/neondatabase/autoscaling/neonvm/pkg/ipam"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util/patch"
 )
@@ -134,11 +134,7 @@ func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if controllerutil.ContainsFinalizer(&virtualmachine, virtualmachineFinalizer) {
 			// our finalizer is present, so lets handle any external dependency
 			log.Info("Performing Finalizer Operations for VirtualMachine before delete it")
-			if err := r.doFinalizerOperationsForVirtualMachine(ctx, &virtualmachine); err != nil {
-				// if fail to delete the external dependency here, return with error
-				// so that it can be retried
-				return ctrl.Result{}, err
-			}
+			r.doFinalizerOperationsForVirtualMachine(ctx, &virtualmachine)
 
 			// remove our finalizer from the list and update it.
 			log.Info("Removing Finalizer for VirtualMachine after successfully perform the operations")
@@ -193,8 +189,8 @@ func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{RequeueAfter: time.Second}, nil
 }
 
-// finalizeVirtualMachine will perform the required operations before delete the CR.
-func (r *VirtualMachineReconciler) doFinalizerOperationsForVirtualMachine(ctx context.Context, virtualmachine *vmv1.VirtualMachine) error {
+// doFinalizerOperationsForVirtualMachine will perform the required operations before delete the CR.
+func (r *VirtualMachineReconciler) doFinalizerOperationsForVirtualMachine(ctx context.Context, virtualmachine *vmv1.VirtualMachine) {
 	// TODO(user): Add the cleanup steps that the operator
 	// needs to do before the CR can be deleted. Examples
 	// of finalizers include performing backups and deleting
@@ -221,33 +217,31 @@ func (r *VirtualMachineReconciler) doFinalizerOperationsForVirtualMachine(ctx co
 		if err != nil {
 			// ignore error
 			log.Error(err, "ignored error")
-			return nil
+			return
 		}
 		nadNamespace, err := nadIpamNamespace()
 		if err != nil {
 			// ignore error
 			log.Error(err, "ignored error")
-			return nil
+			return
 		}
 		ipam, err := ipam.New(ctx, nadName, nadNamespace)
 		if err != nil {
 			// ignore error
 			log.Error(err, "ignored error")
-			return nil
+			return
 		}
 		defer ipam.Close()
 		ip, err := ipam.ReleaseIP(ctx, virtualmachine.Name, virtualmachine.Namespace)
 		if err != nil {
 			// ignore error
 			log.Error(err, "fail to release IP, error ignored")
-			return nil
+			return
 		}
 		message := fmt.Sprintf("Released IP %s", ip.String())
 		log.Info(message)
 		r.Recorder.Event(virtualmachine, "Normal", "OverlayNet", message)
 	}
-
-	return nil
 }
 
 func runnerSupportsCgroup(pod *corev1.Pod) bool {
@@ -268,7 +262,8 @@ func (r *VirtualMachineReconciler) updateVMStatusCPU(
 	ctx context.Context,
 	virtualmachine *vmv1.VirtualMachine,
 	vmRunner *corev1.Pod,
-	qmpPluggedCPUs uint32, supportsCgroup bool, cgroupUsage api.VCPUCgroup,
+	qmpPluggedCPUs uint32,
+	cgroupUsage *api.VCPUCgroup,
 ) {
 	log := log.FromContext(ctx)
 
@@ -277,7 +272,7 @@ func (r *VirtualMachineReconciler) updateVMStatusCPU(
 	// - vm.Status.CPUs.RoundUp() == qmpPluggedCPUs
 	// Otherwise, we update the status.
 	var currentCPUUsage vmv1.MilliCPU
-	if supportsCgroup {
+	if cgroupUsage != nil {
 		if cgroupUsage.VCPUs.RoundedUp() != qmpPluggedCPUs {
 			// This is not expected but it's fine. We only report the
 			// mismatch here and will resolve it in the next reconcile
@@ -469,7 +464,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 			pluggedCPU := uint32(len(cpuSlotsPlugged))
 
 			// get cgroups CPU details from runner pod
-			var cgroupUsage api.VCPUCgroup
+			var cgroupUsage *api.VCPUCgroup
 			supportsCgroup := runnerSupportsCgroup(vmRunner)
 			if supportsCgroup {
 				cgroupUsage, err = getRunnerCgroup(ctx, virtualmachine)
@@ -480,7 +475,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 			}
 
 			// update status by CPUs used in the VM
-			r.updateVMStatusCPU(ctx, virtualmachine, vmRunner, pluggedCPU, supportsCgroup, cgroupUsage)
+			r.updateVMStatusCPU(ctx, virtualmachine, vmRunner, pluggedCPU, cgroupUsage)
 
 			// get Memory details from hypervisor and update VM status
 			memorySize, err := QmpGetMemorySize(QmpAddr(virtualmachine))
@@ -613,7 +608,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		specCPU := virtualmachine.Spec.Guest.CPUs.Use
 		pluggedCPU := uint32(len(cpuSlotsPlugged))
 
-		var cgroupUsage api.VCPUCgroup
+		var cgroupUsage *api.VCPUCgroup
 		supportsCgroup := runnerSupportsCgroup(vmRunner)
 		if supportsCgroup {
 			cgroupUsage, err = getRunnerCgroup(ctx, virtualmachine)
@@ -715,7 +710,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		// set VM phase to running if everything scaled
 		if cpuScaled && ramScaled {
 			// update status by CPUs used in the VM
-			r.updateVMStatusCPU(ctx, virtualmachine, vmRunner, pluggedCPU, supportsCgroup, cgroupUsage)
+			r.updateVMStatusCPU(ctx, virtualmachine, vmRunner, pluggedCPU, cgroupUsage)
 
 			// get Memory details from hypervisor and update VM status
 			memorySize, err := QmpGetMemorySize(QmpAddr(virtualmachine))
@@ -738,7 +733,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 			err := r.Get(ctx, types.NamespacedName{Name: virtualmachine.Status.PodName, Namespace: virtualmachine.Namespace}, vmRunner)
 			if err == nil {
 				// delete current runner
-				if err = r.deleteRunnerPodIfEnabled(ctx, virtualmachine, vmRunner); err != nil {
+				if err := r.deleteRunnerPodIfEnabled(ctx, virtualmachine, vmRunner); err != nil {
 					return err
 				}
 			} else if !apierrors.IsNotFound(err) {
@@ -760,7 +755,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 			// delete runner only when VM failed
 			if found && virtualmachine.Status.Phase == vmv1.VmFailed {
 				// delete current runner
-				if err = r.deleteRunnerPodIfEnabled(ctx, virtualmachine, vmRunner); err != nil {
+				if err := r.deleteRunnerPodIfEnabled(ctx, virtualmachine, vmRunner); err != nil {
 					return err
 				}
 			}
@@ -1048,6 +1043,7 @@ func setRunnerCgroup(ctx context.Context, vm *vmv1.VirtualMachine, cpu vmv1.Mill
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		return fmt.Errorf("unexpected status %s", resp.Status)
@@ -1055,39 +1051,39 @@ func setRunnerCgroup(ctx context.Context, vm *vmv1.VirtualMachine, cpu vmv1.Mill
 	return nil
 }
 
-func getRunnerCgroup(ctx context.Context, vm *vmv1.VirtualMachine) (api.VCPUCgroup, error) {
+func getRunnerCgroup(ctx context.Context, vm *vmv1.VirtualMachine) (*api.VCPUCgroup, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	result := api.VCPUCgroup{}
 
 	url := fmt.Sprintf("http://%s:%d/cpu_current", vm.Status.PodIP, vm.Spec.RunnerPort)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 
 	if resp.StatusCode != 200 {
-		return result, fmt.Errorf("unexpected status %s", resp.Status)
+		return nil, fmt.Errorf("unexpected status %s", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 
+	var result api.VCPUCgroup
 	err = json.Unmarshal(body, &result)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 
-	return result, nil
+	return &result, nil
 }
 
 // imageForVirtualMachine gets the Operand image which is managed by this controller
@@ -1114,12 +1110,12 @@ func podSpec(virtualmachine *vmv1.VirtualMachine) (*corev1.Pod, error) {
 
 	vmSpecJson, err := json.Marshal(virtualmachine.Spec)
 	if err != nil {
-		return nil, fmt.Errorf("marshal VM Spec: %s", err)
+		return nil, fmt.Errorf("marshal VM Spec: %w", err)
 	}
 
 	vmStatusJson, err := json.Marshal(virtualmachine.Status)
 	if err != nil {
-		return nil, fmt.Errorf("marshal VM Status: %s", err)
+		return nil, fmt.Errorf("marshal VM Status: %w", err)
 	}
 
 	pod := &corev1.Pod{

--- a/neonvm/controllers/virtualmachine_controller_test.go
+++ b/neonvm/controllers/virtualmachine_controller_test.go
@@ -18,18 +18,17 @@ package controllers
 
 import (
 	"context"
-	// "fmt"
-	// "errors"
 	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 )
@@ -97,8 +96,9 @@ var _ = Describe("VirtualMachine controller", func() {
 
 			By("Reconciling the custom resource created")
 			virtualmachineReconciler := &VirtualMachineReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: nil,
 			}
 
 			_, err = virtualmachineReconciler.Reconcile(ctx, reconcile.Request{

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -23,6 +23,12 @@ import (
 	"math"
 	"time"
 
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -31,11 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/neonvm/controllers/buildtag"

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -25,25 +25,24 @@ import (
 	"syscall"
 	"time"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
+	"github.com/tychoish/fun/srv"
 	"go.uber.org/zap/zapcore"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/klog/v2"
+
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/neonvm/controllers"
 	"github.com/neondatabase/autoscaling/pkg/util"
-	"github.com/tychoish/fun/srv"
-	//+kubebuilder:scaffold:imports
 )
 
 var (
@@ -94,7 +93,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	opts := zap.Options{
+	opts := zap.Options{ //nolint:exhaustruct // typical options struct; not all fields needed.
 		Development:     true,
 		StacktraceLevel: zapcore.Level(zapcore.PanicLevel),
 		TimeEncoder:     zapcore.ISO8601TimeEncoder,

--- a/neonvm/pkg/ipam-demo.go
+++ b/neonvm/pkg/ipam-demo.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	"go.uber.org/zap/zapcore"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"k8s.io/klog/v2"
 
 	"github.com/neondatabase/autoscaling/neonvm/pkg/ipam"
 )
@@ -27,7 +28,7 @@ var (
 
 func main() {
 
-	opts := zap.Options{
+	opts := zap.Options{ //nolint:exhaustruct // typical options struct; not all fields expected to be filled.
 		Development:     true,
 		StacktraceLevel: zapcore.Level(zapcore.PanicLevel),
 		TimeEncoder:     zapcore.ISO8601TimeEncoder,
@@ -65,7 +66,7 @@ func main() {
 			if ip, err := ipam.AcquireIP(ctx, id, demoNamespace); err != nil {
 				logger.Error(err, "lease failed", "id", id)
 			} else {
-				logger.Info("acquired", "id", id, "ip", ip.String(), "acquired in", time.Now().Sub(startTime))
+				logger.Info("acquired", "id", id, "ip", ip.String(), "acquired in", time.Since(startTime))
 			}
 		}(i)
 		time.Sleep(time.Millisecond * 200)
@@ -83,7 +84,7 @@ func main() {
 			if ip, err := ipam.ReleaseIP(ctx, id, demoNamespace); err != nil {
 				logger.Error(err, "release failed", "id", id)
 			} else {
-				logger.Info("released", "id", id, "ip", ip.String(), "released in", time.Now().Sub(startTime))
+				logger.Info("released", "id", id, "ip", ip.String(), "released in", time.Since(startTime))
 			}
 		}(i)
 		time.Sleep(time.Millisecond * 200)

--- a/neonvm/pkg/ipam/allocate.go
+++ b/neonvm/pkg/ipam/allocate.go
@@ -10,10 +10,13 @@ import (
 	whereaboutstypes "github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 )
 
-func doAcquire(ctx context.Context,
+func doAcquire(
+	_ context.Context,
 	ipRange RangeConfiguration,
 	reservation []whereaboutstypes.IPReservation,
-	vmName string, vmNamespace string) (net.IPNet, []whereaboutstypes.IPReservation, error) {
+	vmName string,
+	vmNamespace string,
+) (net.IPNet, []whereaboutstypes.IPReservation, error) {
 
 	// reduce whereabouts logging
 	whereaboutslogging.SetLogLevel("error")
@@ -38,9 +41,13 @@ func doAcquire(ctx context.Context,
 	return net.IPNet{IP: ip, Mask: ipnet.Mask}, newReservation, nil
 }
 
-func doRelease(ctx context.Context,
-	ipRange RangeConfiguration, reservation []whereaboutstypes.IPReservation,
-	vmName string, vmNamespace string) (net.IPNet, []whereaboutstypes.IPReservation, error) {
+func doRelease(
+	_ context.Context,
+	ipRange RangeConfiguration,
+	reservation []whereaboutstypes.IPReservation,
+	vmName string,
+	vmNamespace string,
+) (net.IPNet, []whereaboutstypes.IPReservation, error) {
 
 	// reduce whereabouts logging
 	whereaboutslogging.SetLogLevel("error")

--- a/neonvm/pkg/ipam/client.go
+++ b/neonvm/pkg/ipam/client.go
@@ -1,10 +1,11 @@
 package ipam
 
 import (
+	nad "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	nad "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	neonvm "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
 )
 

--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -1,26 +1,25 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"io"
-	"net/http"
-	"strconv"
-
-	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"flag"
 	"fmt"
+	"io"
 	"math"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -37,6 +36,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/vishvananda/netlink"
 	"go.uber.org/zap"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
@@ -199,7 +199,7 @@ func createISO9660runtime(diskPath string, command, args, sysctl []string, env [
 	if err != nil {
 		return err
 	}
-	defer writer.Cleanup()
+	defer writer.Cleanup() //nolint:errcheck // Nothing to do with the error, maybe log it ? TODO
 
 	if len(sysctl) != 0 {
 		err = writer.AddFile(bytes.NewReader([]byte(strings.Join(sysctl, "\n"))), "sysctl.conf")
@@ -372,7 +372,7 @@ func createISO9660FromPath(logger *zap.Logger, diskName string, diskPath string,
 	if err != nil {
 		return err
 	}
-	defer writer.Cleanup()
+	defer writer.Cleanup() //nolint:errcheck // Nothing to do with the error, maybe log it ? TODO
 
 	dir, err := os.Open(contentPath)
 	if err != nil {
@@ -407,14 +407,18 @@ func createISO9660FromPath(logger *zap.Logger, diskName string, diskPath string,
 			continue
 		}
 
-		logger.Info("adding file to ISO9660 disk", zap.String("path", outputPath))
-		fileToAdd, err := os.Open(fileName)
-		if err != nil {
-			return err
-		}
-		defer fileToAdd.Close()
+		// run the file handling logic in a closure, so the defers happen within the loop body,
+		// rather than the outer function.
+		err = func() error {
+			logger.Info("adding file to ISO9660 disk", zap.String("path", outputPath))
+			fileToAdd, err := os.Open(fileName)
+			if err != nil {
+				return err
+			}
+			defer fileToAdd.Close()
 
-		err = writer.AddFile(fileToAdd, outputPath)
+			return writer.AddFile(fileToAdd, outputPath)
+		}()
 		if err != nil {
 			return err
 		}
@@ -494,8 +498,8 @@ func main() {
 	if err := json.Unmarshal(vmSpecJson, vmSpec); err != nil {
 		logger.Fatal("Failed to unmarshal VM spec", zap.Error(err))
 	}
-	vmStatus := &vmv1.VirtualMachineStatus{}
-	if err := json.Unmarshal(vmStatusJson, vmStatus); err != nil {
+	var vmStatus vmv1.VirtualMachineStatus
+	if err := json.Unmarshal(vmStatusJson, &vmStatus); err != nil {
 		logger.Fatal("Failed to unmarshal VM Status", zap.Error(err))
 	}
 
@@ -532,8 +536,10 @@ func main() {
 	if err != nil {
 		logger.Fatal("could not get root image size", zap.Error(err))
 	}
-	imageSize := QemuImgOutputPartial{}
-	json.Unmarshal(qemuImgOut, &imageSize)
+	var imageSize QemuImgOutputPartial
+	if err := json.Unmarshal(qemuImgOut, &imageSize); err != nil {
+		logger.Fatal("Failed to unmarhsal QEMU image size", zap.Error(err))
+	}
 	imageSizeQuantity := resource.NewQuantity(imageSize.VirtualSize, resource.BinarySI)
 
 	// going to resize
@@ -698,9 +704,8 @@ func handleCPUChange(logger *zap.Logger, w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	parsed := api.VCPUChange{}
-	err = json.Unmarshal(body, &parsed)
-	if err != nil {
+	var parsed api.VCPUChange
+	if err = json.Unmarshal(body, &parsed); err != nil {
 		logger.Error("could not parse body", zap.Error(err))
 		w.WriteHeader(400)
 		return
@@ -740,7 +745,7 @@ func handleCPUCurrent(logger *zap.Logger, w http.ResponseWriter, r *http.Request
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	w.Write(body)
+	w.Write(body) //nolint:errcheck // Not much to do with the error here. TODO: log it?
 }
 
 func listenForCPUChanges(ctx context.Context, logger *zap.Logger, port int32, cgroupPath string, wg *sync.WaitGroup) {
@@ -944,7 +949,7 @@ func getCgroupQuota(cgroupPath string) (*vmv1.MilliCPU, error) {
 
 	arr := strings.Split(strings.Trim(string(data), "\n"), " ")
 	if len(arr) == 0 {
-		return nil, fmt.Errorf("unexpected cgroup data")
+		return nil, errors.New("unexpected cgroup data")
 	}
 	quota, err := strconv.ParseUint(arr[0], 10, 64)
 	if err != nil {
@@ -1004,7 +1009,7 @@ func terminateQemuOnSigterm(ctx context.Context, logger *zap.Logger, wg *sync.Wa
 		logger.Error("failed to start monitor connection", zap.Error(err))
 		return
 	}
-	defer mon.Disconnect()
+	defer mon.Disconnect() //nolint:errcheck // nothing to do with error when deferred. TODO: log it?
 
 	qmpcmd := []byte(`{"execute": "system_powerdown"}`)
 	_, err = mon.Run(qmpcmd)
@@ -1014,8 +1019,6 @@ func terminateQemuOnSigterm(ctx context.Context, logger *zap.Logger, wg *sync.Wa
 	}
 
 	logger.Info("system_powerdown command sent to QEMU")
-
-	return
 }
 
 func calcIPs(cidr string) (net.IP, net.IP, net.IPMask, error) {
@@ -1138,7 +1141,7 @@ func defaultNetwork(logger *zap.Logger, cidr string, ports []vmv1.Port) (mac.MAC
 	}
 
 	// pass incoming traffic to .Guest.Spec.Ports into VM
-	iptablesArgs := []string{}
+	var iptablesArgs []string
 	for _, port := range ports {
 		logger.Info(fmt.Sprintf("setup DNAT rule for incoming traffic to port %d", port.Port))
 		iptablesArgs = []string{
@@ -1147,7 +1150,7 @@ func defaultNetwork(logger *zap.Logger, cidr string, ports []vmv1.Port) (mac.MAC
 			"-j", "DNAT", "--to", fmt.Sprintf("%s:%d", ipVm.String(), port.Port),
 		}
 		if err := execFg("iptables", iptablesArgs...); err != nil {
-			logger.Error("could not set up DNAT rule  for incoming traffic", zap.Error(err))
+			logger.Error("could not set up DNAT rule for incoming traffic", zap.Error(err))
 			return nil, err
 		}
 		logger.Info(fmt.Sprintf("setup DNAT rule for traffic originating from localhost to port %d", port.Port))
@@ -1173,7 +1176,7 @@ func defaultNetwork(logger *zap.Logger, cidr string, ports []vmv1.Port) (mac.MAC
 			return nil, err
 		}
 	}
-	logger.Info(fmt.Sprintf("setup MASQUERADE rule for traffic originating from localhost"))
+	logger.Info("setup MASQUERADE rule for traffic originating from localhost")
 	iptablesArgs = []string{
 		"-t", "nat", "-A", "POSTROUTING",
 		"-m", "addrtype", "--src-type", "LOCAL", "--dst-type", "UNICAST",

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -56,11 +56,6 @@ var (
 	version   = flag.Bool("version", false, `Print vm-builder version`)
 )
 
-type dockerMessage struct {
-	Stream string `json:"stream"`
-	Error  string `json:"error"`
-}
-
 func AddTemplatedFileToTar(tw *tar.Writer, tmplArgs any, filename string, tmplString string) error {
 	tmpl, err := template.New(filename).Parse(tmplString)
 	if err != nil {
@@ -155,7 +150,7 @@ func main() {
 	if !*forcePull {
 		hostImages, err := cli.ImageList(ctx, types.ImageListOptions{})
 		if err != nil {
-			log.Fatalln(err)
+			log.Fatalln(err) //nolint:gocritic // linter complains that Fatalln circumvents deferred cli.Close(). Too much work to fix in #721, leaving for later.
 		}
 
 		for _, img := range hostImages {
@@ -173,15 +168,22 @@ func main() {
 
 	if !hostContainsSrcImage {
 		// pull source image
-		log.Printf("Pull source docker image: %s", *srcImage)
-		pull, err := cli.ImagePull(ctx, *srcImage, types.ImagePullOptions{})
+		// use a closure so deferred close is closer
+		err := func() error {
+			log.Printf("Pull source docker image: %s", *srcImage)
+			pull, err := cli.ImagePull(ctx, *srcImage, types.ImagePullOptions{})
+			if err != nil {
+				return err
+			}
+			defer pull.Close()
+			// do quiet pull - discard output
+			_, err = io.Copy(io.Discard, pull)
+			return err
+		}()
 		if err != nil {
 			log.Fatalln(err)
 		}
-		defer pull.Close()
 
-		// do quiet pull - discard output
-		io.Copy(io.Discard, pull)
 	}
 
 	log.Printf("Build docker image for virtual machine (disk size %s): %s\n", *size, dstIm)
@@ -200,16 +202,20 @@ func main() {
 	}
 
 	tmplArgs := TemplatesContext{
+		User:          "root", // overridden below, if imageSpec.Config.User != ""
 		Entrypoint:    imageSpec.Config.Entrypoint,
 		Cmd:           imageSpec.Config.Cmd,
 		Env:           imageSpec.Config.Env,
 		RootDiskImage: *srcImage,
+
+		SpecBuild:       "",  // overridden below if spec != nil
+		SpecMerge:       "",  // overridden below if spec != nil
+		InittabCommands: nil, // overridden below if spec != nil
+		ShutdownHook:    "",  // overridden below if spec != nil
 	}
 
 	if len(imageSpec.Config.User) != 0 {
 		tmplArgs.User = imageSpec.Config.User
-	} else {
-		tmplArgs.User = "root"
 	}
 
 	tarBuffer := new(bytes.Buffer)
@@ -326,7 +332,7 @@ func main() {
 		tarReader := tar.NewReader(fromContainer)
 		for {
 			header, err := tarReader.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			} else if err != nil {
 				log.Fatalln(err)
@@ -336,15 +342,19 @@ func main() {
 				log.Printf("skip file %s", header.Name)
 				continue
 			}
-			path := filepath.Join(*outFile)
+			path := filepath.Join(*outFile) //nolint:gocritic // FIXME: this is probably incorrect, intended to join with header.Name ?
 			info := header.FileInfo()
 
-			file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
-			if err != nil {
-				log.Fatalln(err)
-			}
-			defer file.Close()
-			_, err = io.Copy(file, tarReader)
+			// Open and write to the file inside a closure, so we can defer close
+			err = func() error {
+				file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+				if err != nil {
+					return err
+				}
+				defer file.Close()
+				_, err = io.Copy(file, tarReader)
+				return err
+			}()
 			if err != nil {
 				log.Fatalln(err)
 			}

--- a/neonvm/tools/vxlan/controller/main.go
+++ b/neonvm/tools/vxlan/controller/main.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	delete = flag.Bool("delete", false, `delete VXLAN interfaces`)
+	deleteIfaces = flag.Bool("delete", false, `delete VXLAN interfaces`)
 )
 
 func main() {
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// -delete option used for teardown vxlan setup
-	if *delete {
+	if *deleteIfaces {
 		log.Printf("deleting vxlan interface %s", VXLAN_IF_NAME)
 		if err := deleteLink(VXLAN_IF_NAME); err != nil {
 			log.Print(err)
@@ -125,7 +125,7 @@ func createBrigeInterface(name string) error {
 		log.Printf("link with name %s already found", name)
 		return nil
 	}
-	_, notFound := err.(netlink.LinkNotFoundError)
+	_, notFound := err.(netlink.LinkNotFoundError) //nolint:errorlint // errors.Is doesn't work, we actually just want to know the type.
 	if !notFound {
 		return err
 	}
@@ -154,7 +154,7 @@ func createVxlanInterface(name string, vxlanID int, ownIP string, bridgeName str
 		log.Printf("link with name %s already found", name)
 		return nil
 	}
-	_, notFound := err.(netlink.LinkNotFoundError)
+	_, notFound := err.(netlink.LinkNotFoundError) //nolint:errorlint // errors.Is doesn't work, we actually just want to know the type.
 	if !notFound {
 		return err
 	}
@@ -231,7 +231,7 @@ func deleteLink(name string) error {
 		log.Printf("link with name %s was deleted", name)
 		return nil
 	}
-	_, notFound := err.(netlink.LinkNotFoundError)
+	_, notFound := err.(netlink.LinkNotFoundError) //nolint:errorlint // errors.Is doesn't work, we actually just want to know the type.
 	if !notFound {
 		return err
 	}

--- a/pkg/agent/billing/billing.go
+++ b/pkg/agent/billing/billing.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/billing"
 	"github.com/neondatabase/autoscaling/pkg/util"

--- a/pkg/agent/billing/indexedstore.go
+++ b/pkg/agent/billing/indexedstore.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/util/watch"
 )
 

--- a/pkg/agent/core/state.go
+++ b/pkg/agent/core/state.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/zap"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )

--- a/pkg/agent/core/testhelpers/construct.go
+++ b/pkg/agent/core/testhelpers/construct.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/agent/core"
 	"github.com/neondatabase/autoscaling/pkg/api"
 )

--- a/pkg/agent/entrypoint.go
+++ b/pkg/agent/entrypoint.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	vmclient "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
-
 	"github.com/neondatabase/autoscaling/pkg/agent/billing"
 	"github.com/neondatabase/autoscaling/pkg/agent/schedwatch"
 	"github.com/neondatabase/autoscaling/pkg/util"

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -16,7 +16,6 @@ import (
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	vmclient "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
-
 	"github.com/neondatabase/autoscaling/pkg/agent/schedwatch"
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -18,7 +18,6 @@ import (
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	vmclient "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 	"github.com/neondatabase/autoscaling/pkg/util/watch"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 

--- a/pkg/api/vminfo_test.go
+++ b/pkg/api/vminfo_test.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 )
 

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 )
 

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -18,7 +18,6 @@ import (
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	vmclient "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 	"github.com/neondatabase/autoscaling/pkg/util/watch"

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -19,7 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 	"github.com/neondatabase/autoscaling/pkg/util/watch"

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
-
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 	"github.com/neondatabase/autoscaling/pkg/util/watch"


### PR DESCRIPTION
Supersedes #400. With the recent PRs making changes to neonvm, it seemed like enabling golangci-lint would be more valuable. And with the amount of work required, I figured it'd be easier for someone more involved to tackle.

~~This PR builds on #720, but #718 could be used instead.~~

---

Notes for review:

Happy to clarify any weird bits. There's a lot here.

There were a few function signatures changed - either because they were returning a `(struct, error)` tuple (which trips exhaustruct - ends up beings simpler to return `(*struct, error)`), or because they had an unused parameter (or, newly unused, after switching some of the functions in `virtualmachine_controller.go` to use `*api.VCPUCgroup`).

Because of the size of #704, it may be worthwhile to get this merged before it. However, it's probably easier to resolve merge conflicts if that merges first. cc @omrigan for your thoughts.