### PR TITLE
lint: add actionlint

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - gen3
+    - large
+    - small

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,3 +96,17 @@ jobs:
         with:
           check_hidden: true
           skip: go.sum,*.patch # '*.patch' references cluster-autoscaler/ca.patch, but somehow skipping directly doesn't work...
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@54e8faeff91fe07595b1ad3cfdc6aee0157bf51b # v1.40.0
+        env:
+          # SC2046 - Quote this to prevent word splitting.                - https://www.shellcheck.net/wiki/SC2046
+          # SC2086 - Double quote to prevent globbing and word splitting. - https://www.shellcheck.net/wiki/SC2086
+          SHELLCHECK_OPTS: --exclude=SC2046,SC2086
+        with:
+          fail_on_error: true
+          filter_mode: nofilter
+          level: error

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
 jobs:
   golangci:
     name: golangci-lint
@@ -40,7 +44,7 @@ jobs:
           go mod tidy
       - name: check diff
         run: |
-          if ! (test -z "$(git ls-files --exclude-standard --others .)$(git diff .)"); then
+          if ! test -z "$(git ls-files --exclude-standard --others .)$(git diff .)"; then
             git ls-files --exclude-standard --others .
             git diff .
             echo "ERROR: 'go mod tidy' modified the source tree."
@@ -61,7 +65,7 @@ jobs:
           make manifests
       - name: check diff
         run: |
-          if ! (test -z "$(git ls-files --exclude-standard --others .)$(git diff .)"); then
+          if ! test -z "$(git ls-files --exclude-standard --others .)$(git diff .)"; then
             git ls-files --exclude-standard --others .
             git diff .
             echo "ERROR: 'make manifests' modified the source tree."
@@ -79,7 +83,7 @@ jobs:
           make generate
       - name: check diff
         run: |
-          if ! (test -z "$(git ls-files --exclude-standard --others .)$(git diff .)"); then
+          if ! test -z "$(git ls-files --exclude-standard --others .)$(git diff .)"; then
             git ls-files --exclude-standard --others .
             git diff .
             echo "ERROR: 'make generate' modified the source tree."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,13 +33,15 @@ jobs:
       - name: get version and git info
         id: get_vcs_info
         run: |
-          echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-          echo -n "git_info=" >> $GITHUB_OUTPUT
-          # note: --tags enables matching on lightweight (i.e. not annotated) tags, which normally
-          # wouldn't be necessary, except that actions/checkout@v3 does weird things to setup the
-          # repository that means that we actually end up checked out with *just* a lightweight tag
-          # to the tagged commit.
-          git describe --tags --long --dirty >> $GITHUB_OUTPUT
+          {
+            echo "version=${{ github.ref_name }}"
+            echo -n "git_info="
+            # note: --tags enables matching on lightweight (i.e. not annotated) tags, which normally
+            # wouldn't be necessary, except that actions/checkout@v3 does weird things to setup the
+            # repository that means that we actually end up checked out with *just* a lightweight tag
+            # to the tagged commit.
+            git describe --tags --long --dirty
+          } >> $GITHUB_OUTPUT
       - name: get CA base git tag
         id: get_ca_tag
         run: |

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -105,7 +105,7 @@ jobs:
           elif [ -z "${CACHED_IMAGE}" ]; then
             # there's no image to retag
             RETAG_NEEDED=false
-          elif [ -n "${FORCED_TAG}"]; then
+          elif [ -n "${FORCED_TAG}" ]; then
             # we're asked to return image for a specific tag, so no need to retag
             RETAG_NEEDED=false
           elif [ "${FORCE_REBUILD}" == "true" ]; then


### PR DESCRIPTION
This PR adds [`actionlint`](https://github.com/rhysd/actionlint), a linter for GitHub Workflow files.
It also checks inlined bash scripts with [`shellcheck`](https://www.shellcheck.net/).

I've disabled a couple of noisy `shellcheck` rules (`SC2046`, `SC2086`), which in most cases produce benign warnings.
The action itself copied from `neondatabase/neon` (https://github.com/neondatabase/neon/pull/5265).

Run it locally (you should have both `actionlint`, and `shellcheck` installed):
```bash
SHELLCHECK_OPTS=--exclude=SC2046,SC2086 actionlint
```
 