### PR TITLE
agent,plugin: Remove unused metrics from api.Metrics

### DIFF
--- a/pkg/agent/core/metrics.go
+++ b/pkg/agent/core/metrics.go
@@ -12,15 +12,14 @@ import (
 
 type Metrics struct {
 	LoadAverage1Min  float32
-	LoadAverage5Min  float32 // unused. To be removed when api.Metrics.LoadAverage5Min is removed.
 	MemoryUsageBytes float32
 }
 
 func (m Metrics) ToAPI() api.Metrics {
 	return api.Metrics{
 		LoadAverage1Min:  m.LoadAverage1Min,
-		LoadAverage5Min:  m.LoadAverage5Min,
-		MemoryUsageBytes: m.MemoryUsageBytes,
+		LoadAverage5Min:  nil,
+		MemoryUsageBytes: nil,
 	}
 }
 
@@ -62,10 +61,6 @@ func ReadMetrics(nodeExporterOutput []byte, loadPrefix string) (m Metrics, err e
 	}
 
 	m.LoadAverage1Min, err = getField(loadPrefix+"load1", loadPrefix+"load15")
-	if err != nil {
-		return
-	}
-	m.LoadAverage5Min, err = getField(loadPrefix+"load5", "")
 	if err != nil {
 		return
 	}

--- a/pkg/agent/core/state_test.go
+++ b/pkg/agent/core/state_test.go
@@ -415,7 +415,6 @@ func TestPeriodicPluginRequest(t *testing.T) {
 
 	metrics := core.Metrics{
 		LoadAverage1Min:  0.0,
-		LoadAverage5Min:  0.0,
 		MemoryUsageBytes: 0.0,
 	}
 	resources := DefaultComputeUnit
@@ -497,7 +496,6 @@ func TestDeniedDownscalingIncreaseAndRetry(t *testing.T) {
 	clockTick()
 	metrics := core.Metrics{
 		LoadAverage1Min:  0.0,
-		LoadAverage5Min:  0.0,
 		MemoryUsageBytes: 0.0,
 	}
 	a.Do(state.UpdateMetrics, metrics)
@@ -758,7 +756,6 @@ func TestRequestedUpscale(t *testing.T) {
 	clockTick()
 	lastMetrics := core.Metrics{
 		LoadAverage1Min:  0.0,
-		LoadAverage5Min:  0.0, // unused
 		MemoryUsageBytes: 0.0,
 	}
 	a.Do(state.UpdateMetrics, lastMetrics)
@@ -879,12 +876,10 @@ func TestDownscalePivotBack(t *testing.T) {
 
 	initialMetrics := core.Metrics{
 		LoadAverage1Min:  0.0,
-		LoadAverage5Min:  0.0,
 		MemoryUsageBytes: 0.0,
 	}
 	newMetrics := core.Metrics{
 		LoadAverage1Min:  0.3,
-		LoadAverage5Min:  0.0,
 		MemoryUsageBytes: 0.0,
 	}
 
@@ -1080,7 +1075,6 @@ func TestBoundsChangeRequiresDownsale(t *testing.T) {
 	// Set metrics so the desired resources are still 2 CU
 	metrics := core.Metrics{
 		LoadAverage1Min:  0.3,
-		LoadAverage5Min:  0.0,
 		MemoryUsageBytes: 0.0,
 	}
 	a.Do(state.UpdateMetrics, metrics)
@@ -1175,7 +1169,6 @@ func TestBoundsChangeRequiresUpscale(t *testing.T) {
 	// Set metrics so the desired resources are still 2 CU
 	metrics := core.Metrics{
 		LoadAverage1Min:  0.3,
-		LoadAverage5Min:  0.0,
 		MemoryUsageBytes: 0.0,
 	}
 	a.Do(state.UpdateMetrics, metrics)
@@ -1271,7 +1264,6 @@ func TestFailedRequestRetry(t *testing.T) {
 	clockTick()
 	metrics := core.Metrics{
 		LoadAverage1Min:  0.3,
-		LoadAverage5Min:  0.0, // unused
 		MemoryUsageBytes: 0.0,
 	}
 	a.Do(state.UpdateMetrics, metrics)

--- a/pkg/agent/core/state_test.go
+++ b/pkg/agent/core/state_test.go
@@ -34,7 +34,6 @@ func Test_DesiredResourcesFromMetricsOrRequestedUpscaling(t *testing.T) {
 			name: "BasicScaleup",
 			metrics: core.Metrics{
 				LoadAverage1Min:  0.30,
-				LoadAverage5Min:  0.0, // unused
 				MemoryUsageBytes: 0.0,
 			},
 			vmUsing:           api.Resources{VCPU: 250, Mem: 1 * slotSize},
@@ -49,7 +48,6 @@ func Test_DesiredResourcesFromMetricsOrRequestedUpscaling(t *testing.T) {
 			name: "MismatchedApprovedNoScaledown",
 			metrics: core.Metrics{
 				LoadAverage1Min:  0.0, // ordinarily would like to scale down
-				LoadAverage5Min:  0.0,
 				MemoryUsageBytes: 0.0,
 			},
 			vmUsing:           api.Resources{VCPU: 250, Mem: 2 * slotSize},
@@ -66,7 +64,6 @@ func Test_DesiredResourcesFromMetricsOrRequestedUpscaling(t *testing.T) {
 			name: "MismatchedApprovedNoScaledownButVMAtMaximum",
 			metrics: core.Metrics{
 				LoadAverage1Min:  0.0, // ordinarily would like to scale down
-				LoadAverage5Min:  0.0,
 				MemoryUsageBytes: 0.0,
 			},
 			vmUsing:           api.Resources{VCPU: 1000, Mem: 5 * slotSize}, // note: mem greater than maximum. It can happen when scaling bounds change
@@ -265,7 +262,6 @@ func TestBasicScaleUpAndDownFlow(t *testing.T) {
 	clockTick().AssertEquals(duration("0.2s"))
 	lastMetrics := core.Metrics{
 		LoadAverage1Min:  0.3,
-		LoadAverage5Min:  0.0, // unused
 		MemoryUsageBytes: 0.0,
 	}
 	a.Do(state.UpdateMetrics, lastMetrics)
@@ -342,7 +338,6 @@ func TestBasicScaleUpAndDownFlow(t *testing.T) {
 	// Set metrics back so that desired resources should now be zero
 	lastMetrics = core.Metrics{
 		LoadAverage1Min:  0.0,
-		LoadAverage5Min:  0.0, // unused
 		MemoryUsageBytes: 0.0,
 	}
 	a.Do(state.UpdateMetrics, lastMetrics)
@@ -1419,7 +1414,6 @@ func TestMetricsConcurrentUpdatedDuringDownscale(t *testing.T) {
 	// the actual metrics we got in the actual logs
 	metrics := core.Metrics{
 		LoadAverage1Min:  0.0,
-		LoadAverage5Min:  0.0,
 		MemoryUsageBytes: 150589570, // 143.6 MiB
 	}
 	a.Do(state.UpdateMetrics, metrics)

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -44,7 +44,7 @@ import (
 //
 // Currently, each autoscaler-agent supports only one version at a time. In the future, this may
 // change.
-const PluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV4_0
+const PluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV5_0
 
 // Runner is per-VM Pod god object responsible for handling everything
 //

--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -40,7 +40,7 @@ number.
 
 | Release | autoscaler-agent | Scheduler plugin |
 |---------|------------------|------------------|
-| _Current_ | v4.0 only | v3.0-v4.0 |
+| _Current_ | v4.0 only | **v3.0-v5.0** |
 | v0.27.0 | v4.0 only | v3.0-v4.0 |
 | v0.26.0 | v4.0 only | **v3.0-v4.0** |
 | v0.25.0 | v4.0 only | v1.0-v4.0 |

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -78,8 +78,17 @@ const (
 	// * Memory quantities now use "number of bytes" instead of "number of memory slots"
 	// * Adds AgentRequest.ComputeUnit
 	//
-	// Currently the latest version.
+	// Last used in release version v0.27.0.
 	PluginProtoV4_0
+
+	// PluginProtoV5_0 represents v5.0 of the agent<->scheduler plugin protocol.
+	//
+	// Changes from v4.0:
+	//
+	// * Removed AgentRequest.metrics fields loadAvg5M and memoryUsageBytes
+	//
+	// Currently the latest version.
+	PluginProtoV5_0
 
 	// latestPluginProtoVersion represents the latest version of the agent<->scheduler plugin
 	// protocol
@@ -108,6 +117,8 @@ func (v PluginProtoVersion) String() string {
 		return "v3.0"
 	case PluginProtoV4_0:
 		return "v4.0"
+	case PluginProtoV5_0:
+		return "v5.0"
 	default:
 		diff := v - latestPluginProtoVersion
 		return fmt.Sprintf("<unknown = %v + %d>", latestPluginProtoVersion, diff)
@@ -155,6 +166,14 @@ func (v PluginProtoVersion) RepresentsMemoryAsBytes() bool {
 	return v >= PluginProtoV4_0
 }
 
+// IncludesExtendedMetrics returns whether this version of the protocol includes the AgentRequest's
+// metrics loadAvg5M and memoryUsageBytes.
+//
+// This is true for all versions below v4.0.
+func (v PluginProtoVersion) IncludesExtendedMetrics() bool {
+	return v < PluginProtoV4_0
+}
+
 // AgentRequest is the type of message sent from an autoscaler-agent to the scheduler plugin
 //
 // All AgentRequests expect a PluginResponse.
@@ -193,9 +212,11 @@ type AgentRequest struct {
 // Metrics gives the information pulled from vector.dev that the scheduler may use to prioritize
 // which pods it should migrate.
 type Metrics struct {
-	LoadAverage1Min  float32 `json:"loadAvg1M"`
-	LoadAverage5Min  float32 `json:"loadAvg5M"`
-	MemoryUsageBytes float32 `json:"memoryUsageBytes"`
+	LoadAverage1Min float32 `json:"loadAvg1M"`
+	// DEPRECATED. Will be removed in an upcoming release.
+	LoadAverage5Min *float32 `json:"loadAvg5M,omitempty"`
+	// DEPRECATED. Will be removed in an upcoming release.
+	MemoryUsageBytes *float32 `json:"memoryUsageBytes,omitempty"`
 }
 
 // ProtocolRange returns a VersionRange exactly equal to r.ProtoVersion


### PR DESCRIPTION
Ref https://github.com/neondatabase/autoscaling/pull/737#discussion_r1458396094

Basically, with the introduction of a secondary metrics type for internal use inside the autoscaler-agent, we can get rid of the other metrics that aren't used by the scheduler plugin.

This PR is the first step (making the fields pointers and omitempty); we'll have to do a follow-up to actually remove the fields.

---

~~NB: this PR builds on #892 and must not be merged before it.~~