### PR TITLE
runner: don't log i/o timeout

### DIFF
--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -843,6 +843,9 @@ func drainLogsReader(reader *bufio.Reader, logger *zap.Logger) error {
 
 		err = errors.Join(err, err2)
 		if err != nil {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				return nil
+			}
 			if errors.Is(err, io.EOF) {
 				logger.Warn("EOF while reading from log serial")
 			} else {


### PR DESCRIPTION
Last minute logging change in
  6addbdc (runner: pass logs through virtio-serial (#724), 2024-01-24)

Resulted in flooding logs with the following error message:
  "msg":"failed to read from log serial",
  "error":"read unix @->/vm/log.sock: i/o timeout",

Filtering for os.ErrDeadlineExceeded before logging fixes it.

Related to neondatabase/cloud#8602.