### PR TITLE
neonvm-controller: Enable container-mgr by default

### DIFF
--- a/neonvm/config/default-vxlan/manager_config_patch.yaml
+++ b/neonvm/config/default-vxlan/manager_config_patch.yaml
@@ -17,6 +17,7 @@ spec:
         - "--metrics-bind-address=:8080"
         - "--leader-elect"
         - "--concurrency-limit=128"
+        - "--enable-container-mgr"
         - "--zap-devel=false"
         - "--zap-time-encoding=iso8601"
         - "--zap-log-level=info"


### PR DESCRIPTION
We should have this for dev at least. We'll probably need to be careful not to prematurely enable it staging/prod, but that should be straightforward enough.