### PR TITLE
CI: Use separate workflows for image builds 

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -117,11 +117,6 @@ jobs:
         run: |
           echo "tag=$(cat cluster-autoscaler/ca.tag)" >> $GITHUB_OUTPUT
 
-      - name: Check dependencies
-        run: |
-          docker version
-          docker buildx version
-
       # Use custom DOCKER_CONFIG directory to avoid conflicts with default settings
       # The default value is ~/.docker
       - name: set custom docker config directory
@@ -133,6 +128,11 @@ jobs:
         with:
           username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
+
+      - name: Check dependencies
+        run: |
+          docker version
+          docker buildx version
 
       - name: Load VM kernel
         env:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,207 @@
+name: build-images
+
+on:
+  workflow_call:
+    inputs:
+      # 'skip' is kind of silly. it exists because we can't actually *skip* this job from e2e-test,
+      # otherwise the follow-up job that needs it wouldn't be able to run. So instead we pretend the
+      # job completed successfully, but actually do nothing...
+      skip:
+        description: 'Changes this action to perform a no-op'
+        type: boolean
+        required: false
+      tag:
+        description: 'Tag to use for the Docker images'
+        type: string
+        required: true
+      kernel-image:
+        description: 'Kernel image for the VMs embedded in neonvm-runner. If not specified, a kernel will be built from source'
+        type: string
+        required: false
+      build-cluster-autoscaler:
+        description: 'Build the custom cluster-autoscaler image'
+        type: boolean
+        required: false
+    outputs:
+      controller:
+        description: 'neonvm-controller image'
+        value: ${{ jobs.tags.outputs.controller }}
+      vxlan-controller:
+        description: 'neonvm-vxlan-controller image'
+        value: ${{ jobs.tags.outputs.vxlan-controller }}
+      runner:
+        description: 'neonvm-runner image'
+        value: ${{ jobs.tags.outputs.runner }}
+      scheduler:
+        description: 'autoscale-scheduler image'
+        value: ${{ jobs.tags.outputs.scheduler }}
+      autoscaler-agent:
+        description: 'autoscaler-agent image'
+        value: ${{ jobs.tags.outputs.autoscaler-agent }}
+
+env:
+  IMG_CONTROLLER:         "neondatabase/neonvm-controller"
+  IMG_VXLAN_CONTROLLER:   "neondatabase/neonvm-vxlan-controller"
+  IMG_RUNNER:             "neondatabase/neonvm-runner"
+  IMG_KERNEL:             "neondatabase/vm-kernel"
+  IMG_SCHEDULER:          "neondatabase/autoscale-scheduler"
+  IMG_AUTOSCALER_AGENT:   "neondatabase/autoscaler-agent"
+  IMG_CLUSTER_AUTOSCALER: "neondatabase/cluster-autoscaler-neonvm"
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  tags:
+    outputs:
+      controller:         ${{ steps.show-tags.outputs.controller }}
+      vxlan-controller:   ${{ steps.show-tags.outputs.vxlan-controller }}
+      runner:             ${{ steps.show-tags.outputs.runner }}
+      scheduler:          ${{ steps.show-tags.outputs.scheduler }}
+      autoscaler-agent:   ${{ steps.show-tags.outputs.autoscaler-agent }}
+      cluster-autoscaler: ${{ steps.show-tags.outputs.cluster-autoscaler }}
+    runs-on: [ self-hosted, gen3, small ]
+    steps:
+      - id: show-tags
+        run: |
+          echo "controller=${{ env.IMG_CONTROLLER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
+          echo "vxlan-controller=${{ env.IMG_VXLAN_CONTROLLER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
+          echo "runner=${{ env.IMG_RUNNER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
+          echo "scheduler=${{ env.IMG_SCHEDULER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
+          echo "autoscaler-agent=${{ env.IMG_AUTOSCALER_AGENT }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
+          echo "cluster-autoscaler=${{ env.IMG_CLUSTER_AUTOSCALER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
+
+  vm-kernel:
+    if: ${{ ! inputs.skip }}
+    uses: ./.github/workflows/vm-kernel.yaml
+    with:
+      tag: ${{ inputs.kernel-image || inputs.tag }}
+      return-image-for-tag: ${{ inputs.kernel-image }}
+    secrets: inherit
+
+  build:
+    if: ${{ ! inputs.skip }}
+    needs: [ tags, vm-kernel ]
+    runs-on: [ self-hosted, gen3, large ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # fetch all, so that we also include tags
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          # Disable cache on self-hosted runners to avoid /usr/bin/tar errors, see https://github.com/actions/setup-go/issues/403
+          cache: false
+        # Sometimes setup-go gets stuck. Without this, it'll keep going until the job gets killed
+        timeout-minutes: 10
+
+      # Use 'git describe' for embedding git information (duplicated from the Makefile)
+      - name: get git info
+        id: get-git-info
+        run: |
+          # note: --tags enables matching on lightweight (i.e. not annotated) tags, which normally
+          # wouldn't be necessary, except that actions/checkout@v3 does weird things to setup the
+          # repository that means that we actually end up checked out with *just* a lightweight tag
+          # to the tagged commit.
+          echo "info=$(git describe --tags --long --dirty)" >> $GITHUB_OUTPUT
+
+      - name: get CA base git tag
+        id: get-ca-tag
+        if: ${{ inputs.build-cluster-autoscaler }}
+        run: |
+          echo "tag=$(cat cluster-autoscaler/ca.tag)" >> $GITHUB_OUTPUT
+
+      - name: Check dependencies
+        run: |
+          docker version
+          docker buildx version
+
+      # Use custom DOCKER_CONFIG directory to avoid conflicts with default settings
+      # The default value is ~/.docker
+      - name: set custom docker config directory
+        run: |
+          mkdir -p .docker-custom
+          echo DOCKER_CONFIG=$(pwd)/.docker-custom >> $GITHUB_ENV
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
+
+      - name: Load VM kernel
+        env:
+          IMAGE: ${{ needs.vm-kernel.outputs.image }}
+        run: |
+          docker pull --quiet $IMAGE
+          ID=$(docker create $IMAGE true)
+          docker cp ${ID}:/vmlinuz neonvm/hack/kernel/vmlinuz
+          docker rm -f ${ID}
+
+      - name: Build and push neonvm-runner image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          file: neonvm/runner/Dockerfile
+          tags: ${{ needs.tags.outputs.runner }}
+
+      - name: Build and push neonvm-controller image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          file: neonvm/Dockerfile
+          tags: ${{ needs.tags.outputs.controller }}
+          build-args: |
+            VM_RUNNER_IMAGE=${{ needs.tags.outputs.runner }}
+
+      - name: Build and push neonvm-vxlan-controller image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          file: neonvm/tools/vxlan/Dockerfile
+          tags: ${{ needs.tags.outputs.vxlan-controller }}
+
+      - name: Build and push autoscale-scheduler image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          file: build/autoscale-scheduler/Dockerfile
+          tags: ${{ needs.tags.outputs.scheduler }}
+          build-args: |
+            GIT_INFO=${{ steps.get-git-info.outputs.info }}:${{ inputs.tag }}
+
+      - name: Build and push autoscaler-agent image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          file: build/autoscaler-agent/Dockerfile
+          tags: ${{ needs.tags.outputs.autoscaler-agent }}
+          build-args: |
+            GIT_INFO=${{ steps.get-git-info.outputs.info }}
+
+      - name: Build and push cluster-autoscaler image
+        uses: docker/build-push-action@v3
+        if: ${{ inputs.build-cluster-autoscaler }}
+        with:
+          context: cluster-autoscaler
+          platforms: linux/amd64
+          push: true
+          tags: ${{ needs.tags.outputs.cluster-autoscaler }}
+          build-args: |
+            CA_GIT_TAG=${{ steps.get-ca-tag.outputs.tag }}
+
+      - name: Remove custom docker config directory
+        if: always()
+        run: |
+          rm -rf .docker-custom

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -153,6 +153,7 @@ jobs:
           tags: ${{ needs.tags.outputs.runner }}
 
       - name: Generate neonvm-controller build tags
+        id: controller-build-tags
         env:
           PRESERVE_RUNNER_PODS: ${{ inputs.controller-preserve-runner-pods }}
         run: |

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -22,6 +22,10 @@ on:
         description: 'Build the custom cluster-autoscaler image'
         type: boolean
         required: false
+      controller-preserve-runner-pods:
+        description: 'ONLY USE FOR E2E TESTS: Set neonvm-controller to never delete VM runner pods'
+        type: boolean
+        required: false
     outputs:
       controller:
         description: 'neonvm-controller image'
@@ -148,6 +152,16 @@ jobs:
           file: neonvm/runner/Dockerfile
           tags: ${{ needs.tags.outputs.runner }}
 
+      - name: Generate neonvm-controller build tags
+        env:
+          PRESERVE_RUNNER_PODS: ${{ inputs.controller-preserve-runner-pods }}
+        run: |
+          if [ "$PRESERVE_RUNNER_PODS" = 'true' ]; then
+            echo "buildtags=nodelete" | tee -a $GITHUB_OUTPUT
+          else
+            echo "buildtags=" | tee -a $GITHUB_OUTPUT
+          fi
+
       - name: Build and push neonvm-controller image
         uses: docker/build-push-action@v3
         with:
@@ -158,6 +172,7 @@ jobs:
           tags: ${{ needs.tags.outputs.controller }}
           build-args: |
             VM_RUNNER_IMAGE=${{ needs.tags.outputs.runner }}
+            BUILDTAGS=${{ steps.controller-build-tags.outputs.buildtags }}
 
       - name: Build and push neonvm-vxlan-controller image
         uses: docker/build-push-action@v3

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -77,7 +77,7 @@ jobs:
           echo "cluster-autoscaler=${{ env.IMG_CLUSTER_AUTOSCALER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
 
   vm-kernel:
-    if: ${{ ! inputs.skip }}
+    if: ${{ inputs.skip != 'true' }}
     uses: ./.github/workflows/vm-kernel.yaml
     with:
       tag: ${{ inputs.kernel-image || inputs.tag }}
@@ -85,7 +85,7 @@ jobs:
     secrets: inherit
 
   build:
-    if: ${{ ! inputs.skip }}
+    if: ${{ inputs.skip != 'true' }}
     needs: [ tags, vm-kernel ]
     runs-on: [ self-hosted, gen3, large ]
     steps:
@@ -113,7 +113,7 @@ jobs:
 
       - name: get CA base git tag
         id: get-ca-tag
-        if: ${{ inputs.build-cluster-autoscaler }}
+        if: ${{ inputs.build-cluster-autoscaler == 'true' }}
         run: |
           echo "tag=$(cat cluster-autoscaler/ca.tag)" >> $GITHUB_OUTPUT
 
@@ -208,7 +208,7 @@ jobs:
 
       - name: Build and push cluster-autoscaler image
         uses: docker/build-push-action@v3
-        if: ${{ inputs.build-cluster-autoscaler }}
+        if: ${{ inputs.build-cluster-autoscaler == 'true' }}
         with:
           context: cluster-autoscaler
           platforms: linux/amd64

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -65,7 +65,7 @@ jobs:
       scheduler:          ${{ steps.show-tags.outputs.scheduler }}
       autoscaler-agent:   ${{ steps.show-tags.outputs.autoscaler-agent }}
       cluster-autoscaler: ${{ steps.show-tags.outputs.cluster-autoscaler }}
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: ubuntu-latest
     steps:
       - id: show-tags
         run: |

--- a/.github/workflows/build-test-vm.yaml
+++ b/.github/workflows/build-test-vm.yaml
@@ -45,7 +45,7 @@ jobs:
           echo "vm-postgres-15-bullseye=${{ env.IMG_POSTGRES_15_BULLSEYE }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
 
   build:
-    if: ${{ ! inputs.skip }}
+    if: ${{ inputs.skip != 'true' }}
     needs: tags
     runs-on: [ self-hosted, gen3, large ]
     steps:
@@ -61,7 +61,7 @@ jobs:
       - run: make bin/vm-builder
 
       - name: upload vm-builder
-        if: ${{ inputs.upload-vm-builder }}
+        if: ${{ inputs.upload-vm-builder == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: vm-builder

--- a/.github/workflows/build-test-vm.yaml
+++ b/.github/workflows/build-test-vm.yaml
@@ -1,0 +1,86 @@
+name: build-test-vm
+
+on:
+  workflow_dispatch: # adds ability to run this manually
+    inputs:
+      tag:
+        description: 'Tag to use for the Docker images'
+        type: string
+        required: true
+  workflow_call:
+    inputs:
+      skip:
+        description: 'Changes this action to perform a no-op'
+        type: boolean
+        required: false
+      tag:
+        description: 'Tag to use for the Docker images'
+        type: string
+        required: true
+      upload-vm-builder:
+        description: 'If true, upload vm-builder in an artifact'
+        type: boolean
+        required: false
+        default: false
+    outputs:
+      vm-postgres-15-bullseye:
+        description: 'image name for postgres:15-bullseye, VM-ified'
+        value: ${{ jobs.build.outputs.vm-postgres-15-bullseye }}
+
+env:
+  IMG_POSTGRES_15_BULLSEYE: "neondatabase/vm-postgres-15-bullseye"
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  build:
+    outputs:
+      vm-postgres-15-bullseye: ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
+    runs-on: [ self-hosted, gen3, large ]
+    steps:
+      - id: show-tags
+        run: |
+          echo "vm-postgres-15-bullseye=${{ env.IMG_POSTGRES_15_BULLSEYE }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          # Disable cache on self-hosted runners to avoid /usr/bin/tar errors, see https://github.com/actions/setup-go/issues/403
+          cache: false
+        # Sometimes setup-go gets stuck. Without this, it'll keep going until the job gets killed
+        timeout-minutes: 10
+
+      - run: make bin/vm-builder
+
+      - name: upload vm-builder
+        if: ${{ inputs.upload-vm-builder }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: vm-builder
+          path: bin/vm-builder
+          if-no-files-found: error
+          retention-days: 2
+
+      # Use custom DOCKER_CONFIG directory to avoid conflicts with default settings
+      # The default value is ~/.docker
+      - name: set custom docker config directory
+        run: |
+          mkdir -p .docker-custom
+          echo DOCKER_CONFIG=$(pwd)/.docker-custom >> $GITHUB_ENV
+
+      - name: login to docker hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
+
+      - name: build ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
+        run: |
+          ./bin/vm-builder -src postgres:15-bullseye -spec tests/e2e/image-spec.yaml -dst ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
+      - name: docker push ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
+        run: |
+          docker push ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
+

--- a/.github/workflows/build-test-vm.yaml
+++ b/.github/workflows/build-test-vm.yaml
@@ -38,7 +38,7 @@ jobs:
   tags:
     outputs:
       vm-postgres-15-bullseye: ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: ubuntu-latest
     steps:
       - id: show-tags
         run: |

--- a/.github/workflows/build-test-vm.yaml
+++ b/.github/workflows/build-test-vm.yaml
@@ -89,3 +89,7 @@ jobs:
         run: |
           docker push ${{ needs.tags.outputs.vm-postgres-15-bullseye }}
 
+      - name: Remove custom docker config directory
+        if: always()
+        run: |
+          rm -rf .docker-custom

--- a/.github/workflows/build-test-vm.yaml
+++ b/.github/workflows/build-test-vm.yaml
@@ -25,7 +25,7 @@ on:
     outputs:
       vm-postgres-15-bullseye:
         description: 'image name for postgres:15-bullseye, VM-ified'
-        value: ${{ jobs.build.outputs.vm-postgres-15-bullseye }}
+        value: ${{ jobs.tags.outputs.vm-postgres-15-bullseye }}
 
 env:
   IMG_POSTGRES_15_BULLSEYE: "neondatabase/vm-postgres-15-bullseye"
@@ -35,15 +35,20 @@ defaults:
     shell: bash -euo pipefail {0}
 
 jobs:
-  build:
+  tags:
     outputs:
       vm-postgres-15-bullseye: ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
-    runs-on: [ self-hosted, gen3, large ]
+    runs-on: [ self-hosted, gen3, small ]
     steps:
       - id: show-tags
         run: |
           echo "vm-postgres-15-bullseye=${{ env.IMG_POSTGRES_15_BULLSEYE }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
 
+  build:
+    if: ${{ ! inputs.skip }}
+    needs: tags
+    runs-on: [ self-hosted, gen3, large ]
+    steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
@@ -77,10 +82,10 @@ jobs:
           username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
-      - name: build ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
+      - name: build ${{ needs.tags.outputs.vm-postgres-15-bullseye }}
         run: |
-          ./bin/vm-builder -src postgres:15-bullseye -spec tests/e2e/image-spec.yaml -dst ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
-      - name: docker push ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
+          ./bin/vm-builder -src postgres:15-bullseye -spec tests/e2e/image-spec.yaml -dst ${{ needs.tags.outputs.vm-postgres-15-bullseye }}
+      - name: docker push ${{ needs.tags.outputs.vm-postgres-15-bullseye }}
         run: |
-          docker push ${{ steps.show-tags.outputs.vm-postgres-15-bullseye }}
+          docker push ${{ needs.tags.outputs.vm-postgres-15-bullseye }}
 

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -66,7 +66,7 @@ jobs:
       controller-preserve-runner-pods: true
     secrets: inherit
 
-  build-vms:
+  build-test-vm:
     needs: get-tag
     uses: ./.github/workflows/build-test-vm.yaml
     with:
@@ -75,7 +75,7 @@ jobs:
     secrets: inherit
 
   e2e-tests:
-    needs: [ build-images, build-vms ]
+    needs: [ build-images, build-test-vm ]
     strategy:
       fail-fast: false
       matrix:
@@ -164,7 +164,7 @@ jobs:
 
       - name: load e2e test vm image
         env:
-          TEST_IMAGE: ${{ needs.build-vms.outputs.vm-postgres-15-bullseye }}
+          TEST_IMAGE: ${{ needs.build-test-vm.outputs.vm-postgres-15-bullseye }}
         timeout-minutes: 2
         run: |
           # Pull the docker image so we can re-tag it, because using a consistent tag inside the

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -115,7 +115,7 @@ jobs:
           IMG_AUTOSCALER_AGENT: ${{ needs.build-images.outputs.autoscaler-agent }}
 
       - name: upload manifests
-        if: ${{ inputs.push-yamls }}
+        if: ${{ inputs.push-yamls == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: rendered_manifests

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -39,7 +39,7 @@ jobs:
   get-tag:
     outputs:
       tag: ${{ inputs.tag || steps.get-tag.outputs.tag }}
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: ubuntu-latest
     steps:
       - name: get tag
         if: ${{ inputs.tag == '' }}

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -29,7 +29,6 @@ on:
         required: false
 
 env:
-  PRESERVE_RUNNER_PODS: "true"
   IMG_E2E_TEST: vm-postgres:15-bullseye
 
 defaults:
@@ -61,6 +60,10 @@ jobs:
       skip: ${{ inputs.tag != '' }}
       tag: ${{ inputs.tag || needs.get-tag.outputs.tag }}
       kernel-image: ${{ inputs.kernel-image }}
+      # note: setting to preserve runner pods will mean that if !skip, they'll be built with those
+      # settings and used properly in the tests. But if skip (because inputs.tag != ''), then this
+      # setting will have no effect and the release images will be normal.
+      controller-preserve-runner-pods: true
     secrets: inherit
 
   build-vms:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -169,7 +169,7 @@ jobs:
           # cluster means we can avoid dynamically editing the image used in the kuttl files.
           docker pull "$TEST_IMAGE"
           docker image tag "$TEST_IMAGE" "$IMG_E2E_TEST"
-          make load-test-vm
+          make load-example-vms
 
       - run: make e2e
         timeout-minutes: 15

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -105,7 +105,6 @@ jobs:
           kind version
           kuttl version
           docker version
-          docker buildx version
 
       - run: make render-release
         env:

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -17,23 +17,62 @@ on:
           - k3d
           - kind
         default: k3d
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        description: 'Tag to use for images, skipping building'
+        required: false
+      push_yamls:
+        type: boolean
+        description: 'If true, pushes a tarball containing the rendered yaml manifests as an artifact'
+        required: false
 
 env:
   PRESERVE_RUNNER_PODS: "true"
+  IMG_E2E_TEST: vm-postgres:15-bullseye
 
 defaults:
   run:
     shell: bash -euo pipefail {0}
 
 jobs:
-  vm-kernel:
-    uses: ./.github/workflows/vm-kernel.yaml
+  get-tag:
+    outputs:
+      tag: ${{ inputs.tag || steps.get-tag.outputs.tag }}
+    runs-on: [ self-hosted, gen3, small ]
+    steps:
+      - uses: actions/checkout@v3
+        if: ${{ inputs.tag == '' }}
+      - name: get tag
+        if: ${{ inputs.tag == '' }}
+        id: get-tag
+        env:
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          test -n "$SHA"
+          sha="${SHA::7}"
+          echo "tag=$sha.$GITHUB_RUN_ID" | tee -a $GITHUB_OUTPUT
+
+  build-images:
+    needs: get-tag
+    uses: ./.github/workflows/build-images.yaml
     with:
-      return-image-for-tag: ${{ inputs.kernel-image }}
+      skip: ${{ inputs.tag != '' }}
+      tag: ${{ inputs.tag || needs.get-tag.outputs.tag }}
+      kernel-image: ${{ inputs.kernel-image }}
+    secrets: inherit
+
+  build-vms:
+    needs: get-tag
+    uses: ./.github/workflows/build-test-vm.yaml
+    with:
+      skip: ${{ inputs.tag != '' }}
+      tag: ${{ inputs.tag || needs.get-tag.outputs.tag }}
     secrets: inherit
 
   e2e-tests:
-    needs: vm-kernel
+    needs: [ build-images, build-vms ]
     strategy:
       fail-fast: false
       matrix:
@@ -53,8 +92,6 @@ jobs:
         # Sometimes setup-go gets stuck. Without this, it'll keep going until the job gets killed
         timeout-minutes: 10
 
-      - uses: docker/setup-buildx-action@v2
-
       - name: Install dependencies
         run: |
           make e2e-tools
@@ -69,31 +106,70 @@ jobs:
           docker version
           docker buildx version
 
-      - name: Load VM kernel
+      - run: make render-release
         env:
-          IMAGE: ${{ needs.vm-kernel.outputs.image }}
+          IMG_CONTROLLER:       ${{ needs.build-images.outputs.controller }}
+          IMG_VXLAN_CONTROLLER: ${{ needs.build-images.outputs.vxlan-controller }}
+          IMG_RUNNER:           ${{ needs.build-images.outputs.runner }}
+          IMG_SCHEDULER:        ${{ needs.build-images.outputs.scheduler }}
+          IMG_AUTOSCALER_AGENT: ${{ needs.build-images.outputs.autoscaler-agent }}
+
+      - name: upload manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: rendered_manifests
+          # nb: prefix before wildcard is removed from the uploaded files, so the artifact should
+          # contain e.g.
+          #   - autoscale-scheduler.yaml
+          #   - autoscaler-agent.yaml
+          #   ...
+          # ref https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions
+          path: rendered_manifests/*
+          if-no-files-found: error
+          retention-days: 2 # minimum is 1 day; 0 is default. These are only used temporarily.
+
+      # Use custom DOCKER_CONFIG directory to avoid conflicts with default settings
+      # The default value is ~/.docker
+      - name: set custom docker config directory
         run: |
-          docker pull --quiet $IMAGE
-          ID=$(docker create $IMAGE true)
-          docker cp ${ID}:/vmlinuz neonvm/hack/kernel/vmlinuz
-          docker rm -f ${ID}
-
-      # our docker builds use the output of 'git describe' for embedding git information
-      - run: git describe --long --dirty
-
-      # Explicitly build all the images beforehand. Building images while the cluster is up can
-      # sometimes affect the cluster. For more information:
-      # https://github.com/neondatabase/autoscaling/issues/120#issuecomment-1493405844
-      - run: make build
-      - run: make docker-build
-      - run: make docker-build-examples
+          mkdir -p .docker-custom
+          echo DOCKER_CONFIG=$(pwd)/.docker-custom >> $GITHUB_ENV
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
       - run: make ${{ matrix.cluster }}-setup
 
-      - run: make deploy
-        timeout-minutes: 10
-      - run: make example-vms
-        timeout-minutes: 10
+      - name: deploy components
+        timeout-minutes: 3
+        run: |
+          rendered () { echo "rendered_manifests/$1"; }
+
+          kubectl apply -f $(rendered multus.yaml)
+          kubectl -n kube-system rollout status daemonset kube-multus-ds
+          kubectl apply -f $(rendered whereabouts.yaml)
+          kubectl -n kube-system rollout status daemonset whereabouts
+          kubectl apply -f $(rendered neonvm.yaml)
+          kubectl -n neonvm-system rollout status daemonset  neonvm-device-plugin
+          kubectl -n neonvm-system rollout status daemonset  neonvm-vxlan-controller
+          kubectl -n neonvm-system rollout status deployment neonvm-controller
+          kubectl apply -f $(rendered autoscale-scheduler.yaml)
+          kubectl -n kube-system rollout status deployment autoscale-scheduler
+          kubectl apply -f $(rendered autoscaler-agent.yaml)
+          kubectl -n kube-system rollout status daemonset autoscaler-agent
+
+      - name: load e2e test vm image
+        env:
+          TEST_IMAGE: ${{ needs.build-vms.outputs.vm-postgres-15-bullseye }}
+        timeout-minutes: 2
+        run: |
+          # Pull the docker image so we can re-tag it, because using a consistent tag inside the
+          # cluster means we can avoid dynamically editing the image used in the kuttl files.
+          docker pull "$TEST_IMAGE"
+          docker image tag "$TEST_IMAGE" "$IMG_E2E_TEST"
+          make load-test-vm
+
       - run: make e2e
         timeout-minutes: 15
 

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -41,8 +41,6 @@ jobs:
       tag: ${{ inputs.tag || steps.get-tag.outputs.tag }}
     runs-on: [ self-hosted, gen3, small ]
     steps:
-      - uses: actions/checkout@v3
-        if: ${{ inputs.tag == '' }}
       - name: get tag
         if: ${{ inputs.tag == '' }}
         id: get-tag

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -23,7 +23,7 @@ on:
         type: string
         description: 'Tag to use for images, skipping building'
         required: false
-      push_yamls:
+      push-yamls:
         type: boolean
         description: 'If true, pushes a tarball containing the rendered yaml manifests as an artifact'
         required: false
@@ -118,6 +118,7 @@ jobs:
           IMG_AUTOSCALER_AGENT: ${{ needs.build-images.outputs.autoscaler-agent }}
 
       - name: upload manifests
+        if: ${{ inputs.push-yamls }}
         uses: actions/upload-artifact@v4
         with:
           name: rendered_manifests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,10 @@ on:
 env:
   DRY_RUN: "true"
 
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
 jobs:
   get-tag:
     outputs:
@@ -22,8 +26,7 @@ jobs:
           SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
           if [ "$DRY_RUN" = 'true' ]; then
-            test -n "$SHA"
-            sha="${SHA::7}}
+            sha="${SHA::7}"
             day="$(date -u '+%+4Y%m%d')" # equivalent to %F (e.g. '2024-01-19') with no dashes (e.g. '20240119')
             echo "tag=testrelease-$day.$sha.$GITHUB_RUN_ID" | tee -a $GITHUB_OUTPUT
           else

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       build-cluster-autoscaler: true
     secrets: inherit
 
-  build-vms:
+  build-test-vm:
     uses: ./.github/workflows/build-test-vm.yaml
     needs: get-tag
     with:
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit
 
   e2e:
-    needs: [ get-tag, build-images, build-vms ]
+    needs: [ get-tag, build-images, build-test-vm ]
     uses: ./.github/workflows/e2e-test.yaml
     with:
       tag: ${{ needs.get-tag.outputs.tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 name: release
 on:
+  pull_request:
   push:
     tags:
       - "v*.*.*"
@@ -8,7 +9,8 @@ jobs:
   build-images:
     uses: ./.github/workflows/build-images.yaml
     with:
-      tag: ${{ github.ref_name }}
+      # tag: ${{ github.ref_name }}
+      tag: testrelease-20240119.${{ github.event.pull_request.head.sha}}
       kernel-image: ${{ inputs.kernel-image }}
       build-cluster-autoscaler: true
     secrets: inherit
@@ -16,7 +18,8 @@ jobs:
   build-vms:
     uses: ./.github/workflows/build-test-vm.yaml
     with:
-      tag: ${{ github.ref_name }}
+      # tag: ${{ github.ref_name }}
+      tag: testrelease-20240119.${{ github.event.pull_request.head.sha}}
       upload-vm-builder: true
     secrets: inherit
 
@@ -24,7 +27,8 @@ jobs:
     needs: [ build-images, build-vms ]
     uses: ./.github/workflows/e2e-test.yaml
     with:
-      tag: ${{ github.ref_name }}
+      # tag: ${{ github.ref_name }}
+      tag: testrelease-20240119.${{ github.event.pull_request.head.sha}}
       push-yamls: true
     secrets: inherit
 
@@ -48,16 +52,19 @@ jobs:
           # See e2e-test.yaml: the individual yamls are flattened inside the artifact.
           path: rendered_manifests
 
-      - name: github release
-        uses: softprops/action-gh-release@v1
-        with:
-          fail_on_unmatched_files: true
-          files: |
-            vm-builder
-            rendered_manifests/autoscale-scheduler.yaml
-            rendered_manifests/autoscaler-agent.yaml
-            rendered_manifests/neonvm.yaml
-            rendered_manifests/multus.yaml
-            rendered_manifests/multus-eks.yaml
-            rendered_manifests/whereabouts.yaml
-            deploy/vmscrape.yaml
+      - name: show files
+        run: ls -R .
+
+      # - name: github release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     fail_on_unmatched_files: true
+      #     files: |
+      #       vm-builder
+      #       rendered_manifests/autoscale-scheduler.yaml
+      #       rendered_manifests/autoscaler-agent.yaml
+      #       rendered_manifests/neonvm.yaml
+      #       rendered_manifests/multus.yaml
+      #       rendered_manifests/multus-eks.yaml
+      #       rendered_manifests/whereabouts.yaml
+      #       deploy/vmscrape.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,170 +4,56 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  AGENT_IMAGE: "neondatabase/autoscaler-agent"
-  SCHED_IMAGE: "neondatabase/autoscale-scheduler"
-
-  KUSTOMIZE_VERSION:        "4.5.7"
-  CONTROLLER_TOOLS_VERSION: "0.10.0"
-  CODE_GENERATOR_VERSION:   "0.25.16"
-  IMG:                      "neondatabase/neonvm-controller"
-  IMG_VXLAN:                "neondatabase/neonvm-vxlan-controller"
-  IMG_RUNNER:               "neondatabase/neonvm-runner"
-  VM_KERNEL_IMAGE:          "neondatabase/vm-kernel"
-
-  CLUSTER_AUTOSCALER_IMAGE: "neondatabase/cluster-autoscaler-neonvm"
-
 jobs:
-  vm-kernel:
-    uses: ./.github/workflows/vm-kernel.yaml
+  build-images:
+    uses: ./.github/workflows/build-images.yaml
     with:
       tag: ${{ github.ref_name }}
+      kernel-image: ${{ inputs.kernel-image }}
+      build-cluster-autoscaler: true
+    secrets: inherit
+
+  build-vms:
+    uses: ./.github/workflows/build-test-vm.yaml
+    with:
+      tag: ${{ github.ref_name }}
+      upload-vm-builder: true
+    secrets: inherit
+
+  e2e:
+    needs: [ build-images, build-vms ]
+    uses: ./.github/workflows/e2e-test.yaml
+    with:
+      tag: ${{ github.ref_name }}
+      push-yamls: true
+    secrets: inherit
 
   release:
-    needs: vm-kernel
+    needs: e2e
     runs-on: [ self-hosted, gen3, large ]
     steps:
-      - name: git checkout
-        uses: actions/checkout@v3
-      - name: get version and git info
-        id: get_vcs_info
-        run: |
-          echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          echo -n "git_info=" >> $GITHUB_OUTPUT
-          # note: --tags enables matching on lightweight (i.e. not annotated) tags, which normally
-          # wouldn't be necessary, except that actions/checkout@v3 does weird things to setup the
-          # repository that means that we actually end up checked out with *just* a lightweight tag
-          # to the tagged commit.
-          git describe --tags --long --dirty >> $GITHUB_OUTPUT
-      - name: get CA base git tag
-        id: get_ca_tag
-        run: |
-          echo -n "ca_git_tag=" >> $GITHUB_OUTPUT
-          cat cluster-autoscaler/ca.tag >> $GITHUB_OUTPUT
-      - name: install golang
-        uses: actions/setup-go@v4
+      - uses: actions/checkout@v3
+
+      - name: download vm-builder
+        uses: actions/download-artifact@v4
         with:
-          go-version-file: 'go.mod'
-        timeout-minutes: 10
+          name: vm-builder
+          path: .
 
-      # Use custom DOCKER_CONFIG directory to avoid conflicts with default settings
-      # The default value is ~/.docker
-      - name: set custom docker config directory
-        run: |
-          mkdir -p .docker-custom
-          echo DOCKER_CONFIG=$(pwd)/.docker-custom >> $GITHUB_ENV
-
-      - name: check everything builds
-        run: go build ./...
-
-      - name: build binaries
-        run: |
-          make build
-
-      - name: docker - install qemu
-        uses: docker/setup-qemu-action@v2
-      - name: docker - setup buildx
-        uses: docker/setup-buildx-action@v2
-      - name: login to docker hub
-        uses: docker/login-action@v2
+      - name: download manifests
+        uses: actions/download-artifact@v4
         with:
-          username: ${{ secrets.NEON_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
-
-      - name: load vm kernel
-        env:
-          IMAGE: ${{ needs.vm-kernel.outputs.image }}
-        run: |
-          docker pull --quiet $IMAGE
-          ID=$(docker create $IMAGE true)
-          docker cp ${ID}:/vmlinuz neonvm/hack/kernel/vmlinuz
-          docker rm -f ${ID}
-
-      - name: build and push runner image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          file: neonvm/runner/Dockerfile
-          tags: ${{ env.IMG_RUNNER }}:${{ steps.get_vcs_info.outputs.version }}
-
-      - name: build and push controller image
-        uses: docker/build-push-action@v3
-        with:
-          build-args: VM_RUNNER_IMAGE=${{ env.IMG_RUNNER }}:${{ steps.get_vcs_info.outputs.version }}
-          context: .
-          platforms: linux/amd64
-          push: true
-          file: neonvm/Dockerfile
-          tags: ${{ env.IMG }}:${{ steps.get_vcs_info.outputs.version }}
-
-      - name: build and push vxlan controller image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          file: neonvm/tools/vxlan/Dockerfile
-          tags: ${{ env.IMG_VXLAN }}:${{ steps.get_vcs_info.outputs.version }}
-
-      - name: build and push autoscale-scheduler image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          file: build/autoscale-scheduler/Dockerfile
-          tags: ${{ env.SCHED_IMAGE }}:${{ steps.get_vcs_info.outputs.version }}
-          build-args: |
-            GIT_INFO=${{ steps.get_vcs_info.outputs.git_info }}
-
-      - name: build and push autoscaler-agent image
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          file: build/autoscaler-agent/Dockerfile
-          tags: ${{ env.AGENT_IMAGE }}:${{ steps.get_vcs_info.outputs.version }}
-          build-args: |
-            GIT_INFO=${{ steps.get_vcs_info.outputs.git_info }}
-
-      - name: render kubernetes resources
-        uses: stefanprodan/kube-tools@v1
-        with:
-          kustomize: ${{ env.KUSTOMIZE_VERSION }}
-          command: |
-            kustomize version --short
-            cd ${GITHUB_WORKSPACE}/neonvm/config/common/controller && kustomize edit set image controller=${{ env.IMG }}:${{ steps.get_vcs_info.outputs.version }}
-            cd ${GITHUB_WORKSPACE}/neonvm/config/default-vxlan/vxlan-controller && kustomize edit set image vxlan-controller=${{ env.IMG_VXLAN }}:${{ steps.get_vcs_info.outputs.version }}
-            cd ${GITHUB_WORKSPACE}/deploy/scheduler && kustomize edit set image autoscale-scheduler=${{ env.SCHED_IMAGE }}:${{ steps.get_vcs_info.outputs.version }}
-            cd ${GITHUB_WORKSPACE}/deploy/agent && kustomize edit set image autoscaler-agent=${{ env.AGENT_IMAGE }}:${{ steps.get_vcs_info.outputs.version }}
-            cd ${GITHUB_WORKSPACE}
-            mkdir -p rendered_manifests
-            kustomize build neonvm/config/default-vxlan/whereabouts > rendered_manifests/whereabouts.yaml
-            kustomize build neonvm/config/default-vxlan/multus-eks > rendered_manifests/multus-eks.yaml
-            kustomize build neonvm/config/default-vxlan/multus > rendered_manifests/multus.yaml
-            kustomize build neonvm/config/default-vxlan > rendered_manifests/neonvm.yaml
-            kustomize build deploy/scheduler > rendered_manifests/autoscale-scheduler.yaml
-            kustomize build deploy/agent > rendered_manifests/autoscaler-agent.yaml
-
-      - name: build and push cluster-autoscaler image
-        uses: docker/build-push-action@v3
-        with:
-          tags: ${{ env.CLUSTER_AUTOSCALER_IMAGE }}:${{ steps.get_vcs_info.outputs.version }}
-          context: cluster-autoscaler
-          push: true
-          build-args: |
-            CA_GIT_TAG=${{ steps.get_ca_tag.outputs.ca_git_tag }}
+          name: rendered_manifests
+          # files in the artifact will be expanded into the directory 'rendered_manifests'.
+          # See e2e-test.yaml: the individual yamls are flattened inside the artifact.
+          path: rendered_manifests
 
       - name: github release
         uses: softprops/action-gh-release@v1
         with:
           fail_on_unmatched_files: true
           files: |
-            bin/vm-builder
+            vm-builder
             rendered_manifests/autoscale-scheduler.yaml
             rendered_manifests/autoscaler-agent.yaml
             rendered_manifests/neonvm.yaml
@@ -175,8 +61,3 @@ jobs:
             rendered_manifests/multus-eks.yaml
             rendered_manifests/whereabouts.yaml
             deploy/vmscrape.yaml
-
-      - name: remove custom docker config directory
-        if: always()
-        run: |
-          rm -rf .docker-custom

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       tag: ${{ steps.get-tag.outputs.tag }}
       dry-run: ${{ steps.get-tag.outputs.dry-run }}
-    runs-on: [ self-hosted, gen3, small ]
+    runs-on: ubuntu-latest
     steps:
       - name: get tag
         id: get-tag
@@ -61,7 +61,7 @@ jobs:
 
   release:
     needs: [ get-tag, e2e ]
-    runs-on: [ self-hosted, gen3, large ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,6 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  DRY_RUN: "true"
-
 defaults:
   run:
     shell: bash -euo pipefail {0}
@@ -17,6 +14,7 @@ jobs:
   get-tag:
     outputs:
       tag: ${{ steps.get-tag.outputs.tag }}
+      dry-run: ${{ steps.get-tag.outputs.dry-run }}
     runs-on: [ self-hosted, gen3, small ]
     steps:
       - name: get tag
@@ -25,11 +23,15 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
-          if [ "$DRY_RUN" = 'true' ]; then
+          # note: github.ref_name is e.g. '748/merge' for a PR, or the name of the tag for a tag.
+          # Maybe we could use github.event_name for this, not sure.
+          if [[ "$REF_NAME" = */merge ]]; then
+            echo "dry-run=true" | tee -a $GITHUB_OUTPUT
             sha="${SHA::7}"
             day="$(date -u '+%+4Y%m%d')" # equivalent to %F (e.g. '2024-01-19') with no dashes (e.g. '20240119')
             echo "tag=testrelease-$day.$sha.$GITHUB_RUN_ID" | tee -a $GITHUB_OUTPUT
           else
+            echo "dry-run=false" | tee -a $GITHUB_OUTPUT
             echo "tag=$REF_NAME" | tee -a $GITHUB_OUTPUT
           fi
 
@@ -59,7 +61,7 @@ jobs:
     secrets: inherit
 
   release:
-    needs: e2e
+    needs: [ get-tag, e2e ]
     runs-on: [ self-hosted, gen3, large ]
     steps:
       - uses: actions/checkout@v3
@@ -79,7 +81,7 @@ jobs:
           path: rendered_manifests
 
       - name: show files
-        if: ${{ env.DRY_RUN == 'true' }}
+        if: ${{ needs.get-tag.outputs.dry-run == 'true' }}
         run: ls -R .
 
       # - name: github release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,34 +1,57 @@
 name: release
 on:
+  # UNCOMMENT TO ALLOW TESTING:
   pull_request:
   push:
     tags:
       - "v*.*.*"
 
+env:
+  DRY_RUN: "true"
+
 jobs:
+  get-tag:
+    outputs:
+      tag: ${{ steps.get-tag.outputs.tag }}
+    runs-on: [ self-hosted, gen3, small ]
+    steps:
+      - name: get tag
+        id: get-tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.event.pull_request.head.sha || '' }}
+        run: |
+          if [ "$DRY_RUN" = 'true' ]; then
+            test -n "$SHA"
+            sha="${SHA::7}}
+            day="$(date -u '+%+4Y%m%d')" # equivalent to %F (e.g. '2024-01-19') with no dashes (e.g. '20240119')
+            echo "tag=testrelease-$day.$sha.$GITHUB_RUN_ID" | tee -a $GITHUB_OUTPUT
+          else
+            echo "tag=$REF_NAME" | tee -a $GITHUB_OUTPUT
+          fi
+
   build-images:
     uses: ./.github/workflows/build-images.yaml
+    needs: get-tag
     with:
-      # tag: ${{ github.ref_name }}
-      tag: testrelease-20240119.${{ github.event.pull_request.head.sha}}
+      tag: ${{ needs.get-tag.outputs.tag }}
       kernel-image: ${{ inputs.kernel-image }}
       build-cluster-autoscaler: true
     secrets: inherit
 
   build-vms:
     uses: ./.github/workflows/build-test-vm.yaml
+    needs: get-tag
     with:
-      # tag: ${{ github.ref_name }}
-      tag: testrelease-20240119.${{ github.event.pull_request.head.sha}}
+      tag: ${{ needs.get-tag.outputs.tag }}
       upload-vm-builder: true
     secrets: inherit
 
   e2e:
-    needs: [ build-images, build-vms ]
+    needs: [ get-tag, build-images, build-vms ]
     uses: ./.github/workflows/e2e-test.yaml
     with:
-      # tag: ${{ github.ref_name }}
-      tag: testrelease-20240119.${{ github.event.pull_request.head.sha}}
+      tag: ${{ needs.get-tag.outputs.tag }}
       push-yamls: true
     secrets: inherit
 
@@ -53,6 +76,7 @@ jobs:
           path: rendered_manifests
 
       - name: show files
+        if: ${{ env.DRY_RUN == 'true' }}
         run: ls -R .
 
       # - name: github release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,6 @@ jobs:
     needs: get-tag
     with:
       tag: ${{ needs.get-tag.outputs.tag }}
-      kernel-image: ${{ inputs.kernel-image }}
       build-cluster-autoscaler: true
     secrets: inherit
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
-          # note: github.ref_name is e.g. '748/merge' for a PR, or the name of the tag for a tag.
-          # Maybe we could use github.event_name for this, not sure.
-          if [[ "$REF_NAME" = */merge ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             echo "dry-run=true" | tee -a $GITHUB_OUTPUT
             sha="${SHA::7}"
             day="$(date -u '+%+4Y%m%d')" # equivalent to %F (e.g. '2024-01-19') with no dashes (e.g. '20240119')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: release
 on:
-  # UNCOMMENT TO ALLOW TESTING:
-  pull_request:
+  # # UNCOMMENT TO ALLOW TESTING:
+  # pull_request:
   push:
     tags:
       - "v*.*.*"
@@ -80,20 +80,17 @@ jobs:
           # See e2e-test.yaml: the individual yamls are flattened inside the artifact.
           path: rendered_manifests
 
-      - name: show files
-        if: ${{ needs.get-tag.outputs.dry-run == 'true' }}
-        run: ls -R .
-
-      # - name: github release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     fail_on_unmatched_files: true
-      #     files: |
-      #       vm-builder
-      #       rendered_manifests/autoscale-scheduler.yaml
-      #       rendered_manifests/autoscaler-agent.yaml
-      #       rendered_manifests/neonvm.yaml
-      #       rendered_manifests/multus.yaml
-      #       rendered_manifests/multus-eks.yaml
-      #       rendered_manifests/whereabouts.yaml
-      #       deploy/vmscrape.yaml
+      - name: github release
+        if: ${{ needs.get-tag.outputs.dry-run == 'false' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            vm-builder
+            rendered_manifests/autoscale-scheduler.yaml
+            rendered_manifests/autoscaler-agent.yaml
+            rendered_manifests/neonvm.yaml
+            rendered_manifests/multus.yaml
+            rendered_manifests/multus-eks.yaml
+            rendered_manifests/whereabouts.yaml
+            deploy/vmscrape.yaml

--- a/Makefile
+++ b/Makefile
@@ -311,6 +311,11 @@ load-images: kubectl kind k3d docker-build ## Push docker images to the local ki
 	@if [ $$($(KUBECTL) config current-context) = k3d-$(CLUSTER_NAME) ]; then make k3d-load;  fi
 	@if [ $$($(KUBECTL) config current-context) = kind-$(CLUSTER_NAME) ];  then make kind-load; fi
 
+.PHONY: load-test-vm
+load-test-vm: ## Load the testing VM image to the kind/k3d cluster.
+	@if [ $$($(KUBECTL) config current-context) = k3d-$(CLUSTER_NAME) ]; then $(K3D) image import $(E2E_TESTS_VM_IMG) --cluster $(CLUSTER_NAME) --mode direct; fi
+	@if [ $$($(KUBECTL) config current-context) = kind-$(CLUSTER_NAME) ]; then $(KIND) load docker-image $(E2E_TESTS_VM_IMG) --name $(CLUSTER_NAME); fi
+
 .PHONY: example-vms
 example-vms: docker-build-examples kind k3d kubectl ## Build and push the testing VM images to the kind/k3d cluster.
 	@if [ $$($(KUBECTL) config current-context) = k3d-$(CLUSTER_NAME) ]; then $(K3D) image import $(E2E_TESTS_VM_IMG) --cluster $(CLUSTER_NAME) --mode direct; fi

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 # Image URL to use all building/pushing image targets
 IMG_CONTROLLER ?= controller:dev
+IMG_VXLAN_CONTROLLER ?= vxlan-controller:dev
 IMG_RUNNER ?= runner:dev
-IMG_VXLAN ?= vxlan-controller:dev
+IMG_SCHEDULER ?= autoscale-scheduler:dev
+IMG_AUTOSCALER_AGENT ?= autoscaler-agent:dev
 
-# Autoscaler related images
-AUTOSCALER_SCHEDULER_IMG ?= autoscale-scheduler:dev
-AUTOSCALER_AGENT_IMG ?= autoscaler-agent:dev
 E2E_TESTS_VM_IMG ?= vm-postgres:15-bullseye
 PG14_DISK_TEST_IMG ?= pg14-disk-test:dev
 
@@ -147,9 +146,9 @@ docker-build: docker-build-controller docker-build-runner docker-build-vxlan-con
 docker-push: docker-build ## Push docker images to docker registry
 	docker push -q $(IMG_CONTROLLER)
 	docker push -q $(IMG_RUNNER)
-	docker push -q $(IMG_VXLAN)
-	docker push -q $(AUTOSCALER_SCHEDULER_IMG)
-	docker push -q $(AUTOSCALER_AGENT_IMG)
+	docker push -q $(IMG_VXLAN_CONTROLLER)
+	docker push -q $(IMG_SCHEDULER)
+	docker push -q $(IMG_AUTOSCALER_AGENT)
 
 .PHONY: docker-build-controller
 docker-build-controller: ## Build docker image for NeonVM controller
@@ -161,12 +160,12 @@ docker-build-runner: ## Build docker image for NeonVM runner
 
 .PHONY: docker-build-vxlan-controller
 docker-build-vxlan-controller: ## Build docker image for NeonVM vxlan controller
-	docker build -t $(IMG_VXLAN) -f neonvm/tools/vxlan/Dockerfile .
+	docker build -t $(IMG_VXLAN_CONTROLLER) -f neonvm/tools/vxlan/Dockerfile .
 
 .PHONY: docker-build-autoscaler-agent
 docker-build-autoscaler-agent: ## Build docker image for autoscaler-agent
 	docker buildx build \
-		--tag $(AUTOSCALER_AGENT_IMG) \
+		--tag $(IMG_AUTOSCALER_AGENT) \
 		--load \
 		--build-arg "GIT_INFO=$(GIT_INFO)" \
 		--file build/autoscaler-agent/Dockerfile \
@@ -175,7 +174,7 @@ docker-build-autoscaler-agent: ## Build docker image for autoscaler-agent
 .PHONY: docker-build-scheduler
 docker-build-scheduler: ## Build docker image for (autoscaling) scheduler
 	docker buildx build \
-		--tag $(AUTOSCALER_SCHEDULER_IMG) \
+		--tag $(IMG_SCHEDULER) \
 		--load \
 		--build-arg "GIT_INFO=$(GIT_INFO)" \
 		--file build/autoscale-scheduler/Dockerfile \
@@ -256,9 +255,9 @@ $(RENDERED):
 render-manifests: $(RENDERED) kustomize
 	# Prepare:
 	cd neonvm/config/common/controller && $(KUSTOMIZE) edit set image controller=$(IMG_CONTROLLER) && $(KUSTOMIZE) edit add annotation buildtime:$(BUILDTS) --force
-	cd neonvm/config/default-vxlan/vxlan-controller && $(KUSTOMIZE) edit set image vxlan-controller=$(IMG_VXLAN) && $(KUSTOMIZE) edit add annotation buildtime:$(BUILDTS) --force
-	cd deploy/scheduler && $(KUSTOMIZE) edit set image autoscale-scheduler=$(AUTOSCALER_SCHEDULER_IMG) && $(KUSTOMIZE) edit add annotation buildtime:$(BUILDTS) --force
-	cd deploy/agent && $(KUSTOMIZE) edit set image autoscaler-agent=$(AUTOSCALER_AGENT_IMG) && $(KUSTOMIZE) edit add annotation buildtime:$(BUILDTS) --force
+	cd neonvm/config/default-vxlan/vxlan-controller && $(KUSTOMIZE) edit set image vxlan-controller=$(IMG_VXLAN_CONTROLLER) && $(KUSTOMIZE) edit add annotation buildtime:$(BUILDTS) --force
+	cd deploy/scheduler && $(KUSTOMIZE) edit set image autoscale-scheduler=$(IMG_SCHEDULER) && $(KUSTOMIZE) edit add annotation buildtime:$(BUILDTS) --force
+	cd deploy/agent && $(KUSTOMIZE) edit set image autoscaler-agent=$(IMG_AUTOSCALER_AGENT) && $(KUSTOMIZE) edit add annotation buildtime:$(BUILDTS) --force
 	# Build:
 	$(KUSTOMIZE) build neonvm/config/default-vxlan/whereabouts > $(RENDERED)/whereabouts.yaml
 	$(KUSTOMIZE) build neonvm/config/default-vxlan/multus-eks > $(RENDERED)/multus-eks.yaml
@@ -275,9 +274,9 @@ render-manifests: $(RENDERED) kustomize
 render-release: $(RENDERED) kustomize
 	# Prepare:
 	cd neonvm/config/common/controller && $(KUSTOMIZE) edit set image controller=$(IMG_CONTROLLER)
-	cd neonvm/config/default-vxlan/vxlan-controller && $(KUSTOMIZE) edit set image vxlan-controller=$(IMG_VXLAN)
-	cd deploy/scheduler && $(KUSTOMIZE) edit set image autoscale-scheduler=$(AUTOSCALER_SCHEDULER_IMG)
-	cd deploy/agent && $(KUSTOMIZE) edit set image autoscaler-agent=$(AUTOSCALER_AGENT_IMG)
+	cd neonvm/config/default-vxlan/vxlan-controller && $(KUSTOMIZE) edit set image vxlan-controller=$(IMG_VXLAN_CONTROLLER)
+	cd deploy/scheduler && $(KUSTOMIZE) edit set image autoscale-scheduler=$(IMG_SCHEDULER)
+	cd deploy/agent && $(KUSTOMIZE) edit set image autoscaler-agent=$(IMG_AUTOSCALER_AGENT)
 	# Build:
 	$(KUSTOMIZE) build neonvm/config/default-vxlan/whereabouts > $(RENDERED)/whereabouts.yaml
 	$(KUSTOMIZE) build neonvm/config/default-vxlan/multus-eks > $(RENDERED)/multus-eks.yaml
@@ -327,9 +326,9 @@ kind-load: kind # Push docker images to the kind cluster.
 	$(KIND) load docker-image \
 		$(IMG_CONTROLLER) \
 		$(IMG_RUNNER) \
-		$(IMG_VXLAN) \
-		$(AUTOSCALER_SCHEDULER_IMG) \
-		$(AUTOSCALER_AGENT_IMG) \
+		$(IMG_VXLAN_CONTROLLER) \
+		$(IMG_SCHEDULER) \
+		$(IMG_AUTOSCALER_AGENT) \
 		--name $(CLUSTER_NAME)
 
 .PHONY: k3d-load
@@ -337,9 +336,9 @@ k3d-load: k3d # Push docker images to the k3d cluster.
 	$(K3D) image import \
 		$(IMG_CONTROLLER) \
 		$(IMG_RUNNER) \
-		$(IMG_VXLAN) \
-		$(AUTOSCALER_SCHEDULER_IMG) \
-		$(AUTOSCALER_AGENT_IMG) \
+		$(IMG_VXLAN_CONTROLLER) \
+		$(IMG_SCHEDULER) \
+		$(IMG_AUTOSCALER_AGENT) \
 		--cluster $(CLUSTER_NAME) --mode direct
 
 ##@ End-to-End tests


### PR DESCRIPTION
Brief summary of changes:

1. Add new workflow `build-images.yaml` in that builds images and pushes them to dockerhub (e.g. neonvm-controller, autoscaler-agent, etc.)
2. Add new workflow `build-test-vm.yaml` that builds vm-builder and makes the postgres:15-bullseye VM image.
    - Also uploads vm-builder as an artifact if requested
3. In `e2e-test.yaml`, use images from (1) and (2)
    - Also uploads the rendered manifests as an artifact if requested
4. In `release.yaml`, use images from (1) and (2), run tests with (3), and use vm-builder and manifests from (1) and (3).
5. Adds `make load-example-vms` and equivalents, which load images without building

---

Pre-req for #580, should also help with #660 (+ unlocks ability to cache test VM image builds).

---

~~Absolutely no clue if this'll work, but hey.~~ it works!

Time taken for successful runs:

1. [8m7s](https://github.com/neondatabase/autoscaling/actions/runs/7580706491?pr=748)
2. [7m56s](https://github.com/neondatabase/autoscaling/actions/runs/7580777438?pr=748)
3. [22m6s](https://github.com/neondatabase/autoscaling/actions/runs/7586471547?pr=748), runtime 8m52s but spent a lot of time waiting on large runners
4. [24m20s](https://github.com/neondatabase/autoscaling/actions/runs/7586866987?pr=748), runtime 8m38s but spent a lot of time waiting on large runners (again)
5. [9m0s](https://github.com/neondatabase/autoscaling/actions/runs/7589995576?pr=748)
6. [9m59s](https://github.com/neondatabase/autoscaling/actions/runs/7590401818)
7. [10m20s](https://github.com/neondatabase/autoscaling/actions/runs/7590429497?pr=748)
8. [8m19s](https://github.com/neondatabase/autoscaling/actions/runs/7590639304?pr=748)
9. [10m52s](https://github.com/neondatabase/autoscaling/actions/runs/7590671328?pr=748)
10. [10m24s](https://github.com/neondatabase/autoscaling/actions/runs/7590671354?pr=748) (release dry-run)
11. [8m31s](https://github.com/neondatabase/autoscaling/actions/runs/7590841065?pr=748)
12. [10m40s](https://github.com/neondatabase/autoscaling/actions/runs/7590841081?pr=748) (release dry-run)
13. [8m49s](https://github.com/neondatabase/autoscaling/actions/runs/7590939672?pr=748)
14. [8m57s](https://github.com/neondatabase/autoscaling/actions/runs/7632219609?pr=748)

### Known issues

- [x] e2e-tests git tag doesn't use the correct commit hash
- [x] Kind of weird that we have this one-off makefile target.... if you have ideas, please suggest!
- [x] Calling from release workflow not yet tested

### Next steps

- Switch e2e-test job to small runner?
  - Go back to k3d _and_ kind tests? kind is much closer to EKS than k3d, so there's distinct benefits from this, actually
- Enable caching of build-test-vm, similar to vm-kernel