### PR TITLE
agent: Sleep for random delay before first metrics request

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -351,6 +351,16 @@ func (r *Runner) getMetricsLoop(
 	timeout := time.Second * time.Duration(r.global.config.Metrics.RequestTimeoutSeconds)
 	waitBetweenDuration := time.Second * time.Duration(r.global.config.Metrics.SecondsBetweenRequests)
 
+	randomStartWait := util.NewTimeRange(time.Second, 0, int(r.global.config.Metrics.SecondsBetweenRequests)).Random()
+
+	logger.Info("Sleeping for random delay before making first metrics request", zap.Duration("delay", randomStartWait))
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(randomStartWait):
+	}
+
 	for {
 		metrics, err := r.doMetricsRequest(ctx, logger, timeout)
 		if err != nil {


### PR DESCRIPTION
Part of #741, see there for more info. Basically, we generally want to avoid letting requests become synchronized across VMs, and this is one part of doing that.