### PR TITLE
neonvm: Use container statuses, not pod phase, to trigger restart

### DIFF
--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -770,8 +770,15 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 			virtualmachine.Cleanup()
 			virtualmachine.Status.Phase = phase
 
-			shouldRestart := virtualmachine.Spec.RestartPolicy == vmv1.RestartPolicyAlways ||
-				(virtualmachine.Spec.RestartPolicy == vmv1.RestartPolicyOnFailure && virtualmachine.Status.Phase == vmv1.VmFailed)
+			var shouldRestart bool
+			switch virtualmachine.Spec.RestartPolicy {
+			case vmv1.RestartPolicyAlways:
+				shouldRestart = true
+			case vmv1.RestartPolicyOnFailure:
+				shouldRestart = virtualmachine.Status.Phase == vmv1.VmFailed
+			case vmv1.RestartPolicyNever:
+				shouldRestart = false
+			}
 
 			if shouldRestart {
 				log.Info("Restarting VM runner pod", "VM.Phase", virtualmachine.Status.Phase, "RestartPolicy", virtualmachine.Spec.RestartPolicy)

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -762,7 +762,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		// one is still running.
 		//
 		// Note that this is required because 'VmSucceeded' and 'VmFailed' are true if *at least
-		// one* container inside the runner pod has finished; the other may still be running.
+		// one* container inside the runner pod has finished; the VM itself may still be running.
 		if apierrors.IsNotFound(err) || runnerContainerStopped(vmRunner) {
 			// clean up status, but keep the phase; we'll use it below (and possibly keep it around to
 			// be visible to the user if we don't intend to restart).

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -429,7 +429,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 			return err
 		}
 		// runner pod found, check phase
-		switch runnerContainerStatus(vmRunner) {
+		switch runnerStatus(vmRunner) {
 		case runnerRunning:
 			virtualmachine.Status.PodIP = vmRunner.Status.PodIP
 			virtualmachine.Status.Phase = vmv1.VmRunning
@@ -489,7 +489,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		}
 
 		// runner pod found, check/update phase now
-		switch runnerContainerStatus(vmRunner) {
+		switch runnerStatus(vmRunner) {
 		case runnerRunning:
 			// update status by IP of runner pod
 			virtualmachine.Status.PodIP = vmRunner.Status.PodIP
@@ -609,7 +609,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		}
 
 		// runner pod found, check that it's still up:
-		switch runnerContainerStatus(vmRunner) {
+		switch runnerStatus(vmRunner) {
 		case runnerSucceeded:
 			virtualmachine.Status.Phase = vmv1.VmSucceeded
 			meta.SetStatusCondition(&virtualmachine.Status.Conditions,
@@ -797,7 +797,7 @@ const (
 	runnerSucceeded runnerStatusKind = "Succeeded"
 )
 
-func runnerContainerStatus(pod *corev1.Pod) runnerStatusKind {
+func runnerStatus(pod *corev1.Pod) runnerStatusKind {
 	switch pod.Status.Phase {
 	case "", corev1.PodPending:
 		return runnerPending

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -787,17 +787,17 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 	return nil
 }
 
-type runnerStatus string
+type runnerStatusKind string
 
 const (
-	runnerUnknown   runnerStatus = "Unknown"
-	runnerPending   runnerStatus = "Pending"
-	runnerRunning   runnerStatus = "Running"
-	runnerFailed    runnerStatus = "Failed"
-	runnerSucceeded runnerStatus = "Succeeded"
+	runnerUnknown   runnerStatusKind = "Unknown"
+	runnerPending   runnerStatusKind = "Pending"
+	runnerRunning   runnerStatusKind = "Running"
+	runnerFailed    runnerStatusKind = "Failed"
+	runnerSucceeded runnerStatusKind = "Succeeded"
 )
 
-func runnerContainerStatus(pod *corev1.Pod) runnerStatus {
+func runnerContainerStatus(pod *corev1.Pod) runnerStatusKind {
 	switch pod.Status.Phase {
 	case "", corev1.PodPending:
 		return runnerPending

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -297,7 +297,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 		}
 
 		// now inspect target pod status and update migration
-		switch runnerContainerStatus(targetRunner) {
+		switch runnerStatus(targetRunner) {
 		case runnerRunning:
 			// update migration status
 			migration.Status.SourcePodName = vm.Status.PodName


### PR DESCRIPTION
Extracted from #738, which adds a second container to the runner pods. Because of that second container, if only one container exits, the pod will still have `.status.phase = Running`, so we need to proactively notice that one of the containers has stopped and propagate that status to the VM itself.

This also introduces some funky logic around how we handle restarts: Because the `Succeeded` and `Failed` phases no longer imply that QMEU itself has stopped, we need to explicitly wait until either the pod is gone or the neonvm-runner container has stopped; otherwise we could end up with >1 instance of the VM running at a time.

---

Tested locally as part of #738 and validated that it has the intended effect and works as expected when I `kubectl exec <pod> -c <container> -- kill 1`.

NB: Some follow-up changes in #754 building on this. See there for details.