### PR TITLE
plugin: Handle panics from agent requests

### DIFF
--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -34,9 +34,22 @@ const (
 func (e *AutoscaleEnforcer) startPermitHandler(ctx context.Context, logger *zap.Logger) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		logger := logger // copy locally, so that we can add fields and refer to it in defers
+
 		var finalStatus int
 		defer func() {
 			e.metrics.resourceRequests.WithLabelValues(r.RemoteAddr, strconv.Itoa(finalStatus)).Inc()
+		}()
+
+		// Catch any potential panics and report them as 500s
+		defer func() {
+			if err := recover(); err != nil {
+				msg := "request handler panicked"
+				logger.Error(msg, zap.String("error", fmt.Sprint(err)))
+				finalStatus = 500
+				w.WriteHeader(finalStatus)
+				_, _ = w.Write([]byte(msg))
+			}
 		}()
 
 		if r.Method != "POST" {
@@ -58,7 +71,7 @@ func (e *AutoscaleEnforcer) startPermitHandler(ctx context.Context, logger *zap.
 			return
 		}
 
-		logger := logger.With(zap.Object("pod", req.Pod))
+		logger = logger.With(zap.Object("pod", req.Pod))
 		logger.Info(
 			"Received autoscaler-agent request",
 			zap.String("client", r.RemoteAddr), zap.Any("request", req),


### PR DESCRIPTION
Closes #760.

AFAIK this hasn't been an issue in the past, but as we're trying to improve reliability, it's good to get this out of the way before it becomes an issue.

Note that this PR is quite minimal - expanding the existing tech debt we have around how the scheduler plugin handles HTTP requests. It's probably ok *enough* for now. I don't expect we'll be making too many changes to it in the near future. See also: #13.

Tested locally by forcing it to panic on every request:

```diff
diff --git a/pkg/plugin/run.go b/pkg/plugin/run.go index 007554a..6da7728 100644
--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -262,8 +262,10 @@ func (e *AutoscaleEnforcer) handleAgentRequest(
 		}
 	}

-	pod.vm.mostRecentComputeUnit = &e.state.conf.ComputeUnit
-	return &resp, 200, nil
+	panic(errors.New("test panic!")) +
+	// pod.vm.mostRecentComputeUnit = &e.state.conf.ComputeUnit
+	// return &resp, 200, nil }

 // getComputeUnitForResponse tries to return compute unit that the agent supports
```

The change appears to work as intended.