### PR TITLE
neonvm-controller: Fix field name typo in webhook validation

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
@@ -159,7 +159,7 @@ func (r *VirtualMachine) ValidateUpdate(old runtime.Object) error {
 		{".spec.guest.args", func(v *VirtualMachine) any { return v.Spec.Guest.Args }},
 		{".spec.guest.env", func(v *VirtualMachine) any { return v.Spec.Guest.Env }},
 		{".spec.guest.settings", func(v *VirtualMachine) any { return v.Spec.Guest.Settings }},
-		{".spec.disk", func(v *VirtualMachine) any { return v.Spec.Disks }},
+		{".spec.disks", func(v *VirtualMachine) any { return v.Spec.Disks }},
 		{".spec.podResources", func(v *VirtualMachine) any { return v.Spec.PodResources }},
 		{".spec.enableAcceleration", func(v *VirtualMachine) any { return v.Spec.EnableAcceleration }},
 		{".spec.enableSSH", func(v *VirtualMachine) any { return v.Spec.EnableSSH }},


### PR DESCRIPTION
Noticed while reviewing #782.

Maybe we want to go through the list more thoroughly, I think there's a handful of fields missing.