### PR TITLE
neonvm: Use crictl to change container CPU, ditch cgroup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test: fmt vet envtest ## Run tests.
 build: fmt vet bin/vm-builder ## Build all neonvm binaries.
 	go build -o bin/controller       neonvm/main.go
 	go build -o bin/vxlan-controller neonvm/tools/vxlan/controller/main.go
-	go build -o bin/runner           neonvm/runner/main.go
+	go build -o bin/runner           neonvm/runner/*.go
 
 .PHONY: bin/vm-builder
 bin/vm-builder: ## Build vm-builder binary.

--- a/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
@@ -116,6 +116,7 @@ func (r *VirtualMachine) ValidateCreate() error {
 		"rootdisk",
 		"runtime",
 		"sysfscgroup",
+		"containerdsock",
 		"ssh-privatekey",
 		"ssh-publickey",
 		"ssh-authorized-keys",

--- a/neonvm/config/common/rbac/role.yaml
+++ b/neonvm/config/common/rbac/role.yaml
@@ -15,6 +15,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create

--- a/neonvm/controllers/config.go
+++ b/neonvm/controllers/config.go
@@ -1,0 +1,27 @@
+package controllers
+
+// ReconcilerConfig stores shared configuration for VirtualMachineReconciler and
+// VirtualMachineMigrationReconciler.
+type ReconcilerConfig struct {
+	// IsK3s is true iff the cluster is running k3s nodes.
+	//
+	// This is required because - unlike the other most common kubernetes distributions - k3s
+	// changes the location of the containerd socket.
+	// There unfortunately does not appear to be a way to disable this behavior.
+	IsK3s bool
+
+	// UseContainerMgr, if true, enables using container-mgr for new VM runner pods.
+	//
+	// This is defined as a config option so we can do a gradual rollout of this change.
+	UseContainerMgr bool
+
+	MaxConcurrentReconciles int
+}
+
+func (c *ReconcilerConfig) criEndpointSocketPath() string {
+	if c.IsK3s {
+		return "/run/k3s/containerd/containerd.sock"
+	} else {
+		return "/run/containerd/containerd.sock"
+	}
+}

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -47,6 +47,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/tools/record"
 
@@ -74,10 +75,9 @@ type VirtualMachineReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+	Config   *ReconcilerConfig
 
 	Metrics ReconcilerMetrics `exhaustruct:"optional"`
-
-	MaxConcurrentReconciles int
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
@@ -88,6 +88,7 @@ type VirtualMachineReconciler struct {
 //+kubebuilder:rbac:groups=vm.neon.tech,resources=virtualmachines/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=vm.neon.tech,resources=virtualmachines/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+//+kubebuilder:rbac:groups=core,resources=nodes,verbs=list
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods/status,verbs=get;list;watch
@@ -686,7 +687,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 				fmt.Sprintf("One CPU was unplugged from VM %s",
 					virtualmachine.Name))
 		} else if supportsCgroup && *specCPU != cgroupUsage.VCPUs {
-			log.Info("Update runner pod cgroups")
+			log.Info("Update runner pod cgroups", "runner", cgroupUsage.VCPUs, "spec", *specCPU)
 			if err := setRunnerCgroup(ctx, virtualmachine, *specCPU); err != nil {
 				return err
 			}
@@ -1061,7 +1062,7 @@ func (r *VirtualMachineReconciler) podForVirtualMachine(
 	virtualmachine *vmv1.VirtualMachine,
 	sshSecret *corev1.Secret,
 ) (*corev1.Pod, error) {
-	pod, err := podSpec(virtualmachine, sshSecret)
+	pod, err := podSpec(virtualmachine, sshSecret, r.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -1257,7 +1258,7 @@ func imageForVmRunner() (string, error) {
 	return image, nil
 }
 
-func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret) (*corev1.Pod, error) {
+func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret, config *ReconcilerConfig) (*corev1.Pod, error) {
 	runnerVersion := api.RunnerProtoV1
 	labels := labelsForVirtualMachine(virtualmachine, &runnerVersion)
 	annotations := annotationsForVirtualMachine(virtualmachine)
@@ -1322,8 +1323,9 @@ func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret) (*co
 					},
 				},
 			},
-			Containers: []corev1.Container{
-				{
+			// generate containers as an inline function so the context isn't isolated
+			Containers: func() []corev1.Container {
+				runner := corev1.Container{
 					Image:           image,
 					Name:            "neonvm-runner",
 					ImagePullPolicy: corev1.PullIfNotPresent,
@@ -1346,11 +1348,20 @@ func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret) (*co
 						ContainerPort: virtualmachine.Spec.QMPManual,
 						Name:          "qmp-manual",
 					}},
-					Command: []string{
-						"runner",
-						"-vmspec", base64.StdEncoding.EncodeToString(vmSpecJson),
-						"-vmstatus", base64.StdEncoding.EncodeToString(vmStatusJson),
-					},
+					Command: func() []string {
+						cmd := []string{"runner"}
+						// intentionally add this first, so it's easier to see among the very long
+						// args that follow.
+						if config.UseContainerMgr {
+							cmd = append(cmd, "-skip-cgroup-management")
+						}
+						cmd = append(
+							cmd,
+							"-vmspec", base64.StdEncoding.EncodeToString(vmSpecJson),
+							"-vmstatus", base64.StdEncoding.EncodeToString(vmStatusJson),
+						)
+						return cmd
+					}(),
 					Env: []corev1.EnvVar{{
 						Name: "K8S_POD_NAME",
 						ValueFrom: &corev1.EnvVarSource{
@@ -1359,12 +1370,12 @@ func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret) (*co
 							},
 						},
 					}},
-					VolumeMounts: []corev1.VolumeMount{
-						{
+					VolumeMounts: func() []corev1.VolumeMount {
+						images := corev1.VolumeMount{
 							Name:      "virtualmachineimages",
 							MountPath: "/vm/images",
-						},
-						{
+						}
+						cgroups := corev1.VolumeMount{
 							Name:      "sysfscgroup",
 							MountPath: "/sys/fs/cgroup",
 							// MountPropagationNone means that the volume in a container will
@@ -1373,19 +1384,83 @@ func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret) (*co
 							// containers.
 							// Note that this mode corresponds to "private" in Linux terminology.
 							MountPropagation: &[]corev1.MountPropagationMode{corev1.MountPropagationNone}[0],
+						}
+
+						if config.UseContainerMgr {
+							return []corev1.VolumeMount{images}
+						} else {
+							// the /sys/fs/cgroup mount is only necessary if neonvm-runner has to
+							// do is own cpu limiting
+							return []corev1.VolumeMount{images, cgroups}
+						}
+					}(),
+					Resources: virtualmachine.Spec.PodResources,
+				}
+				containerMgr := corev1.Container{
+					Image: image,
+					Name:  "neonvm-container-mgr",
+					Command: []string{
+						"container-mgr",
+						"-port", strconv.Itoa(int(virtualmachine.Spec.RunnerPort)),
+						"-init-milli-cpu", strconv.Itoa(int(*virtualmachine.Spec.Guest.CPUs.Use)),
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name: "K8S_POD_UID",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.uid",
+								},
+							},
+						},
+						{
+							Name:  "CRI_ENDPOINT",
+							Value: fmt.Sprintf("unix://%s", config.criEndpointSocketPath()),
 						},
 					},
-					Resources: virtualmachine.Spec.PodResources,
-				},
-			},
-			Volumes: []corev1.Volume{
-				{
+					LivenessProbe: &corev1.Probe{
+						InitialDelaySeconds: 10,
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/healthz",
+								Port: intstr.FromInt(int(virtualmachine.Spec.RunnerPort)),
+							},
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("50m"),
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"), // cpu limit > request, because usage is spiky
+							corev1.ResourceMemory: resource.MustParse("50Mi"),
+						},
+					},
+					// socket for crictl to connect to
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "containerdsock",
+							MountPath: config.criEndpointSocketPath(),
+						},
+					},
+				}
+
+				if config.UseContainerMgr {
+					return []corev1.Container{runner, containerMgr}
+				} else {
+					// Return only the runner if we aren't supposed to use container-mgr
+					return []corev1.Container{runner}
+				}
+			}(),
+			Volumes: func() []corev1.Volume {
+				images := corev1.Volume{
 					Name: "virtualmachineimages",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},
-				},
-				{
+				}
+				cgroup := corev1.Volume{
 					Name: "sysfscgroup",
 					VolumeSource: corev1.VolumeSource{
 						HostPath: &corev1.HostPathVolumeSource{
@@ -1393,8 +1468,23 @@ func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret) (*co
 							Type: &[]corev1.HostPathType{corev1.HostPathDirectory}[0],
 						},
 					},
-				},
-			},
+				}
+				containerdSock := corev1.Volume{
+					Name: "containerdsock",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: config.criEndpointSocketPath(),
+							Type: &[]corev1.HostPathType{corev1.HostPathSocket}[0],
+						},
+					},
+				}
+
+				if config.UseContainerMgr {
+					return []corev1.Volume{images, containerdSock}
+				} else {
+					return []corev1.Volume{images, cgroup}
+				}
+			}(),
 		},
 	}
 
@@ -1446,6 +1536,9 @@ func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret) (*co
 	// If a custom neonvm-runner image is requested, use that instead:
 	if virtualmachine.Spec.RunnerImage != nil {
 		pod.Spec.Containers[0].Image = *virtualmachine.Spec.RunnerImage
+		if config.UseContainerMgr {
+			pod.Spec.Containers[1].Image = *virtualmachine.Spec.RunnerImage
+		}
 	}
 
 	// If a custom kernel is used, add that image:
@@ -1579,7 +1672,7 @@ func (r *VirtualMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachine{}).
 		Owns(&corev1.Pod{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
 		Named(cntrlName).
 		Complete(reconciler)
 }

--- a/neonvm/controllers/virtualmachine_controller_test.go
+++ b/neonvm/controllers/virtualmachine_controller_test.go
@@ -99,8 +99,11 @@ var _ = Describe("VirtualMachine controller", func() {
 				Client:   k8sClient,
 				Scheme:   k8sClient.Scheme(),
 				Recorder: nil,
-
-				MaxConcurrentReconciles: 1,
+				Config: &ReconcilerConfig{
+					IsK3s:                   false,
+					UseContainerMgr:         true,
+					MaxConcurrentReconciles: 1,
+				},
 			}
 
 			_, err = virtualmachineReconciler.Reconcile(ctx, reconcile.Request{

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -57,10 +57,9 @@ type VirtualMachineMigrationReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+	Config   *ReconcilerConfig
 
 	Metrics ReconcilerMetrics
-
-	MaxConcurrentReconciles int
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
@@ -675,7 +674,7 @@ func (r *VirtualMachineMigrationReconciler) SetupWithManager(mgr ctrl.Manager) e
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachineMigration{}).
 		Owns(&corev1.Pod{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
 		Named(cntrlName).
 		Complete(reconciler)
 }
@@ -687,7 +686,7 @@ func (r *VirtualMachineMigrationReconciler) targetPodForVirtualMachine(
 	sshSecret *corev1.Secret,
 ) (*corev1.Pod, error) {
 
-	pod, err := podSpec(vm, sshSecret)
+	pod, err := podSpec(vm, sshSecret, r.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/neonvm/runner/Dockerfile
+++ b/neonvm/runner/Dockerfile
@@ -25,6 +25,18 @@ COPY pkg/util pkg/util
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /runner neonvm/runner/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /container-mgr neonvm/runner/container-mgr/*.go
+
+FROM alpine:3.16 as crictl
+
+RUN apk add --no-cache \
+    curl
+WORKDIR /workspace
+# FIXME: There's non-overlapping version support for <1.27 and >=1.27.
+# We should carefully consider how we go about future-proofing this (or not).
+ENV VERSION="v1.25.0"
+RUN curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz" -o crictl.tar.gz \
+	&& tar zxvf crictl.tar.gz -C /
 
 FROM alpine:3.16
 
@@ -42,10 +54,12 @@ RUN apk add --no-cache \
     e2fsprogs \
     qemu-system-x86_64 \
     qemu-img \
-    cgroup-tools \
+	cgroup-tools \
     openssh
 
 COPY --from=builder /runner /usr/bin/runner
+COPY --from=builder /container-mgr /usr/bin/container-mgr
+COPY --from=crictl /crictl /usr/bin/crictl
 COPY neonvm/hack/kernel/vmlinuz /vm/kernel/vmlinuz
 COPY neonvm/runner/ssh_config /etc/ssh/ssh_config
 

--- a/neonvm/runner/container-mgr/crictl.go
+++ b/neonvm/runner/container-mgr/crictl.go
@@ -1,0 +1,146 @@
+package main
+
+// crictl abstraction and commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"go.uber.org/zap"
+)
+
+type Crictl struct {
+	endpoint string
+}
+
+// Pods calls 'crictl pods' and, if successful, returns the parsed output
+//
+// This command lists all running pods.
+func (c *Crictl) Pods(logger *zap.Logger) (*CrictlPods, error) {
+	var pods CrictlPods
+	if err := c.run(logger, &pods, "pods", "-o", "json"); err != nil {
+		return nil, err
+	}
+	return &pods, nil
+}
+
+// CrictlPods represents the JSON output of 'crictl pods', limited to the subset we care about.
+type CrictlPods struct {
+	Items []CrictlPod `json:"items"`
+}
+type CrictlPod struct {
+	ID       string            `json:"id"`
+	Metadata CrictlPodMetadata `json:"metadata"`
+}
+type CrictlPodMetadata struct {
+	UID string `json:"uid"`
+}
+
+// Ps calls 'crictl ps -p <podID>' and, if successful, returns the parsed output
+//
+// This command lists the containers in the pod.
+func (c *Crictl) Ps(logger *zap.Logger, podID string) (*CrictlContainers, error) {
+	var containers CrictlContainers
+	if err := c.run(logger, &containers, "ps", "-p", podID, "-o", "json"); err != nil {
+		return nil, err
+	}
+	return &containers, nil
+}
+
+// CrictlContainers represents the JSON output of 'crictl ps', limited to the subset we care about.
+type CrictlContainers struct {
+	Containers []CrictlContainer `json:"containers"`
+}
+type CrictlContainer struct {
+	ID       string                  `json:"id"`
+	Metadata CrictlContainerMetadata `json:"metadata"`
+}
+type CrictlContainerMetadata struct {
+	Name string `json:"name"`
+}
+
+func (c *Crictl) Update(logger *zap.Logger, containerID string, values CrictlContainerUpdate) error {
+	return c.run(
+		logger, nil,
+		"update",
+		"--cpu-share", strconv.Itoa(values.cpuShares),
+		"--cpu-quota", strconv.FormatInt(values.cpuQuota, 10),
+		"--cpu-period", strconv.FormatInt(values.cpuPeriod, 10),
+		containerID,
+	)
+}
+
+type CrictlContainerUpdate struct {
+	cpuShares int
+	cpuQuota  int64
+	cpuPeriod int64
+}
+
+func (c *Crictl) Inspect(logger *zap.Logger, containerID string) (*CrictlContainerInspect, error) {
+	var container CrictlContainerInspect
+	if err := c.run(logger, &container, "inspect", containerID); err != nil {
+		return nil, err
+	}
+	return &container, nil
+}
+
+// CrictlContainerInspect represents the JSON output of 'crictl inspect', limited to the subset we
+// care about.
+type CrictlContainerInspect struct {
+	Info CrictlContainerInfo `json:"info"`
+}
+type CrictlContainerInfo struct {
+	RuntimeSpec CrictlContainerRuntimeSpec `json:"runtimeSpec"`
+}
+type CrictlContainerRuntimeSpec struct {
+	Linux CrictlContainerRuntimeSpecLinux `json:"linux"`
+}
+type CrictlContainerRuntimeSpecLinux struct {
+	Resources CrictlContainerResources `json:"resources"`
+}
+type CrictlContainerResources struct {
+	CPU CrictlContainerResourcesCPU `json:"cpu"`
+}
+type CrictlContainerResourcesCPU struct {
+	Period uint64 `json:"period"`
+	Quota  uint64 `json:"quota"`
+	Shares uint64 `json:"shares"`
+}
+
+func (c *Crictl) run(logger *zap.Logger, output any, args ...string) error {
+	actualArgs := []string{
+		"--runtime-endpoint",
+		c.endpoint,
+	}
+	actualArgs = append(actualArgs, args...)
+
+	logger.Info("running crictl", zap.Strings("args", actualArgs))
+
+	cmd := exec.Command("/usr/bin/crictl", actualArgs...)
+
+	stderr, err := os.OpenFile("/dev/stderr", os.O_RDWR, 0 /* unused */)
+	if err != nil {
+		panic(fmt.Errorf("failed to open /dev/stderr: %w", err))
+	}
+	cmd.Stderr = stderr
+
+	if output == nil {
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to run command: %w", err)
+		}
+		return nil
+	} else {
+		out, err := cmd.Output()
+		if err != nil {
+			return fmt.Errorf("failed to run command: %w", err)
+		}
+
+		if err := json.Unmarshal(out, output); err != nil {
+			return fmt.Errorf("error parsing JSON: %w", err)
+		}
+		return nil
+	}
+}

--- a/neonvm/runner/container-mgr/main.go
+++ b/neonvm/runner/container-mgr/main.go
@@ -1,0 +1,301 @@
+package main
+
+// container-mgr ('neonvm-container-runner') runs in a container alongside neonvm-runner, and is
+// responsible for updating the CPU shares & quotas for neonvm-runner by communicating directly with
+// containerd (via CRI API, over containerd's socket).
+//
+// We have to go this back-channel route because kubernetes <1.27 doesn't support updating container
+// resources without restarting, and with cgroups v2, kubernetes 1.25+ uses cgroup namespaces which
+// prevents our ability to interact with cgroups inside the container *except by* going through the
+// containerd API.
+//
+// We use a separate container to limit possibilities for privilege escalation.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	"github.com/neondatabase/autoscaling/pkg/api"
+)
+
+const (
+	runnerContainerName = "neonvm-runner"
+
+	retryInitEvery = 5 * time.Second
+
+	// cpuLimitOvercommitFactor sets the amount above the VM's spec.guest.cpus.use that we set the
+	// QEMU cgroup's CPU limit to. e.g. if cpuLimitOvercommitFactor = 3 and the VM is using 0.5
+	// CPUs, we set the cgroup to limit QEMU+VM to 1.5 CPUs.
+	//
+	// This exists because setting the cgroup exactly equal to the VM's CPU value is overly
+	// pessimistic, results in a lot of unused capacity on the host, and particularly impacts
+	// operations that parallelize between the VM and QEMU, like heavy disk access.
+	//
+	// See also: https://neondb.slack.com/archives/C03TN5G758R/p1693462680623239
+	cpuLimitOvercommitFactor = 4
+
+	// number of CPU shares per vCPU to use when updating a container
+	sharesPerCPU = 1024
+	cpuPeriod    = 100000
+)
+
+func main() {
+	logger := zap.Must(zap.NewProduction()).Named("neonvm-container-mgr")
+
+	selfPodUID, ok := os.LookupEnv("K8S_POD_UID")
+	if !ok {
+		logger.Fatal("environment variable K8S_POD_UID missing")
+	}
+	logger.Info("Got pod UID", zap.String("uid", selfPodUID))
+
+	containerRuntimeEndpoint, ok := os.LookupEnv("CRI_ENDPOINT")
+	if !ok {
+		logger.Fatal("environment variable CRI_ENDPOINT missing")
+	}
+	logger.Info("Got CRI endpoint", zap.String("endpoint", containerRuntimeEndpoint))
+
+	crictl := &Crictl{
+		endpoint: containerRuntimeEndpoint,
+	}
+
+	var httpPort int
+	var initMilliCPU int
+	flag.IntVar(&httpPort, "port", -1, "Port for the CPU http server")
+	flag.IntVar(&initMilliCPU, "init-milli-cpu", -1, "Initial milli-CPU to use for the VM")
+	flag.Parse()
+
+	if httpPort < 0 {
+		logger.Fatal("missing 'port' flag")
+	} else if initMilliCPU < 0 {
+		logger.Fatal("missing 'init-milli-cpu' flag")
+	}
+
+	pods, err := crictl.Pods(logger)
+	if err != nil {
+		logger.Fatal("failed to run crictl command to get CRI ID for pod UID", zap.String("uid", selfPodUID), zap.Error(err))
+	}
+
+	// find pod with matching uid
+	var criPodID string
+	for _, p := range pods.Items {
+		if p.Metadata.UID == selfPodUID {
+			criPodID = p.ID
+			break
+		}
+	}
+	if criPodID == "" {
+		logger.Fatal("could not find CRI pod with matching UID", zap.String("uid", selfPodUID))
+	}
+
+	logger.Info("Got CRI ID for pod", zap.String("podID", criPodID))
+
+	var criRunnerContainerID string
+	for criRunnerContainerID == "" {
+		containers, err := crictl.Ps(logger, criPodID)
+		if err != nil {
+			logger.Fatal(
+				"failed to run crictl command to get CRI ID for container",
+				zap.String("podID", criPodID),
+				zap.String("name", runnerContainerName),
+				zap.Error(err),
+			)
+		}
+
+		for _, c := range containers.Containers {
+			if c.Metadata.Name == runnerContainerName {
+				criRunnerContainerID = c.ID
+				break
+			}
+		}
+		if criRunnerContainerID == "" {
+			logger.Error(
+				"could not find CRI container with matching name",
+				zap.String("podID", criPodID),
+				zap.String("name", runnerContainerName),
+			)
+			time.Sleep(retryInitEvery)
+		}
+	}
+
+	logger.Info(
+		fmt.Sprintf("Got CRI ID for %s container", runnerContainerName),
+		zap.String("containerID", criRunnerContainerID),
+	)
+
+	// Set the CPU to initMilliCPU:
+	err = updateContainerCPU(logger, crictl, criRunnerContainerID, vmv1.MilliCPU(initMilliCPU))
+	if err != nil {
+		logger.Fatal("could not set initial runner container CPU", zap.Error(err))
+	}
+
+	srvState := cpuServerState{
+		podID:        criPodID,
+		containerID:  criRunnerContainerID,
+		lastMilliCPU: atomic.Uint32{},
+	}
+	srvState.lastMilliCPU.Store(uint32(initMilliCPU))
+
+	srvState.listenForCPUChanges(context.TODO(), logger, crictl, int32(httpPort))
+}
+
+type cpuServerState struct {
+	podID        string
+	containerID  string
+	lastMilliCPU atomic.Uint32
+}
+
+func (s *cpuServerState) listenForCPUChanges(ctx context.Context, logger *zap.Logger, crictl *Crictl, port int32) {
+	mux := http.NewServeMux()
+	loggerHandlers := logger.Named("http-handlers")
+	cpuChangeLogger := loggerHandlers.Named("cpu_change")
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.Body.Close()
+		w.WriteHeader(200)
+	})
+	mux.HandleFunc("/cpu_change", func(w http.ResponseWriter, r *http.Request) {
+		s.handleCPUChange(cpuChangeLogger, crictl, w, r)
+	})
+	cpuCurrentLogger := loggerHandlers.Named("cpu_current")
+	mux.HandleFunc("/cpu_current", func(w http.ResponseWriter, r *http.Request) {
+		s.handleCPUCurrent(cpuCurrentLogger, crictl, w, r)
+	})
+	server := http.Server{
+		Addr:              fmt.Sprintf("0.0.0.0:%d", port),
+		Handler:           mux,
+		ReadTimeout:       5 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      5 * time.Second,
+	}
+	errChan := make(chan error)
+	go func() {
+		errChan <- server.ListenAndServe()
+	}()
+	select {
+	case err := <-errChan:
+		if errors.Is(err, http.ErrServerClosed) {
+			logger.Info("cpu_change server closed")
+		} else if err != nil {
+			logger.Fatal("cpu_change server exited with error", zap.Error(err))
+		}
+	case <-ctx.Done():
+		err := server.Shutdown(context.Background())
+		logger.Info("shut down cpu_change server", zap.Error(err))
+	}
+}
+
+func (s *cpuServerState) handleCPUChange(logger *zap.Logger, crictl *Crictl, w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		logger.Error("unexpected method", zap.String("method", r.Method))
+		w.WriteHeader(400)
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		logger.Error("could not read body", zap.Error(err))
+		w.WriteHeader(400)
+		return
+	}
+
+	var parsed api.VCPUChange
+	if err = json.Unmarshal(body, &parsed); err != nil {
+		logger.Error("could not parse body", zap.Error(err))
+		w.WriteHeader(400)
+		return
+	}
+
+	logger.Info("got CPU update", zap.Float64("CPU", parsed.VCPUs.AsFloat64()))
+
+	if err := updateContainerCPU(logger, crictl, s.containerID, parsed.VCPUs); err != nil {
+		logger.Error("could not update container CPU", zap.String("id", s.containerID), zap.Error(err))
+		w.WriteHeader(500)
+		return
+	}
+
+	// store the milli CPU now that we've set it, so that in handleCPUCurrent we can handle rounding
+	// issues based on the last operation we did.
+	s.lastMilliCPU.Store(uint32(parsed.VCPUs))
+
+	w.WriteHeader(200)
+}
+
+func updateContainerCPU(logger *zap.Logger, crictl *Crictl, containerID string, cpu vmv1.MilliCPU) error {
+	shares := sharesForCPU(cpu)
+	quota := int64(vmv1.MilliCPU(cpuLimitOvercommitFactor*cpu).AsFloat64() * float64(cpuPeriod))
+
+	logger.Info(
+		"calculated CPU quantities for vCPU",
+		zap.Int("shares", shares),
+		zap.Int64("quota", quota),
+		zap.Int("period", cpuPeriod),
+	)
+
+	// update container
+	return crictl.Update(logger, containerID, CrictlContainerUpdate{
+		cpuShares: shares,
+		cpuQuota:  quota,
+		cpuPeriod: cpuPeriod,
+	})
+}
+
+func (s *cpuServerState) handleCPUCurrent(logger *zap.Logger, crictl *Crictl, w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		logger.Error("unexpected method", zap.String("method", r.Method))
+		w.WriteHeader(400)
+		return
+	}
+
+	logger.Info("got CPU current request")
+
+	container, err := crictl.Inspect(logger, s.containerID)
+	if err != nil {
+		logger.Error("could not inspect container", zap.String("id", s.containerID), zap.Error(err))
+	}
+
+	shares := int(container.Info.RuntimeSpec.Linux.Resources.CPU.Shares)
+
+	logger.Info(
+		"fetched current CPU shares",
+		zap.Int("shares", shares),
+	)
+
+	last := vmv1.MilliCPU(s.lastMilliCPU.Load())
+	expectedIfNoChange := sharesForCPU(last)
+
+	var resp api.VCPUCgroup
+	if shares == expectedIfNoChange {
+		resp = api.VCPUCgroup{VCPUs: last}
+	} else {
+		resp = api.VCPUCgroup{VCPUs: cpuForShares(shares)}
+	}
+
+	logger.Info("responding with current CPU", zap.Float64("cpu", resp.VCPUs.AsFloat64()))
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		logger.Error("could not marshal body", zap.Error(err))
+		w.WriteHeader(500)
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	w.Write(body) //nolint:errcheck // Not much to do with the error here. TODO: log it?
+}
+
+func sharesForCPU(cpu vmv1.MilliCPU) int {
+	return sharesPerCPU * int(cpu) / 1000
+}
+
+func cpuForShares(shares int) vmv1.MilliCPU {
+	return vmv1.MilliCPU(shares * 1000 / sharesPerCPU)
+}

--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -680,27 +680,27 @@ func main() {
 		qemuCmd = append(qemuCmd, "-incoming", fmt.Sprintf("tcp:0:%d", vmv1.MigrationPort))
 	}
 
-	selfCgroupPath, err := getSelfCgroupPath(logger)
-	if err != nil {
-		logger.Fatal("Failed to get self cgroup path", zap.Error(err))
-	}
-	// Sometimes we'll get just '/' as our cgroup path. If that's the case, we should reset it so
-	// that the cgroup '/neonvm-qemu-...' still works.
-	if selfCgroupPath == "/" {
-		selfCgroupPath = ""
-	}
-	// ... but also we should have some uniqueness just in case, so we're not sharing a root level
-	// cgroup if that *is* what's happening. This *should* only be relevant for local clusters.
-	//
-	// We don't want to just use the VM spec's .status.PodName because during migrations that will
-	// be equal to the source pod, not this one, which may be... somewhat confusing.
-	cgroupPath := fmt.Sprintf("%s/neonvm-qemu-%s", selfCgroupPath, selfPodName)
+		selfCgroupPath, err := getSelfCgroupPath(logger)
+		if err != nil {
+			logger.Fatal("Failed to get self cgroup path", zap.Error(err))
+		}
+		// Sometimes we'll get just '/' as our cgroup path. If that's the case, we should reset it so
+		// that the cgroup '/neonvm-qemu-...' still works.
+		if selfCgroupPath == "/" {
+			selfCgroupPath = ""
+		}
+		// ... but also we should have some uniqueness just in case, so we're not sharing a root level
+		// cgroup if that *is* what's happening. This *should* only be relevant for local clusters.
+		//
+		// We don't want to just use the VM spec's .status.PodName because during migrations that will
+		// be equal to the source pod, not this one, which may be... somewhat confusing.
+		cgroupPath := fmt.Sprintf("%s/neonvm-qemu-%s", selfCgroupPath, selfPodName)
 
-	logger.Info("Determined QEMU cgroup path", zap.String("path", cgroupPath))
+		logger.Info("Determined QEMU cgroup path", zap.String("path", cgroupPath))
 
-	if err := setCgroupLimit(logger, qemuCPUs.use, cgroupPath); err != nil {
-		logger.Fatal("Failed to set cgroup limit", zap.Error(err))
-	}
+		if err := setCgroupLimit(logger, qemuCPUs.use, cgroupPath); err != nil {
+			logger.Fatal("Failed to set cgroup limit", zap.Error(err))
+		}
 	ctx, cancel := context.WithCancel(context.Background())
 	wg := sync.WaitGroup{}
 

--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -487,10 +487,12 @@ func main() {
 	var vmStatusDump string
 	var kernelPath string
 	var appendKernelCmdline string
+	var skipCgroupManagement bool
 	flag.StringVar(&vmSpecDump, "vmspec", vmSpecDump, "Base64 encoded VirtualMachine json specification")
 	flag.StringVar(&vmStatusDump, "vmstatus", vmStatusDump, "Base64 encoded VirtualMachine json status")
 	flag.StringVar(&kernelPath, "kernelpath", defaultKernelPath, "Override path for kernel to use")
 	flag.StringVar(&appendKernelCmdline, "appendKernelCmdline", "", "Additional kernel command line arguments")
+	flag.BoolVar(&skipCgroupManagement, "skip-cgroup-management", false, "Don't try to manage CPU (use if running alongside container-mgr)")
 	flag.Parse()
 
 	selfPodName, ok := os.LookupEnv("K8S_POD_NAME")
@@ -680,6 +682,9 @@ func main() {
 		qemuCmd = append(qemuCmd, "-incoming", fmt.Sprintf("tcp:0:%d", vmv1.MigrationPort))
 	}
 
+	var cgroupPath string
+
+	if !skipCgroupManagement {
 		selfCgroupPath, err := getSelfCgroupPath(logger)
 		if err != nil {
 			logger.Fatal("Failed to get self cgroup path", zap.Error(err))
@@ -694,26 +699,39 @@ func main() {
 		//
 		// We don't want to just use the VM spec's .status.PodName because during migrations that will
 		// be equal to the source pod, not this one, which may be... somewhat confusing.
-		cgroupPath := fmt.Sprintf("%s/neonvm-qemu-%s", selfCgroupPath, selfPodName)
+		cgroupPath = fmt.Sprintf("%s/neonvm-qemu-%s", selfCgroupPath, selfPodName)
 
 		logger.Info("Determined QEMU cgroup path", zap.String("path", cgroupPath))
 
 		if err := setCgroupLimit(logger, qemuCPUs.use, cgroupPath); err != nil {
 			logger.Fatal("Failed to set cgroup limit", zap.Error(err))
 		}
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	wg := sync.WaitGroup{}
 
 	wg.Add(1)
 	go terminateQemuOnSigterm(ctx, logger, &wg)
-	wg.Add(1)
-	go listenForCPUChanges(ctx, logger, vmSpec.RunnerPort, cgroupPath, &wg)
+	if !skipCgroupManagement {
+		wg.Add(1)
+		go listenForCPUChanges(ctx, logger, vmSpec.RunnerPort, cgroupPath, &wg)
+	}
 	wg.Add(1)
 	go forwardLogs(ctx, logger, &wg)
 
-	args := append([]string{"-g", fmt.Sprintf("cpu:%s", cgroupPath), QEMU_BIN}, qemuCmd...)
-	logger.Info("calling cgexec", zap.Strings("args", args))
-	if err := execFg("cgexec", args...); err != nil {
+	var bin string
+	var cmd []string
+	if !skipCgroupManagement {
+		bin = "cgexec"
+		cmd = append([]string{"-g", fmt.Sprintf("cpu:%s", cgroupPath), QEMU_BIN}, qemuCmd...)
+	} else {
+		bin = QEMU_BIN
+		cmd = qemuCmd
+	}
+
+	logger.Info(fmt.Sprintf("calling %s", bin), zap.Strings("args", cmd))
+	if err := execFg(bin, cmd...); err != nil {
 		logger.Error("QEMU exited with error", zap.Error(err))
 	} else {
 		logger.Info("QEMU exited without error")


### PR DESCRIPTION
We recently realized[^1] that under cgroups v2, kubernetes uses cgroup namespaces which has a few effects:

1. The output of /proc/self/cgroup shows as if the container were at the root of the hierarchy
2. It's very difficult for us to determine the actual cgroup that the container corresponds to on the host
3. We still can't directly create a cgroup in the container's namespace because /sys/fs/cgroup is mounted read-only

So, neonvm-runner currently *does not* work as expected with cgroups v2; it creates a new cgroup for the VM, at the top of the hierarchy, and doesn't clean it up on exit.

How do we fix this? The aim of this PR is to remove the special cgroup handling entirely, and "just" go through the Container Runtime Interface (CRI) exposed by containerd to modify the existing container we're running in.

This requires access to `/run/containerd/containerd.sock`, which a malicious user could use to perform priviledged operations on the host (or in any other container on the host). Obviously we'd like to prevent that as much as possible, so the CPU handling is now runs alongside neonvm-runner as a separate container. neonvm-runner does not have access to the containerd socket.

On the upside, one key benefit we get from this is being able to set cpu shares, the abstraction underlying container resources.requests. The other options weren't looking so great[^2], so if this works, this would be a nice compromise.

---

~~Honestly have no clue whether this'll work. Haven't tested it _at all_ (except for some ad-hoc interactions with `crictl` from ssh-ing into a `kind` node).~~ Wanted to open this for visibility, in case there's something silly I missed.

---

Fixes #755.
Fixes #591.

[^1]: https://neondb.slack.com/archives/C03TN5G758R/p1705092611188719
[^2]: https://github.com/neondatabase/autoscaling/issues/591