### PR TITLE
neonvm-controller: Use --concurrency-limit=128

### DIFF
--- a/neonvm/config/default-vxlan/manager_config_patch.yaml
+++ b/neonvm/config/default-vxlan/manager_config_patch.yaml
@@ -16,7 +16,7 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=:8080"
         - "--leader-elect"
-        - "--concurrency-limit=8"
+        - "--concurrency-limit=128"
         - "--zap-devel=false"
         - "--zap-time-encoding=iso8601"
         - "--zap-log-level=info"


### PR DESCRIPTION
We noticed issues at at 8, then 16, then 32, and even 64 for some large regions.

128 appears to be stable in prod (even though it's overcommitting controller CPU limits 32:1).

ref https://neondb.slack.com/archives/C03TN5G758R/p1706725735037289?thread_ts=1706160071.213319