### PR TITLE
agent/billing: Fix unregistered metric lastSendDuration

### DIFF
--- a/pkg/agent/billing/prommetrics.go
+++ b/pkg/agent/billing/prommetrics.go
@@ -60,6 +60,7 @@ func (m PromMetrics) MustRegister(reg *prometheus.Registry) {
 	reg.MustRegister(m.vmsProcessedTotal)
 	reg.MustRegister(m.vmsCurrent)
 	reg.MustRegister(m.queueSizeCurrent)
+	reg.MustRegister(m.lastSendDuration)
 	reg.MustRegister(m.sendErrorsTotal)
 }
 


### PR DESCRIPTION
While working on the "billing" section of the new autoscaler-agents dashboard [1], I noticed that this metric is recorded but never actually registered, hence not *actually* available.

See also #788.
We may also want to reorganize the way these metrics are defined, so we can use e.g. `util.RegisterMetric` while initializing the struct (to avoid having this issue in the first place).

[1]: https://neonprod.grafana.net/d/bdbt33ngwqc5cb