### PR TITLE
util/watch: Add relist rate limiting

### DIFF
--- a/pkg/agent/schedwatch/watch.go
+++ b/pkg/agent/schedwatch/watch.go
@@ -76,6 +76,7 @@ func StartSchedulerWatcher(
 			// FIXME: make these configurable.
 			RetryRelistAfter: util.NewTimeRange(time.Second, 4, 5),
 			RetryWatchAfter:  util.NewTimeRange(time.Second, 4, 5),
+			RelistRateLimit:  nil,
 		},
 		watch.Accessors[*corev1.PodList, corev1.Pod]{
 			Items: func(list *corev1.PodList) []corev1.Pod { return list.Items },

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -83,6 +83,7 @@ func startVMWatcher(
 			// We want to be relatively snappy; don't wait for too long before retrying.
 			RetryRelistAfter: util.NewTimeRange(time.Millisecond, 500, 1000),
 			RetryWatchAfter:  util.NewTimeRange(time.Millisecond, 500, 1000),
+			RelistRateLimit:  nil,
 		},
 		watch.Accessors[*vmapi.VirtualMachineList, vmapi.VirtualMachine]{
 			Items: func(list *vmapi.VirtualMachineList) []vmapi.VirtualMachine { return list.Items },

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -46,6 +46,7 @@ func (e *AutoscaleEnforcer) watchNodeEvents(
 			// FIXME: make these configurable.
 			RetryRelistAfter: util.NewTimeRange(time.Second, 3, 5),
 			RetryWatchAfter:  util.NewTimeRange(time.Second, 3, 5),
+			RelistRateLimit:  nil,
 		},
 		watch.Accessors[*corev1.NodeList, corev1.Node]{
 			Items: func(list *corev1.NodeList) []corev1.Node { return list.Items },
@@ -99,6 +100,7 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 			// FIXME: make these configurable.
 			RetryRelistAfter: util.NewTimeRange(time.Millisecond, 250, 750),
 			RetryWatchAfter:  util.NewTimeRange(time.Millisecond, 250, 750),
+			RelistRateLimit:  nil,
 		},
 		watch.Accessors[*corev1.PodList, corev1.Pod]{
 			Items: func(list *corev1.PodList) []corev1.Pod { return list.Items },
@@ -251,6 +253,7 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 			// FIXME: make these durations configurable.
 			RetryRelistAfter: util.NewTimeRange(time.Millisecond, 250, 750),
 			RetryWatchAfter:  util.NewTimeRange(time.Millisecond, 250, 750),
+			RelistRateLimit:  util.NewTimeRange(time.Second, 1, 2),
 		},
 		watch.Accessors[*vmapi.VirtualMachineList, vmapi.VirtualMachine]{
 			Items: func(list *vmapi.VirtualMachineList) []vmapi.VirtualMachine { return list.Items },
@@ -370,6 +373,7 @@ func (e *AutoscaleEnforcer) watchMigrationEvents(
 			// FIXME: make these durations configurable.
 			RetryRelistAfter: util.NewTimeRange(time.Second, 3, 5),
 			RetryWatchAfter:  util.NewTimeRange(time.Second, 3, 5),
+			RelistRateLimit:  nil,
 		},
 		watch.Accessors[*vmapi.VirtualMachineMigrationList, vmapi.VirtualMachineMigration]{
 			Items: func(list *vmapi.VirtualMachineMigrationList) []vmapi.VirtualMachineMigration { return list.Items },


### PR DESCRIPTION
This will be required for the autoscaler-agent as we try to use the VM spec as a source of truth (ref #350); we need relist rate limiting because we need relists in order to make a consistent read of the source of truth.

(For the scheduler, we're mostly fine without this - in practice, rate of relists is quite low.)

Like #727, marked as draft until there's a PR that actually uses it.

Also haven't tested this; need to do so before merging — some kind of ad-hoc testing like what was used for #667 should suffice.