### PR TITLE
agent: Send compute unit in requests to plugin

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -655,6 +655,7 @@ func (r *Runner) DoSchedulerRequest(
 	reqData := &api.AgentRequest{
 		ProtoVersion: PluginProtocolVersion,
 		Pod:          r.podName,
+		ComputeUnit:  &r.global.config.Scaling.ComputeUnit,
 		Resources:    resources,
 		LastPermit:   lastPermit,
 		Metrics:      metrics,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -76,6 +76,7 @@ const (
 	// Changes from v3.0:
 	//
 	// * Memory quantities now use "number of bytes" instead of "number of memory slots"
+	// * Adds AgentRequest.ComputeUnit
 	//
 	// Currently the latest version.
 	PluginProtoV4_0
@@ -138,6 +139,14 @@ func (v PluginProtoVersion) PluginSendsComputeUnit() bool {
 	return v < PluginProtoV3_0
 }
 
+// AgentSendsComputeUnit returns whether this version of the protocol expects the autoscaler-agent
+// to send the value of its configured Compute Unit in its AgentRequest.
+//
+// This is true for version v4.0 and greater.
+func (v PluginProtoVersion) AgentSendsComputeUnit() bool {
+	return v >= PluginProtoV4_0
+}
+
 // RepresentsMemoryAsBytes returns whether this version of the protocol uses byte quantities to
 // refer to memory amounts, rather than a number of memory slots.
 //
@@ -156,6 +165,8 @@ type AgentRequest struct {
 	ProtoVersion PluginProtoVersion `json:"protoVersion"`
 	// Pod is the namespaced name of the pod making the request
 	Pod util.NamespacedName `json:"pod"`
+	// ComputeUnit gives the value of the agent's configured compute unit to use for the VM.
+	ComputeUnit *Resources `json:"computeUnit"`
 	// Resources gives a requested or notified change in resources allocated to the VM.
 	//
 	// The requested amount MAY be equal to the current amount, in which case it serves as a

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -166,6 +166,10 @@ type AgentRequest struct {
 	// Pod is the namespaced name of the pod making the request
 	Pod util.NamespacedName `json:"pod"`
 	// ComputeUnit gives the value of the agent's configured compute unit to use for the VM.
+	//
+	// If the requested resources are not a multiple of ComputeUnit, the scheduler plugin will make
+	// a best-effort attempt to return a value satisfying the request. Any approved increases will
+	// be a multiple of ComputeUnit, but otherwise the plugin does not check.
 	ComputeUnit *Resources `json:"computeUnit"`
 	// Resources gives a requested or notified change in resources allocated to the VM.
 	//


### PR DESCRIPTION
Related to moving the compute unit source of truth from the scheduler plugin to the autoscaler-agent (see #706).

We also particularly want to have this so that the plugin doesn't approve resources that aren't an integer multiple of the respective value in the compute unit. If we didn't we could e.g. approve 1.01 CPUs, leaving the autoscaler-agent with 0.01 CPUs that it'll never use. In practice, that's quite unlikely to happen, but it's still worth avoiding potential issues there.

~~**NB: This PR builds on #653 and must not be merged before it.**~~

~~**Before merging:** Still need to check that we're able to run with old autoscaler-agent + new scheduler, with this PR.~~ Done