### PR TITLE
CI: Use `format('{0}', x) == 'true')` to check truthiness

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -77,7 +77,8 @@ jobs:
           echo "cluster-autoscaler=${{ env.IMG_CLUSTER_AUTOSCALER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
 
   vm-kernel:
-    if: ${{ inputs.skip != 'true' }}
+    # nb: use format(..) to catch both inputs.skip = true AND inputs.skip = 'true'.
+    if: ${{ format('{0}', inputs.skip) != 'true' }}
     uses: ./.github/workflows/vm-kernel.yaml
     with:
       tag: ${{ inputs.kernel-image || inputs.tag }}
@@ -85,7 +86,8 @@ jobs:
     secrets: inherit
 
   build:
-    if: ${{ inputs.skip != 'true' }}
+    # nb: use format(..) to catch both inputs.skip = true AND inputs.skip = 'true'.
+    if: ${{ format('{0}', inputs.skip) != 'true' }}
     needs: [ tags, vm-kernel ]
     runs-on: [ self-hosted, gen3, large ]
     steps:
@@ -113,7 +115,7 @@ jobs:
 
       - name: get CA base git tag
         id: get-ca-tag
-        if: ${{ inputs.build-cluster-autoscaler == 'true' }}
+        if: ${{ format('{0}', inputs.build-cluster-autoscaler) == 'true' }}
         run: |
           echo "tag=$(cat cluster-autoscaler/ca.tag)" >> $GITHUB_OUTPUT
 
@@ -208,7 +210,7 @@ jobs:
 
       - name: Build and push cluster-autoscaler image
         uses: docker/build-push-action@v3
-        if: ${{ inputs.build-cluster-autoscaler == 'true' }}
+        if: ${{ format('{0}', inputs.build-cluster-autoscaler) == 'true' }}
         with:
           context: cluster-autoscaler
           platforms: linux/amd64

--- a/.github/workflows/build-test-vm.yaml
+++ b/.github/workflows/build-test-vm.yaml
@@ -45,7 +45,8 @@ jobs:
           echo "vm-postgres-15-bullseye=${{ env.IMG_POSTGRES_15_BULLSEYE }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
 
   build:
-    if: ${{ inputs.skip != 'true' }}
+    # nb: use format(..) to catch both inputs.skip = true AND inputs.skip = 'true'.
+    if: ${{ format('{0}', inputs.skip) != 'true' }}
     needs: tags
     runs-on: [ self-hosted, gen3, large ]
     steps:
@@ -61,7 +62,7 @@ jobs:
       - run: make bin/vm-builder
 
       - name: upload vm-builder
-        if: ${{ inputs.upload-vm-builder == 'true' }}
+        if: ${{ format('{0}', inputs.upload-vm-builder) == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: vm-builder

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -115,7 +115,8 @@ jobs:
           IMG_AUTOSCALER_AGENT: ${{ needs.build-images.outputs.autoscaler-agent }}
 
       - name: upload manifests
-        if: ${{ inputs.push-yamls == 'true' }}
+        # nb: use format(..) to catch both inputs.push-yamls = true AND inputs.push-yamls = 'true'.
+        if: ${{ format('{0}', inputs.push-yamls) == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: rendered_manifests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: release
 on:
-  # # UNCOMMENT TO ALLOW TESTING:
-  # pull_request:
+  # UNCOMMENT TO ALLOW TESTING:
+  pull_request:
   push:
     tags:
       - "v*.*.*"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: release
 on:
-  # UNCOMMENT TO ALLOW TESTING:
-  pull_request:
+  # # UNCOMMENT TO ALLOW TESTING:
+  # pull_request:
   push:
     tags:
       - "v*.*.*"


### PR DESCRIPTION
After the changes by #748 (adding separate image build workflows), releasing [hit some issues](https://github.com/neondatabase/autoscaling/actions/runs/7818714553) because `true != 'true'` and [sometimes workflow inputs are the string](https://github.com/actions/runner/issues/1483) "true", whereas other times, they're the *value* `true`.

Hopefully this solution works. It's quite hacky though, so it'd be good to find a clean solution (e.g., maybe `fromJSON` works?)

---

Found the relevant occurrences with
```sh
rg "[!=]= 'true'" .github
```