### PR TITLE
neonvm-controller: Add reconcile metrics debug endpoint

### DIFF
--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -90,8 +90,10 @@ type ReconcileSnapshot struct {
 	Failing []string `json:"failing"`
 }
 
-// WithMetrics wraps a given Reconciler with metrics capabilities, also returning a function that
-// produces a snapshot of the metrics, for easier inspection.
+// WithMetrics wraps a given Reconciler with metrics capabilities.
+//
+// The returned reconciler also provides a way to get a snapshot of the state of ongoing reconciles,
+// to see the data backing the metrics.
 func WithMetrics(reconciler reconcile.Reconciler, rm ReconcilerMetrics, cntrlName string) ReconcilerWithMetrics {
 	return &wrappedReconciler{
 		Reconciler:     reconciler,

--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -68,7 +68,7 @@ type wrappedReconciler struct {
 	failing map[client.ObjectKey]struct{}
 }
 
-// ReocncileSnapshot provides a glimpse into the current state of ongoing reconciles
+// ReconcileSnapshot provides a glimpse into the current state of ongoing reconciles
 //
 // This type is (transitively) returned by the controller's "dump state" HTTP endpoint, and exists
 // to allow us to get deeper information on the metrics - we can't expose information for every

--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -72,13 +72,13 @@ type wrappedReconciler struct {
 //
 // This type is (transitively) returned by the controller's "dump state" HTTP endpoint, and exists
 // to allow us to get deeper information on the metrics - we can't expose information for every
-// VirtualMachine into the metrics (it'd be too high cardinality), but we *can* make it availalbe
+// VirtualMachine into the metrics (it'd be too high cardinality), but we *can* make it available
 // when requested.
 type ReconcileSnapshot struct {
 	// ControllerName is the name of the controller: virtualmachine or virtualmachinemigration.
 	ControllerName string
 
-	// Failing is the list of objects currenly failing to reconcile
+	// Failing is the list of objects currently failing to reconcile
 	Failing []string
 }
 

--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -97,15 +97,13 @@ func WithMetrics(
 	rm ReconcilerMetrics,
 	cntrlName string,
 ) ReconcilerWithMetrics {
-	r := &wrappedReconciler{
+	return &wrappedReconciler{
 		Reconciler:     reconciler,
 		Metrics:        rm,
 		ControllerName: cntrlName,
 		lock:           sync.Mutex{},
 		failing:        make(map[client.ObjectKey]struct{}),
 	}
-
-	return r
 }
 
 func (d *wrappedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -82,7 +82,8 @@ type ReconcileSnapshot struct {
 	Failing []string
 }
 
-// WithMetrics wraps a given Reconciler with metrics capabilities.
+// WithMetrics wraps a given Reconciler with metrics capabilities, also returning a function that
+// produces a snapshot of the metrics, for easier inspection.
 func WithMetrics(reconciler reconcile.Reconciler, rm ReconcilerMetrics, cntrlName string) (reconcile.Reconciler, func() ReconcileSnapshot) {
 	r := &wrappedReconciler{
 		Reconciler:     reconciler,

--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -92,11 +92,7 @@ type ReconcileSnapshot struct {
 
 // WithMetrics wraps a given Reconciler with metrics capabilities, also returning a function that
 // produces a snapshot of the metrics, for easier inspection.
-func WithMetrics(
-	reconciler reconcile.Reconciler,
-	rm ReconcilerMetrics,
-	cntrlName string,
-) ReconcilerWithMetrics {
+func WithMetrics(reconciler reconcile.Reconciler, rm ReconcilerMetrics, cntrlName string) ReconcilerWithMetrics {
 	return &wrappedReconciler{
 		Reconciler:     reconciler,
 		Metrics:        rm,

--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -76,10 +76,10 @@ type wrappedReconciler struct {
 // when requested.
 type ReconcileSnapshot struct {
 	// ControllerName is the name of the controller: virtualmachine or virtualmachinemigration.
-	ControllerName string
+	ControllerName string `json:"controllerName"`
 
 	// Failing is the list of objects currently failing to reconcile
-	Failing []string
+	Failing []string `json:"failing"`
 }
 
 // WithMetrics wraps a given Reconciler with metrics capabilities, also returning a function that

--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -84,7 +84,11 @@ type ReconcileSnapshot struct {
 
 // WithMetrics wraps a given Reconciler with metrics capabilities, also returning a function that
 // produces a snapshot of the metrics, for easier inspection.
-func WithMetrics(reconciler reconcile.Reconciler, rm ReconcilerMetrics, cntrlName string) (reconcile.Reconciler, func() ReconcileSnapshot) {
+func WithMetrics(
+	reconciler reconcile.Reconciler,
+	rm ReconcilerMetrics,
+	cntrlName string,
+) (reconcile.Reconciler, func() ReconcileSnapshot) {
 	r := &wrappedReconciler{
 		Reconciler:     reconciler,
 		Metrics:        rm,

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -1681,16 +1681,16 @@ func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret, conf
 // SetupWithManager sets up the controller with the Manager.
 // Note that the Runner Pod will be also watched in order to ensure its
 // desirable state on the cluster
-func (r *VirtualMachineReconciler) SetupWithManager(mgr ctrl.Manager) (func() ReconcileSnapshot, error) {
+func (r *VirtualMachineReconciler) SetupWithManager(mgr ctrl.Manager) (ReconcilerWithMetrics, error) {
 	cntrlName := "virtualmachine"
-	reconciler, snapshot := WithMetrics(r, r.Metrics, cntrlName)
+	reconciler := WithMetrics(r, r.Metrics, cntrlName)
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachine{}).
 		Owns(&corev1.Pod{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
 		Named(cntrlName).
 		Complete(reconciler)
-	return snapshot, err
+	return reconciler, err
 }
 
 func DeepEqual(v1, v2 interface{}) bool {

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -1681,15 +1681,16 @@ func podSpec(virtualmachine *vmv1.VirtualMachine, sshSecret *corev1.Secret, conf
 // SetupWithManager sets up the controller with the Manager.
 // Note that the Runner Pod will be also watched in order to ensure its
 // desirable state on the cluster
-func (r *VirtualMachineReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *VirtualMachineReconciler) SetupWithManager(mgr ctrl.Manager) (func() ReconcileSnapshot, error) {
 	cntrlName := "virtualmachine"
-	reconciler := WithMetrics(r, r.Metrics, cntrlName)
-	return ctrl.NewControllerManagedBy(mgr).
+	reconciler, snapshot := WithMetrics(r, r.Metrics, cntrlName)
+	err := ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachine{}).
 		Owns(&corev1.Pod{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
 		Named(cntrlName).
 		Complete(reconciler)
+	return snapshot, err
 }
 
 func DeepEqual(v1, v2 interface{}) bool {

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -668,15 +668,16 @@ func (r *VirtualMachineMigrationReconciler) doFinalizerOperationsForVirtualMachi
 // SetupWithManager sets up the controller with the Manager.
 // Note that the Pods will be also watched in order to ensure its
 // desirable state on the cluster
-func (r *VirtualMachineMigrationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *VirtualMachineMigrationReconciler) SetupWithManager(mgr ctrl.Manager) (func() ReconcileSnapshot, error) {
 	cntrlName := "virtualmachinemigration"
-	reconciler := WithMetrics(r, r.Metrics, cntrlName)
-	return ctrl.NewControllerManagedBy(mgr).
+	reconciler, snapshot := WithMetrics(r, r.Metrics, cntrlName)
+	err := ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachineMigration{}).
 		Owns(&corev1.Pod{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
 		Named(cntrlName).
 		Complete(reconciler)
+	return snapshot, err
 }
 
 // targetPodForVirtualMachine returns a VirtualMachine Pod object

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -668,16 +668,16 @@ func (r *VirtualMachineMigrationReconciler) doFinalizerOperationsForVirtualMachi
 // SetupWithManager sets up the controller with the Manager.
 // Note that the Pods will be also watched in order to ensure its
 // desirable state on the cluster
-func (r *VirtualMachineMigrationReconciler) SetupWithManager(mgr ctrl.Manager) (func() ReconcileSnapshot, error) {
+func (r *VirtualMachineMigrationReconciler) SetupWithManager(mgr ctrl.Manager) (ReconcilerWithMetrics, error) {
 	cntrlName := "virtualmachinemigration"
-	reconciler, snapshot := WithMetrics(r, r.Metrics, cntrlName)
+	reconciler := WithMetrics(r, r.Metrics, cntrlName)
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachineMigration{}).
 		Owns(&corev1.Pod{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: r.Config.MaxConcurrentReconciles}).
 		Named(cntrlName).
 		Complete(reconciler)
-	return snapshot, err
+	return reconciler, err
 }
 
 // targetPodForVirtualMachine returns a VirtualMachine Pod object

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -270,14 +270,13 @@ func debugServerFunc(snapshots ...func() controllers.ReconcileSnapshot) manager.
 			Handler: mux,
 		}
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 
 		go func() {
 			<-ctx.Done()
 			_ = server.Shutdown(context.TODO())
 		}()
 
-		err := server.ListenAndServe()
-		cancel() // avoid leaking the goroutine. It's *probably* fine, but good practice.
-		return err
+		return server.ListenAndServe()
 	})
 }


### PR DESCRIPTION
Similar in spirit to the "dump state" endpoints exposed by the autsocaler-agent and scheduler plugin.

This one is on port 7778 (+1 from the pprof server on 7777).

The state can be fetched with:

```sh
kubectl port-forward -n neonvm-system pod/<pod-name> 7778:7778 &
curl http://localhost:7778/
```

---

Part of the reason for this change is that the metrics reported by #757 indicate there's a VM in prod that has been failing to reconcile, even though the logs don't show per-VM error rates consistent with that. So hopefully this should allow us to debug issues like this in the future.