### PR TITLE
neonvm: Custom reconciler metrics

### DIFF
--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -1,0 +1,64 @@
+package controllers
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type ReconcilerMetrics struct {
+	failing *prometheus.GaugeVec
+}
+
+func MakeReconcilerMetrics() ReconcilerMetrics {
+	m := ReconcilerMetrics{
+		failing: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "failing",
+				Help: "number of failing objects",
+			},
+			[]string{"controller"},
+		),
+	}
+	metrics.Registry.MustRegister(m.failing)
+	return m
+}
+
+type wrappedReconciler struct {
+	ControllerName string
+	Reconciler     reconcile.Reconciler
+	Metrics        ReconcilerMetrics
+
+	lock    sync.Mutex
+	failing map[client.ObjectKey]struct{}
+}
+
+func WithMetrics(reconciler reconcile.Reconciler, rm ReconcilerMetrics, cntrlName string) reconcile.Reconciler {
+	return &wrappedReconciler{
+		ControllerName: cntrlName,
+		Reconciler:     reconciler,
+		Metrics:        rm,
+		lock:           sync.Mutex{},
+		failing:        make(map[client.ObjectKey]struct{}),
+	}
+}
+
+func (d *wrappedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	res, err := d.Reconciler.Reconcile(ctx, req)
+
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if err != nil {
+		d.failing[req.NamespacedName] = struct{}{}
+	} else {
+		delete(d.failing, req.NamespacedName)
+	}
+	d.Metrics.failing.WithLabelValues(d.ControllerName).Set(float64(len(d.failing)))
+
+	return res, err
+}

--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -53,9 +53,8 @@ func (d *wrappedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	res, err := d.Reconciler.Reconcile(ctx, req)
 
 	// This part is executed sequentially since we acquire a mutex lock. It
-	// should be quite fast since a mutex lock/unlock + 1 memory write takes
-	// ~60ns. Having 8 reconile workers, we wait at most 8*60=480ns to acquire
-	// the lock. I (@shayanh) preferred to go with the simplest implementation
+	// should be quite fast since a mutex lock/unlock + 2 memory writes takes less
+	// than 100ns. I (@shayanh) preferred to go with the simplest implementation
 	// as of now. For a more performant solution, if needed, we can switch to an
 	// async approach.
 	d.lock.Lock()

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -75,7 +75,7 @@ type VirtualMachineReconciler struct {
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
 
-	Metrics ReconcilerMetrics
+	Metrics ReconcilerMetrics `exhaustruct:"optional"`
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -74,6 +74,8 @@ type VirtualMachineReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	Metrics ReconcilerMetrics
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
@@ -1473,11 +1475,14 @@ func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret) (*co
 // Note that the Runner Pod will be also watched in order to ensure its
 // desirable state on the cluster
 func (r *VirtualMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	cntrlName := "virtualmachine"
+	reconciler := WithMetrics(r, r.Metrics, cntrlName)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachine{}).
 		Owns(&corev1.Pod{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 8}).
-		Complete(r)
+		Named(cntrlName).
+		Complete(reconciler)
 }
 
 func DeepEqual(v1, v2 interface{}) bool {

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -133,10 +134,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	reconcilerMetrics := controllers.MakeReconcilerMetrics()
+
 	if err = (&controllers.VirtualMachineReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("virtualmachine-controller"),
+		Metrics:  reconcilerMetrics,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachine")
 		os.Exit(1)
@@ -149,6 +153,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("virtualmachinemigration-controller"),
+		Metrics:  reconcilerMetrics,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachineMigration")
 		os.Exit(1)


### PR DESCRIPTION
Providing custom metrics for reconciler objects.

- `reconcile_failing_objects` represents the number of objects that are failing to reconcile for each specific controller.

Fixes #247 (along with #739).