### PR TITLE
Avoid "dnsmasq: failed to create inotify .." errors.

### DIFF
--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -1349,7 +1349,14 @@ func defaultNetwork(logger *zap.Logger, cidr string, ports []vmv1.Port) (mac.MAC
 	// prepare dnsmask command line (instead of config file)
 	logger.Info("run dnsmasq for interface", zap.String("name", defaultNetworkBridgeName))
 	dnsMaskCmd := []string{
+		// No DNS, DHCP only
 		"--port=0",
+
+		// Because we don't provide DNS, no need to load resolv.conf. This helps to
+		// avoid "dnsmasq: failed to create inotify: No file descriptors available"
+		// errors.
+		"--no-resolv",
+
 		"--bind-interfaces",
 		"--dhcp-authoritative",
 		fmt.Sprintf("--interface=%s", defaultNetworkBridgeName),


### PR DESCRIPTION
When testing on my laptop, launching the VM sometimes failed with:

    dnsmasq: failed to create inotify: No file descriptors available

That can be fixed by raising the inotify limits, which are apparently quite low by default. We did that in commit a17be2b062 for e2e tests, although that was later removed because we changed the settings in the runners instead.

But to avoid having to change those settings, we can use the --no-resolv flag. When --no-resolv is given, and none of the dhcp-hostsdir dhcp-optsdir, hostsdir options are used, dnsmasq doesn't use inotify at all.

It's a bit silly that --no-resolv has that effect when DNS is disabled (--port=0), because dnsmasq doesn't actually read resolv.conf when DNS is disabled. I think that could be improved in dnsmasq. But in the meanwhile. See the dnsmasq code where inotify is initialized: https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=blob;f=src/dnsmasq.c;h=ce897ae43483aba99bf59a90e67debfe08ed135d;hb=HEAD#l431