### PR TITLE
neonvm-controller: Bump CPU limits 4 -> 8

### DIFF
--- a/neonvm/config/default-vxlan/manager_config_patch.yaml
+++ b/neonvm/config/default-vxlan/manager_config_patch.yaml
@@ -32,7 +32,7 @@ spec:
           value: $(NAD_RUNNER_NAMESPACE)
         resources:
           limits:
-            cpu: 4
+            cpu: 8
             memory: 2Gi
           requests:
             cpu: 2


### PR DESCRIPTION
We noticed higher than desired reconcile latency in prod because of CPU throttling. Bumping CPU limits from 4 to 8 in larger regions significantly reduced latency, without increasing average CPU usage.

ref https://neondb.slack.com/archives/C03TN5G758R/p1707686417925039