### PR TITLE
Remove old kernel path `neonvm/hack/vmlinuz`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ testbin/*
 *~
 
 *.qcow2
-neonvm/hack/vmlinuz
 neonvm/hack/kernel/vmlinuz
 
 rendered_manifests

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ endif
 
 .PHONY: kernel
 kernel: ## Build linux kernel.
-	rm -f neonvm/hack/vmlinuz neonvm/hack/kernel/vmlinuz; \
+	rm -f neonvm/hack/kernel/vmlinuz; \
 	linux_config=$$(ls neonvm/hack/kernel/linux-config-*) \
 	kernel_version=$${linux_config##*-} \
 	iidfile=$$(mktemp /tmp/iid-XXXXXX); \


### PR DESCRIPTION
**Merge after 15th of February**

https://github.com/neondatabase/autoscaling/pull/715 has moved `vmlinuz` directory from `neonvm/hack` to `neonvm/hack/kernel`. This PR deletes the old path from the code. 

Let's give people some time and merge it in a month or so.

Ref https://github.com/neondatabase/autoscaling/pull/715#discussion_r1446239895