### PR TITLE
neonvm-controller: Make max concurrency configurable via CLI

### DIFF
--- a/neonvm/config/common/controller/manager.yaml
+++ b/neonvm/config/common/controller/manager.yaml
@@ -58,6 +58,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --concurrency-limit=8
         image: controller:dev
         name: manager
         securityContext:

--- a/neonvm/config/common/controller/manager.yaml
+++ b/neonvm/config/common/controller/manager.yaml
@@ -58,7 +58,6 @@ spec:
         - /manager
         args:
         - --leader-elect
-        - --concurrency-limit=8
         image: controller:dev
         name: manager
         securityContext:

--- a/neonvm/config/default-vxlan/manager_config_patch.yaml
+++ b/neonvm/config/default-vxlan/manager_config_patch.yaml
@@ -16,6 +16,7 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=:8080"
         - "--leader-elect"
+        - "--concurrency-limit=8"
         - "--zap-devel=false"
         - "--zap-time-encoding=iso8601"
         - "--zap-log-level=info"

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -76,6 +76,8 @@ type VirtualMachineReconciler struct {
 	Recorder record.EventRecorder
 
 	Metrics ReconcilerMetrics `exhaustruct:"optional"`
+
+	MaxConcurrentReconciles int
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
@@ -1482,7 +1484,7 @@ func (r *VirtualMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachine{}).
 		Owns(&corev1.Pod{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 8}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Named(cntrlName).
 		Complete(reconciler)
 }

--- a/neonvm/controllers/virtualmachine_controller_test.go
+++ b/neonvm/controllers/virtualmachine_controller_test.go
@@ -99,6 +99,8 @@ var _ = Describe("VirtualMachine controller", func() {
 				Client:   k8sClient,
 				Scheme:   k8sClient.Scheme(),
 				Recorder: nil,
+
+				MaxConcurrentReconciles: 1,
 			}
 
 			_, err = virtualmachineReconciler.Reconcile(ctx, reconcile.Request{

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -59,6 +59,8 @@ type VirtualMachineMigrationReconciler struct {
 	Recorder record.EventRecorder
 
 	Metrics ReconcilerMetrics
+
+	MaxConcurrentReconciles int
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
@@ -673,7 +675,7 @@ func (r *VirtualMachineMigrationReconciler) SetupWithManager(mgr ctrl.Manager) e
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachineMigration{}).
 		Owns(&corev1.Pod{}).
-		WithOptions(controller.Options{MaxConcurrentReconciles: 8}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Named(cntrlName).
 		Complete(reconciler)
 }

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -88,11 +88,13 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var concurrencyLimit int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.IntVar(&concurrencyLimit, "concurrency-limit", 1, "Maximum number of concurrent reconcile operations")
 	opts := zap.Options{ //nolint:exhaustruct // typical options struct; not all fields needed.
 		Development:     true,
 		StacktraceLevel: zapcore.Level(zapcore.PanicLevel),
@@ -140,6 +142,8 @@ func main() {
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("virtualmachine-controller"),
 		Metrics:  reconcilerMetrics,
+
+		MaxConcurrentReconciles: concurrencyLimit,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachine")
 		os.Exit(1)
@@ -153,6 +157,8 @@ func main() {
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("virtualmachinemigration-controller"),
 		Metrics:  reconcilerMetrics,
+
+		MaxConcurrentReconciles: concurrencyLimit,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VirtualMachineMigration")
 		os.Exit(1)


### PR DESCRIPTION
We noticed a couple prod regions are close to all capacity used w.r.t. the existing concurrency limits.

This PR intends to provide a low-risk way to allow tweaking the precise limit more quickly.

ref https://neondb.slack.com/archives/C03TN5G758R/p1706641824349959?thread_ts=1706160071.213319
ref https://neondb.slack.com/archives/C03TN5G758R/p1706646482943109