### PR TITLE
util: use prometheus.Registerer in RegisterMetrics

### DIFF
--- a/pkg/util/metrics.go
+++ b/pkg/util/metrics.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func RegisterMetric[P prometheus.Collector](reg *prometheus.Registry, collector P) P {
+func RegisterMetric[P prometheus.Collector](reg prometheus.Registerer, collector P) P {
 	reg.MustRegister(collector)
 	return collector
 }


### PR DESCRIPTION
Using the interface allows to use other implementations as well.