### PR TITLE
plugin: Make auto- live migration opt-in

### DIFF
--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -39,6 +39,6 @@ data:
         "timeoutSeconds": 5
       },
       "migrationDeletionRetrySeconds": 5,
-      "doMigration": false,
+      "doMigration": true,
       "randomizeScores": true
     }

--- a/pkg/agent/core/state.go
+++ b/pkg/agent/core/state.go
@@ -625,8 +625,8 @@ func (s *state) calculateMonitorDownscaleAction(
 }
 
 func (s *state) scalingConfig() api.ScalingConfig {
-	if s.VM.ScalingConfig != nil {
-		return *s.VM.ScalingConfig
+	if s.VM.Config.ScalingConfig != nil {
+		return *s.VM.Config.ScalingConfig
 	} else {
 		return s.Config.DefaultScalingConfig
 	}

--- a/pkg/agent/core/state_test.go
+++ b/pkg/agent/core/state_test.go
@@ -100,9 +100,11 @@ func Test_DesiredResourcesFromMetricsOrRequestedUpscaling(t *testing.T) {
 					Max:      4,
 				},
 				// remaining fields are also unused:
-				ScalingConfig:  nil,
-				AlwaysMigrate:  false,
-				ScalingEnabled: true,
+				Config: api.VmConfig{
+					AlwaysMigrate:  false,
+					ScalingEnabled: true,
+					ScalingConfig:  nil,
+				},
 			},
 			core.Config{
 				ComputeUnit: api.Resources{VCPU: 250, Mem: 1 * slotSize},

--- a/pkg/agent/core/state_test.go
+++ b/pkg/agent/core/state_test.go
@@ -101,9 +101,10 @@ func Test_DesiredResourcesFromMetricsOrRequestedUpscaling(t *testing.T) {
 				},
 				// remaining fields are also unused:
 				Config: api.VmConfig{
-					AlwaysMigrate:  false,
-					ScalingEnabled: true,
-					ScalingConfig:  nil,
+					AutoMigrationEnabled: false,
+					AlwaysMigrate:        false,
+					ScalingEnabled:       true,
+					ScalingConfig:        nil,
 				},
 			},
 			core.Config{

--- a/pkg/agent/core/testhelpers/construct.go
+++ b/pkg/agent/core/testhelpers/construct.go
@@ -80,9 +80,11 @@ func CreateVmInfo(config InitialVmInfoConfig, opts ...VmInfoOpt) api.VmInfo {
 			Use:      config.MinCU * uint16(config.ComputeUnit.Mem/config.MemorySlotSize),
 			Max:      config.MaxCU * uint16(config.ComputeUnit.Mem/config.MemorySlotSize),
 		},
-		ScalingConfig:  nil,
-		AlwaysMigrate:  false,
-		ScalingEnabled: true,
+		Config: api.VmConfig{
+			ScalingConfig:  nil,
+			AlwaysMigrate:  false,
+			ScalingEnabled: true,
+		},
 	}
 
 	for _, o := range opts {

--- a/pkg/agent/core/testhelpers/construct.go
+++ b/pkg/agent/core/testhelpers/construct.go
@@ -81,9 +81,10 @@ func CreateVmInfo(config InitialVmInfoConfig, opts ...VmInfoOpt) api.VmInfo {
 			Max:      config.MaxCU * uint16(config.ComputeUnit.Mem/config.MemorySlotSize),
 		},
 		Config: api.VmConfig{
-			ScalingConfig:  nil,
-			AlwaysMigrate:  false,
-			ScalingEnabled: true,
+			AutoMigrationEnabled: false,
+			AlwaysMigrate:        false,
+			ScalingConfig:        nil,
+			ScalingEnabled:       true,
 		},
 	}
 

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -113,6 +113,8 @@ func NewVmMemInfo(memSlots vmapi.MemorySlots, memSlotSize resource.Quantity) (*V
 // handling for a VM (e.g., AlwaysMigrate) or are expected to largely be the same for most VMs
 // (e.g., ScalingConfig).
 type VmConfig struct {
+	// AlwaysMigrate is a test-only debugging flag that, if present in the VM's labels, will always
+	// prompt it to migrate, regardless of whether the VM actually *needs* to.
 	AlwaysMigrate  bool           `json:"alwaysMigrate"`
 	ScalingEnabled bool           `json:"scalingEnabled"`
 	ScalingConfig  *ScalingConfig `json:"scalingConfig,omitempty"`

--- a/pkg/api/vminfo_test.go
+++ b/pkg/api/vminfo_test.go
@@ -27,16 +27,17 @@ func TestFormatting(t *testing.T) {
 			SlotSize: api.BytesFromResourceQuantity(slotSize),
 		},
 		Config: api.VmConfig{
-			AlwaysMigrate:  false,
-			ScalingEnabled: true,
+			AutoMigrationEnabled: true,
+			AlwaysMigrate:        false,
+			ScalingEnabled:       true,
 			ScalingConfig: &api.ScalingConfig{
 				LoadAverageFractionTarget: 0.7,
 				MemoryUsageFractionTarget: 0.7,
 			},
 		},
 	})
-	defaultFormat := "{Name:foo Namespace:bar Cpu:{Min:1 Max:5 Use:3.75} Mem:{Min:2 Max:6 Use:4 SlotSize:1Gi} Config:{AlwaysMigrate:false ScalingEnabled:true ScalingConfig:&{LoadAverageFractionTarget:0.7 MemoryUsageFractionTarget:0.7}}}"
-	goSyntaxRepr := `api.VmInfo{Name:"foo", Namespace:"bar", Cpu:api.VmCpuInfo{Min:api.MilliCPU(1000), Max:api.MilliCPU(5000), Use:api.MilliCPU(3750)}, Mem:api.VmMemInfo{Min:2, Max:6, Use:4, SlotSize:1073741824}, Config:api.VmConfig{AlwaysMigrate:false, ScalingEnabled:true, ScalingConfig:&api.ScalingConfig{LoadAverageFractionTarget:0.7, MemoryUsageFractionTarget:0.7}}}`
+	defaultFormat := "{Name:foo Namespace:bar Cpu:{Min:1 Max:5 Use:3.75} Mem:{Min:2 Max:6 Use:4 SlotSize:1Gi} Config:{AutoMigrationEnabled:true AlwaysMigrate:false ScalingEnabled:true ScalingConfig:&{LoadAverageFractionTarget:0.7 MemoryUsageFractionTarget:0.7}}}"
+	goSyntaxRepr := `api.VmInfo{Name:"foo", Namespace:"bar", Cpu:api.VmCpuInfo{Min:api.MilliCPU(1000), Max:api.MilliCPU(5000), Use:api.MilliCPU(3750)}, Mem:api.VmMemInfo{Min:2, Max:6, Use:4, SlotSize:1073741824}, Config:api.VmConfig{AutoMigrationEnabled:true, AlwaysMigrate:false, ScalingEnabled:true, ScalingConfig:&api.ScalingConfig{LoadAverageFractionTarget:0.7, MemoryUsageFractionTarget:0.7}}}`
 	cases := []struct {
 		name     string
 		expected string

--- a/pkg/api/vminfo_test.go
+++ b/pkg/api/vminfo_test.go
@@ -26,15 +26,17 @@ func TestFormatting(t *testing.T) {
 			Use:      4,
 			SlotSize: api.BytesFromResourceQuantity(slotSize),
 		},
-		ScalingConfig: &api.ScalingConfig{
-			LoadAverageFractionTarget: 0.7,
-			MemoryUsageFractionTarget: 0.7,
+		Config: api.VmConfig{
+			AlwaysMigrate:  false,
+			ScalingEnabled: true,
+			ScalingConfig: &api.ScalingConfig{
+				LoadAverageFractionTarget: 0.7,
+				MemoryUsageFractionTarget: 0.7,
+			},
 		},
-		AlwaysMigrate:  false,
-		ScalingEnabled: true,
 	})
-	defaultFormat := "{Name:foo Namespace:bar Cpu:{Min:1 Max:5 Use:3.75} Mem:{Min:2 Max:6 Use:4 SlotSize:1Gi} ScalingConfig:&{LoadAverageFractionTarget:0.7 MemoryUsageFractionTarget:0.7} AlwaysMigrate:false ScalingEnabled:true}"
-	goSyntaxRepr := `api.VmInfo{Name:"foo", Namespace:"bar", Cpu:api.VmCpuInfo{Min:api.MilliCPU(1000), Max:api.MilliCPU(5000), Use:api.MilliCPU(3750)}, Mem:api.VmMemInfo{Min:2, Max:6, Use:4, SlotSize:1073741824}, ScalingConfig:&api.ScalingConfig{LoadAverageFractionTarget:0.7, MemoryUsageFractionTarget:0.7}, AlwaysMigrate:false, ScalingEnabled:true}`
+	defaultFormat := "{Name:foo Namespace:bar Cpu:{Min:1 Max:5 Use:3.75} Mem:{Min:2 Max:6 Use:4 SlotSize:1Gi} Config:{AlwaysMigrate:false ScalingEnabled:true ScalingConfig:&{LoadAverageFractionTarget:0.7 MemoryUsageFractionTarget:0.7}}}"
+	goSyntaxRepr := `api.VmInfo{Name:"foo", Namespace:"bar", Cpu:api.VmCpuInfo{Min:api.MilliCPU(1000), Max:api.MilliCPU(5000), Use:api.MilliCPU(3750)}, Mem:api.VmMemInfo{Min:2, Max:6, Use:4, SlotSize:1073741824}, Config:api.VmConfig{AlwaysMigrate:false, ScalingEnabled:true, ScalingConfig:&api.ScalingConfig{LoadAverageFractionTarget:0.7, MemoryUsageFractionTarget:0.7}}}`
 	cases := []struct {
 		name     string
 		expected string

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -209,7 +209,7 @@ func (s *nodeState) dump() nodeStateDump {
 		if p == nil {
 			mq = append(mq, nil)
 		} else {
-			v := podNameAndPointer{Obj: makePointerString(p), PodName: p.name}
+			v := podNameAndPointer{Obj: makePointerString(p), PodName: p.Name}
 			mq = append(mq, &v)
 		}
 	}
@@ -246,22 +246,22 @@ func (s *podState) dump() podStateDump {
 func (s *vmPodState) dump() vmPodStateDump {
 	// Copy some of the "may be nil" pointer fields
 	var metrics *api.Metrics
-	if s.metrics != nil {
-		m := *s.metrics
+	if s.Metrics != nil {
+		m := *s.Metrics
 		metrics = &m
 	}
 	var migrationState *podMigrationStateDump
-	if s.migrationState != nil {
+	if s.MigrationState != nil {
 		migrationState = &podMigrationStateDump{
-			MigrationName: s.migrationState.name,
+			MigrationName: s.MigrationState.Name,
 		}
 	}
 
 	return vmPodStateDump{
-		Name:                     s.name,
-		TestingOnlyAlwaysMigrate: s.testingOnlyAlwaysMigrate,
+		Name:                     s.Name,
+		TestingOnlyAlwaysMigrate: s.TestingOnlyAlwaysMigrate,
 		Metrics:                  metrics,
-		MqIndex:                  s.mqIndex,
+		MqIndex:                  s.MqIndex,
 		MigrationState:           migrationState,
 	}
 }

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -134,19 +134,7 @@ type podStateDump struct {
 	Node pointerString                    `json:"node"`
 	CPU  podResourceState[vmapi.MilliCPU] `json:"cpu"`
 	Mem  podResourceState[api.Bytes]      `json:"mem"`
-	VM   *vmPodStateDump                  `json:"vm"`
-}
-
-type vmPodStateDump struct {
-	Name                     util.NamespacedName    `json:"name"`
-	TestingOnlyAlwaysMigrate bool                   `json:"testingOnlyAlwaysMigrate"`
-	Metrics                  *api.Metrics           `json:"metrics"`
-	MqIndex                  int                    `json:"mqIndex"`
-	MigrationState           *podMigrationStateDump `json:"migrationState"`
-}
-
-type podMigrationStateDump struct {
-	MigrationName util.NamespacedName `json:"migrationName"`
+	VM   *vmPodState                      `json:"vm"`
 }
 
 func makePointerString[T any](t *T) pointerString {
@@ -228,9 +216,9 @@ func (s *nodeState) dump() nodeStateDump {
 
 func (s *podState) dump() podStateDump {
 
-	var vm *vmPodStateDump
+	var vm *vmPodState
 	if s.vm != nil {
-		vm = &[]vmPodStateDump{s.vm.dump()}[0]
+		vm = &[]vmPodState{s.vm.dump()}[0]
 	}
 
 	return podStateDump{
@@ -243,22 +231,23 @@ func (s *podState) dump() podStateDump {
 	}
 }
 
-func (s *vmPodState) dump() vmPodStateDump {
+func (s *vmPodState) dump() vmPodState {
 	// Copy some of the "may be nil" pointer fields
 	var metrics *api.Metrics
 	if s.Metrics != nil {
 		m := *s.Metrics
 		metrics = &m
 	}
-	var migrationState *podMigrationStateDump
+	var migrationState *podMigrationState
 	if s.MigrationState != nil {
-		migrationState = &podMigrationStateDump{
-			MigrationName: s.MigrationState.Name,
+		migrationState = &podMigrationState{
+			Name: s.MigrationState.Name,
 		}
 	}
 
-	return vmPodStateDump{
+	return vmPodState{
 		Name:                     s.Name,
+		MemSlotSize:              s.MemSlotSize,
 		TestingOnlyAlwaysMigrate: s.TestingOnlyAlwaysMigrate,
 		Metrics:                  metrics,
 		MqIndex:                  s.MqIndex,

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -246,11 +246,11 @@ func (s *vmPodState) dump() vmPodState {
 	}
 
 	return vmPodState{
-		Name:                     s.Name,
-		MemSlotSize:              s.MemSlotSize,
-		TestingOnlyAlwaysMigrate: s.TestingOnlyAlwaysMigrate,
-		Metrics:                  metrics,
-		MqIndex:                  s.MqIndex,
-		MigrationState:           migrationState,
+		Name:           s.Name,
+		MemSlotSize:    s.MemSlotSize,
+		Config:         s.Config,
+		Metrics:        metrics,
+		MqIndex:        s.MqIndex,
+		MigrationState: migrationState,
 	}
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -149,8 +149,8 @@ func makeAutoscaleEnforcerPlugin(
 		},
 	}
 	vwc := vmWatchCallbacks{
-		submitDisabledScaling: func(logger *zap.Logger, pod util.NamespacedName) {
-			pushToQueue(logger, pod.Name, func() { p.handleVMDisabledScaling(hlogger, pod) })
+		submitConfigUpdated: func(logger *zap.Logger, pod util.NamespacedName, newCfg api.VmConfig) {
+			pushToQueue(logger, pod.Name, func() { p.handleVMConfigUpdated(hlogger, pod, newCfg) })
 		},
 		submitBoundsChanged: func(logger *zap.Logger, vm *api.VmInfo, podName string) {
 			pushToQueue(logger, vm.Name, func() { p.handleUpdatedScalingBounds(hlogger, vm, podName) })

--- a/pkg/plugin/queue.go
+++ b/pkg/plugin/queue.go
@@ -13,10 +13,10 @@ type migrationQueue []*vmPodState
 ///////////////////////
 
 func (mq *migrationQueue) addOrUpdate(vm *vmPodState) {
-	if vm.mqIndex == -1 {
+	if vm.MqIndex == -1 {
 		heap.Push(mq, vm)
 	} else {
-		heap.Fix(mq, vm.mqIndex)
+		heap.Fix(mq, vm.MqIndex)
 	}
 }
 
@@ -24,12 +24,12 @@ func (mq migrationQueue) isNextInQueue(vm *vmPodState) bool {
 	// the documentation for heap.Pop says that it's equivalent to heap.Remove(h, 0). Therefore,
 	// checking whether something's the next pop target can just be done by checking if its index is
 	// zero.
-	return vm.mqIndex == 0
+	return vm.MqIndex == 0
 }
 
 func (mq *migrationQueue) removeIfPresent(vm *vmPodState) {
-	if vm.mqIndex != -1 {
-		_ = heap.Remove(mq, vm.mqIndex)
+	if vm.MqIndex != -1 {
+		_ = heap.Remove(mq, vm.MqIndex)
 	}
 }
 
@@ -45,14 +45,14 @@ func (mq migrationQueue) Less(i, j int) bool {
 
 func (mq migrationQueue) Swap(i, j int) {
 	mq[i], mq[j] = mq[j], mq[i]
-	mq[i].mqIndex = i
-	mq[j].mqIndex = j
+	mq[i].MqIndex = i
+	mq[j].MqIndex = j
 }
 
 func (mq *migrationQueue) Push(v any) {
 	n := len(*mq)
 	vm := v.(*vmPodState)
-	vm.mqIndex = n
+	vm.MqIndex = n
 	*mq = append(*mq, vm)
 }
 
@@ -62,7 +62,7 @@ func (mq *migrationQueue) Pop() any {
 	n := len(old)
 	vm := old[n-1]
 	old[n-1] = nil  // avoid memory leak
-	vm.mqIndex = -1 // for safety
+	vm.MqIndex = -1 // for safety
 	*mq = old[0 : n-1]
 	return vm
 }

--- a/pkg/plugin/queue.go
+++ b/pkg/plugin/queue.go
@@ -30,6 +30,7 @@ func (mq migrationQueue) isNextInQueue(vm *vmPodState) bool {
 func (mq *migrationQueue) removeIfPresent(vm *vmPodState) {
 	if vm.MqIndex != -1 {
 		_ = heap.Remove(mq, vm.MqIndex)
+		vm.MqIndex = -1
 	}
 }
 

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -321,7 +321,7 @@ func (e *AutoscaleEnforcer) updateMetricsAndCheckMustMigrate(
 	// A third condition, "the pod is marked to always migrate" causes it to migrate even if neither
 	// of the above conditions are met, so long as it has *previously* provided metrics.
 	shouldMigrate := node.mq.isNextInQueue(vm) && node.tooMuchPressure(logger)
-	forcedMigrate := vm.TestingOnlyAlwaysMigrate && vm.Metrics != nil
+	forcedMigrate := vm.Config.AlwaysMigrate && vm.Metrics != nil
 
 	logger.Info("Updating pod metrics", zap.Any("metrics", metrics))
 	oldMetrics := vm.Metrics

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -187,9 +187,8 @@ type vmPodState struct {
 	// earlier versions of the agent<->plugin protocol.
 	MemSlotSize api.Bytes
 
-	// TestingOnlyAlwaysMigrate is a test-only debugging flag that, if present in the pod's labels,
-	// will always prompt it to mgirate, regardless of whether the VM actually *needs* to.
-	TestingOnlyAlwaysMigrate bool
+	// Config stores the values of per-VM settings for this VM
+	Config api.VmConfig
 
 	// Metrics is the most recent Metrics update we received for this pod. A nil pointer means that
 	// we have not yet received Metrics.
@@ -675,12 +674,12 @@ func (e *AutoscaleEnforcer) reserveResources(
 
 	if vmInfo != nil {
 		vmState = &vmPodState{
-			Name:                     vmInfo.NamespacedName(),
-			MemSlotSize:              vmInfo.Mem.SlotSize,
-			TestingOnlyAlwaysMigrate: vmInfo.Config.AlwaysMigrate,
-			Metrics:                  nil,
-			MqIndex:                  -1,
-			MigrationState:           nil,
+			Name:           vmInfo.NamespacedName(),
+			MemSlotSize:    vmInfo.Mem.SlotSize,
+			Config:         vmInfo.Config,
+			Metrics:        nil,
+			MqIndex:        -1,
+			MigrationState: nil,
 		}
 		cpuState = podResourceState[vmapi.MilliCPU]{
 			Reserved:         vmInfo.Using().VCPU,
@@ -1332,8 +1331,8 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context, logger *zap.Lo
 				Metrics:        nil,
 				MigrationState: nil,
 
-				MemSlotSize:              vmInfo.Mem.SlotSize,
-				TestingOnlyAlwaysMigrate: vmInfo.Config.AlwaysMigrate,
+				MemSlotSize: vmInfo.Mem.SlotSize,
+				Config:      vmInfo.Config,
 			},
 		}
 

--- a/pkg/plugin/state.go
+++ b/pkg/plugin/state.go
@@ -677,7 +677,7 @@ func (e *AutoscaleEnforcer) reserveResources(
 		vmState = &vmPodState{
 			name:                     vmInfo.NamespacedName(),
 			memSlotSize:              vmInfo.Mem.SlotSize,
-			testingOnlyAlwaysMigrate: vmInfo.AlwaysMigrate,
+			testingOnlyAlwaysMigrate: vmInfo.Config.AlwaysMigrate,
 			metrics:                  nil,
 			mqIndex:                  -1,
 			migrationState:           nil,
@@ -1333,13 +1333,13 @@ func (p *AutoscaleEnforcer) readClusterState(ctx context.Context, logger *zap.Lo
 				migrationState: nil,
 
 				memSlotSize:              vmInfo.Mem.SlotSize,
-				testingOnlyAlwaysMigrate: vmInfo.AlwaysMigrate,
+				testingOnlyAlwaysMigrate: vmInfo.Config.AlwaysMigrate,
 			},
 		}
 
 		// If scaling isn't enabled *or* the pod is involved in an ongoing migration, then we can be
 		// more precise about usage (because scaling is forbidden while migrating).
-		if !vmInfo.ScalingEnabled || migrationName != nil {
+		if !vmInfo.Config.ScalingEnabled || migrationName != nil {
 			ps.cpu.Buffer = 0
 			ps.cpu.Reserved = vmInfo.Cpu.Use
 

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -288,13 +288,13 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 					return
 				}
 
-				if oldInfo.ScalingEnabled && !newInfo.ScalingEnabled {
+				if oldInfo.Config.ScalingEnabled && !newInfo.Config.ScalingEnabled {
 					logger.Info("Received update to disable autoscaling for VM", util.VMNameFields(newVM))
 					name := util.NamespacedName{Namespace: newInfo.Namespace, Name: newVM.Status.PodName}
 					callbacks.submitDisabledScaling(logger, name)
 				}
 
-				if (!oldInfo.ScalingEnabled || !newInfo.ScalingEnabled) && oldInfo.Using() != newInfo.Using() {
+				if (!oldInfo.Config.ScalingEnabled || !newInfo.Config.ScalingEnabled) && oldInfo.Using() != newInfo.Using() {
 					podName := util.NamespacedName{Namespace: newInfo.Namespace, Name: newVM.Status.PodName}
 					logger.Info("Received update changing usage for VM", zap.Object("old", oldInfo.Using()), zap.Object("new", newInfo.Using()))
 					callbacks.submitNonAutoscalingVmUsageChanged(logger, newInfo, podName.Name)

--- a/pkg/plugin/watch.go
+++ b/pkg/plugin/watch.go
@@ -5,6 +5,7 @@ package plugin
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"go.uber.org/zap"
@@ -179,7 +180,7 @@ func (e *AutoscaleEnforcer) watchPodEvents(
 }
 
 type vmWatchCallbacks struct {
-	submitDisabledScaling              func(_ *zap.Logger, podName util.NamespacedName)
+	submitConfigUpdated                func(_ *zap.Logger, podName util.NamespacedName, newCfg api.VmConfig)
 	submitBoundsChanged                func(_ *zap.Logger, _ *api.VmInfo, podName string)
 	submitNonAutoscalingVmUsageChanged func(_ *zap.Logger, _ *api.VmInfo, podName string)
 }
@@ -288,10 +289,10 @@ func (e *AutoscaleEnforcer) watchVMEvents(
 					return
 				}
 
-				if oldInfo.Config.ScalingEnabled && !newInfo.Config.ScalingEnabled {
-					logger.Info("Received update to disable autoscaling for VM", util.VMNameFields(newVM))
+				if !reflect.DeepEqual(oldInfo.Config, newInfo.Config) {
+					logger.Info("Received config update for VM", util.VMNameFields(newVM))
 					name := util.NamespacedName{Namespace: newInfo.Namespace, Name: newVM.Status.PodName}
-					callbacks.submitDisabledScaling(logger, name)
+					callbacks.submitConfigUpdated(logger, name, newInfo.Config)
 				}
 
 				if (!oldInfo.Config.ScalingEnabled || !newInfo.Config.ScalingEnabled) && oldInfo.Using() != newInfo.Using() {


### PR DESCRIPTION
Resolves #756. Copying from that issue:

> When we enable automatic live migration in prod, we'll require enabling the overlay IP addresses on all existing VMs. This is not currently enabled, so enabling migration will either (a) have to wait until all VMs use the overlay IP addresses, or (b) be enabled
> gradually, on a case-by-case basis.

Now that it's opt-in, we can *also* set the global config setting to default to true. Still worth keeping for now, at the very least as a "break glass in case of emergency" button.

---

**Notes for review:** This is a lot of commits. Every commit except the last one is just laying the groundwork for this PR, so I figured I'd include it here.

Happy to split those out into a separate PR if that'd be easier.

I intend to merge this PR via rebase, so the commits history is preserved (and so blame becomes easier).

TBH not sure the easiest way to review this. I'd _probably_ recommend going commit-by-commit.