### PR TITLE
CI: Fix e2e-tests failure from empty $SHA on main

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ inputs.tag == '' }}
         id: get-tag
         env:
-          SHA: ${{ github.event.pull_request.head.sha }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           test -n "$SHA"
           sha="${SHA::7}"


### PR DESCRIPTION
ref https://github.com/neondatabase/autoscaling/actions/runs/7673566092

`${{ github.event.pull_request }}` doesn't exist for 'push' events :facepalm: