### PR TITLE
add more example vms of different pg version

### DIFF
--- a/vm-examples/pg-tools/cgconfig.conf
+++ b/vm-examples/pg-tools/cgconfig.conf
@@ -1,0 +1,14 @@
+# Configuration for cgroups.
+#
+# This file just defines a cgroup for testing.
+group neon-test {
+    perm {
+        admin {
+            uid = vm-monitor;
+        }
+        task {
+            gid = users;
+        }
+    }
+    memory {}
+}

--- a/vm-examples/pg-tools/image-spec.yaml
+++ b/vm-examples/pg-tools/image-spec.yaml
@@ -1,0 +1,56 @@
+# Input to vm-builder
+---
+commands:
+  - name: cgconfigparser
+    user: root
+    sysvInitAction: sysinit
+    shell: "/usr/sbin/cgconfigparser -l /etc/cgconfig.conf -s 1664"
+  - name: vm-monitor
+    user: vm-monitor
+    sysvInitAction: respawn
+    shell: 'RUST_LOG=info /bin/vm-monitor --cgroup=neon-test --addr="0.0.0.0:10301"'
+build: |
+  # Build vm-monitor
+  FROM rust:1.74-alpine as monitor-builder
+  WORKDIR /workspace
+
+  RUN apk add musl-dev git openssl-dev
+
+  # Which branch to pull from
+  ENV BRANCH main
+
+  # Ensures we reclone upon new commits
+  # https://stackoverflow.com/questions/35134713
+  ADD "https://api.github.com/repos/neondatabase/neon/commits/$BRANCH" latest_commit
+
+  RUN git clone --depth 1 --branch $BRANCH https://github.com/neondatabase/neon.git
+  RUN cargo build --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+  # Move binary so we can cargo clean
+  RUN mkdir -p /workspace/bin && cp /workspace/neon/target/release/vm-monitor /workspace/bin
+  # Cargo clean dramatically reduces the size of the image
+  RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+
+merge: |
+  RUN adduser vm-monitor --disabled-password --no-create-home
+
+  RUN set -e \
+      && apk add --no-cache \
+              ca-certificates \
+              util-linux-misc \
+              coreutils \
+              cgroup-tools
+
+  # postgresql and tools
+  RUN set -e \
+        && apk add --no-cache \
+                su-exec \
+                postgresql14 \
+                postgresql15 \
+                postgresql16 \
+                curl \
+                wget
+    
+  COPY --from=monitor-builder       /workspace/bin/vm-monitor /bin/vm-monitor
+
+  # set the greeting message on ssh logins
+  RUN echo -e 'Welcome to Alpine!\n ~ This is the pg_tools VM :) ~' >/etc/motd

--- a/vm-examples/pg-tools/vector.yaml
+++ b/vm-examples/pg-tools/vector.yaml
@@ -1,0 +1,21 @@
+data_dir: /tmp
+api:
+  enabled: true
+  address: "0.0.0.0:8686"
+  playground: false
+sources:
+  host_metrics:
+    filesystem:
+      devices:
+        excludes: [binfmt_misc]
+      filesystems:
+        excludes: [binfmt_misc]
+      mountPoints:
+        excludes: ["*/proc/sys/fs/binfmt_misc"]
+    type: host_metrics
+sinks:
+  prom_exporter:
+    type: prometheus_exporter
+    inputs:
+      - host_metrics
+    address: "0.0.0.0:9100"

--- a/vm-examples/pg15-disk-test/allocate-loop.c
+++ b/vm-examples/pg15-disk-test/allocate-loop.c
@@ -1,0 +1,178 @@
+// allocate-loop.c
+//
+// This program allocates memory up and down in a loop, based on the user-provided amounts.
+//
+// USAGE:
+//
+//   ./allocate-loop <MIN SIZE> <MAX SIZE>
+//
+// Both <MIN SIZE> and <MAX SIZE> must be integers, in units of MiB. For example, running:
+//
+//   ./allocate-loop 128 512
+//
+// ... will gradually allocate from 128 MiB to 512 MiB and back down, repeating back and forth.
+//
+// The rate of allocation is set by internal constants, and is currently 256 MiB/s.
+
+#define _GNU_SOURCE
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+// Inferred stats:
+// * Change by 256 MiB / second
+// * Print every 0.1s (approx. every 25 MiB)
+const size_t step_size = 256 * (1 << 10); // 256 KiB
+const int print_every = 100;
+const long step_wait_ns = 1000*1000; // Wait 1ms between steps
+
+size_t step(size_t current, size_t previous, size_t min, size_t max);
+size_t get_rss();
+char* get_time();
+
+int main(int argc, char* argv[]) {
+	if (argc != 3) {
+		fprintf(stderr, "bad arguments");
+		return 1;
+	}
+
+	size_t min_size_mb;
+	size_t max_size_mb;
+
+	if (sscanf(argv[1], "%zu", &min_size_mb) != 1 || sscanf(argv[2], "%zu", &max_size_mb) != 1) {
+		fprintf(stderr, "bad arguments: must be integers\n");
+		return 1;
+	}
+
+	printf("Selected: minimum = %zu MiB, maximum = %zu MiB\n", min_size_mb, max_size_mb);
+
+	size_t mib = 1 << 20;
+	size_t min_size = min_size_mb * mib;
+	size_t max_size = max_size_mb * mib;
+
+	int memfd = memfd_create("experiment", 0);
+	if (memfd == -1) {
+		err(errno, "memfd");
+	}
+
+	if (ftruncate(memfd, max_size) == -1) {
+		err(errno, "memfd set to min_size");
+	}
+
+	char *map = mmap(NULL, max_size, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_NORESERVE, memfd, 0);
+	if (map == (void *)-1) {
+		err(errno, "map");
+	}
+
+	memset(map, 0xAB, min_size);
+	printf("mmap created at minimum size\n");
+
+	// Run in a loop
+	size_t current_size = min_size;
+	size_t previous_size = current_size;
+	for (int i = 0; ; i++) {
+		size_t new_size = step(current_size, previous_size, min_size, max_size);
+
+		if (new_size > current_size) {
+			// to allocate more, just write to the pages:
+			memset(&map[current_size], 0xAB, new_size-current_size);
+		} else if (new_size < current_size) {
+			// to deallocate, use madvise() to tell the kernel it can reclaim some pages
+			if (madvise(&map[new_size], current_size-new_size, MADV_REMOVE) == -1) {
+				err(errno, "madvise");
+			}
+		} else {
+			fprintf(stderr,
+					"internal error: previous = %ld, current = %ld, new = %ld\n",
+					previous_size, current_size, new_size);
+			return 1;
+		}
+
+		if (i % print_every == 0) {
+			char* time = get_time();
+			size_t rss = get_rss();
+			printf("%s :: %ld MiB + %ld KiB, rss = %ld\n",
+					time,
+					new_size / (1 << 20),
+					(new_size % (1 << 20)) / (1 << 10),
+					rss);
+		}
+
+		previous_size = current_size;
+		current_size = new_size;
+
+		struct timespec ts;
+		ts.tv_sec = 0;
+		ts.tv_nsec = step_wait_ns;
+		nanosleep(&ts, NULL);
+	}
+
+	return 0;
+}
+
+size_t step(size_t current, size_t previous, size_t min, size_t max) {
+	if (current == min) {
+		return current + step_size;
+	} else if (current == max) {
+		return current - step_size;
+	} else {
+		return current + (current - previous);
+	}
+}
+
+// note: the returned string points into a static variable. Do not use old return values across
+// calls to this function.
+char* get_time() {
+	static char time[64] = {0};
+
+	struct timeval now;
+	gettimeofday(&now, NULL);
+	int milli = now.tv_usec / 1000;
+
+	char buf[32];
+	strftime(buf, sizeof(buf), "%H:%M:%S", gmtime(&now.tv_sec));
+
+	sprintf(time, "%s.%03d", buf, milli);
+	return time;
+}
+
+size_t get_rss() {
+	char* path;
+	if (asprintf(&path, "/proc/%d/status", getpid()) == -1) {
+		err(errno, "asprintf");
+	}
+
+	FILE* file;
+	if ((file = fopen(path, "r")) == NULL) {
+		err(errno, "fopen");
+	}
+
+	char* vmrss_prefix = "VmRSS:";
+	int prefix_len = strlen(vmrss_prefix);
+
+	char line_buf[256];
+	while (fgets(line_buf, sizeof(line_buf), file)) {
+		if (strncmp(line_buf, vmrss_prefix, prefix_len) == 0) {
+			size_t rss;
+			if (sscanf(line_buf + prefix_len, " %ld", &rss) != 1) {
+				err(errno, "sscanf");
+			}
+
+			fclose(file);
+			free(path);
+			return rss;
+		}
+	}
+
+	fprintf(stderr, "couldn't find VmRSS in %s\n", path);
+	exit(1);
+}

--- a/vm-examples/pg15-disk-test/cgconfig.conf
+++ b/vm-examples/pg15-disk-test/cgconfig.conf
@@ -1,0 +1,14 @@
+# Configuration for cgroups.
+#
+# This file just defines a cgroup for testing.
+group neon-test {
+    perm {
+        admin {
+            uid = vm-monitor;
+        }
+        task {
+            gid = users;
+        }
+    }
+    memory {}
+}

--- a/vm-examples/pg15-disk-test/image-spec.yaml
+++ b/vm-examples/pg15-disk-test/image-spec.yaml
@@ -1,0 +1,90 @@
+# Input to vm-builder
+---
+commands:
+  - name: cgconfigparser
+    user: root
+    sysvInitAction: sysinit
+    shell: '/usr/sbin/cgconfigparser -l /etc/cgconfig.conf -s 1664'
+  - name: postgres-data
+    user: root
+    sysvInitAction: sysinit
+    shell: 'mkdir -p /run/postgresql && chown -R postgres:postgres /run/postgresql'
+  - name: vm-monitor
+    user: vm-monitor
+    sysvInitAction: respawn
+    shell: 'RUST_LOG=info /bin/vm-monitor --cgroup=neon-test --addr="0.0.0.0:10301"'
+  - name: start-postgres
+    user: postgres
+    sysvInitAction: once
+    shell: 'PGDATA=/var/lib/postgresql pg_ctl start -o "-c config_file=/etc/postgresql.conf -c hba_file=/etc/pg_hba.conf" -l /dev/virtio-ports/tech.neon.log.0'
+files:
+  - filename: postgresql.conf
+    hostPath: postgresql.conf
+  - filename: pg_hba.conf
+    hostPath: pg_hba.conf
+  - filename: allocate-loop.c
+    hostPath: allocate-loop.c
+  - filename: cgconfig.conf
+    hostPath: cgconfig.conf
+build: |
+  # Build vm-monitor
+  FROM rust:1.74-alpine as monitor-builder
+  WORKDIR /workspace
+
+  RUN apk add musl-dev git openssl-dev
+
+  # Which branch to pull from
+  ENV BRANCH main
+
+  # Ensures we reclone upon new commits
+  # https://stackoverflow.com/questions/35134713
+  ADD "https://api.github.com/repos/neondatabase/neon/commits/$BRANCH" latest_commit
+
+  RUN git clone --depth 1 --branch $BRANCH https://github.com/neondatabase/neon.git
+  RUN cargo build --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+  # Move binary so we can cargo clean
+  RUN mkdir -p /workspace/bin && cp /workspace/neon/target/release/vm-monitor /workspace/bin
+  # Cargo clean dramatically reduces the size of the image
+  RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+
+  # Build the allocation tester:
+  FROM alpine:3.16 AS allocate-loop-builder
+  RUN set -e \
+      && apk add gcc musl-dev
+  COPY allocate-loop.c allocate-loop.c
+  RUN set -e \
+      && gcc -g -O allocate-loop.c -o /bin/allocate-loop
+
+merge: |
+  RUN adduser vm-monitor --disabled-password --no-create-home
+
+  COPY cgconfig.conf         /etc/cgconfig.conf
+  COPY postgresql.conf       /etc/postgresql.conf
+  COPY pg_hba.conf           /etc/pg_hba.conf
+
+  # General tools
+  RUN set -e \
+      && apk add --no-cache \
+              ca-certificates \
+              util-linux-misc \
+              coreutils \
+              cgroup-tools
+
+  # postgresql stuff
+  RUN set -e \
+        && apk add --no-cache \
+                su-exec \
+                postgresql15
+
+  # Initialize postgres
+  ENV PGDATA /var/lib/postgresql
+  RUN set -e \
+      && mkdir -p ${PGDATA} /run/postgresql \
+      && chown -R postgres:postgres ${PGDATA} /run/postgresql \
+      && su-exec postgres pg_ctl init
+
+  COPY --from=allocate-loop-builder /bin/allocate-loop        /bin/allocate-loop
+  COPY --from=monitor-builder       /workspace/bin/vm-monitor /bin/vm-monitor
+
+  # set the greeting message on ssh logins
+  RUN echo -e 'Welcome to Alpine!\n ~ This is the VM :) ~' >/etc/motd

--- a/vm-examples/pg15-disk-test/pg_hba.conf
+++ b/vm-examples/pg15-disk-test/pg_hba.conf
@@ -1,0 +1,23 @@
+# ATTENTION
+#
+# USE IT ONLY FOR TESTS (SEE DANGEROUS PART)
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust
+
+
+# DANGEROUS PART! DO NOT USE IN REAL SCENARIO
+host    all             all             10.0.0.0/8              trust
+host    all             all             172.16.0.0/12           trust
+host    all             all             192.168.0.0/16          trust

--- a/vm-examples/pg15-disk-test/postgresql.conf
+++ b/vm-examples/pg15-disk-test/postgresql.conf
@@ -1,0 +1,35 @@
+# DB Version: 14
+# OS Type: linux
+# DB Type: oltp
+# Total Memory (RAM): 1 GB
+# CPUs num: 1
+# Connections num: 32
+# Data Storage: ssd
+
+max_connections = 32
+shared_buffers = 256MB
+effective_cache_size = 768MB
+maintenance_work_mem = 64MB
+checkpoint_completion_target = 0.9
+wal_buffers = 7864kB
+default_statistics_target = 100
+random_page_cost = 1.1
+effective_io_concurrency = 200
+work_mem = 4MB
+min_wal_size = 2GB
+max_wal_size = 8GB
+
+# MANUAL TUNING
+#
+listen_addresses = '*'
+dynamic_shared_memory_type = mmap
+
+min_wal_size = 1GB
+max_wal_size = 3GB
+
+# comment out next setting used for performance
+#max_wal_senders = 0
+#wal_level = minimal
+#fsync = off
+#synchronous_commit = off
+#full_page_writes = off

--- a/vm-examples/pg15-disk-test/vector.yaml
+++ b/vm-examples/pg15-disk-test/vector.yaml
@@ -1,0 +1,21 @@
+data_dir: /tmp
+api:
+  enabled: true
+  address: "0.0.0.0:8686"
+  playground: false
+sources:
+  host_metrics:
+    filesystem:
+      devices:
+        excludes: [binfmt_misc]
+      filesystems:
+        excludes: [binfmt_misc]
+      mountPoints:
+        excludes: ["*/proc/sys/fs/binfmt_misc"]
+    type: host_metrics
+sinks:
+  prom_exporter:
+    type: prometheus_exporter
+    inputs:
+      - host_metrics
+    address: "0.0.0.0:9100"

--- a/vm-examples/pg16-disk-test/allocate-loop.c
+++ b/vm-examples/pg16-disk-test/allocate-loop.c
@@ -1,0 +1,178 @@
+// allocate-loop.c
+//
+// This program allocates memory up and down in a loop, based on the user-provided amounts.
+//
+// USAGE:
+//
+//   ./allocate-loop <MIN SIZE> <MAX SIZE>
+//
+// Both <MIN SIZE> and <MAX SIZE> must be integers, in units of MiB. For example, running:
+//
+//   ./allocate-loop 128 512
+//
+// ... will gradually allocate from 128 MiB to 512 MiB and back down, repeating back and forth.
+//
+// The rate of allocation is set by internal constants, and is currently 256 MiB/s.
+
+#define _GNU_SOURCE
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+// Inferred stats:
+// * Change by 256 MiB / second
+// * Print every 0.1s (approx. every 25 MiB)
+const size_t step_size = 256 * (1 << 10); // 256 KiB
+const int print_every = 100;
+const long step_wait_ns = 1000*1000; // Wait 1ms between steps
+
+size_t step(size_t current, size_t previous, size_t min, size_t max);
+size_t get_rss();
+char* get_time();
+
+int main(int argc, char* argv[]) {
+	if (argc != 3) {
+		fprintf(stderr, "bad arguments");
+		return 1;
+	}
+
+	size_t min_size_mb;
+	size_t max_size_mb;
+
+	if (sscanf(argv[1], "%zu", &min_size_mb) != 1 || sscanf(argv[2], "%zu", &max_size_mb) != 1) {
+		fprintf(stderr, "bad arguments: must be integers\n");
+		return 1;
+	}
+
+	printf("Selected: minimum = %zu MiB, maximum = %zu MiB\n", min_size_mb, max_size_mb);
+
+	size_t mib = 1 << 20;
+	size_t min_size = min_size_mb * mib;
+	size_t max_size = max_size_mb * mib;
+
+	int memfd = memfd_create("experiment", 0);
+	if (memfd == -1) {
+		err(errno, "memfd");
+	}
+
+	if (ftruncate(memfd, max_size) == -1) {
+		err(errno, "memfd set to min_size");
+	}
+
+	char *map = mmap(NULL, max_size, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_NORESERVE, memfd, 0);
+	if (map == (void *)-1) {
+		err(errno, "map");
+	}
+
+	memset(map, 0xAB, min_size);
+	printf("mmap created at minimum size\n");
+
+	// Run in a loop
+	size_t current_size = min_size;
+	size_t previous_size = current_size;
+	for (int i = 0; ; i++) {
+		size_t new_size = step(current_size, previous_size, min_size, max_size);
+
+		if (new_size > current_size) {
+			// to allocate more, just write to the pages:
+			memset(&map[current_size], 0xAB, new_size-current_size);
+		} else if (new_size < current_size) {
+			// to deallocate, use madvise() to tell the kernel it can reclaim some pages
+			if (madvise(&map[new_size], current_size-new_size, MADV_REMOVE) == -1) {
+				err(errno, "madvise");
+			}
+		} else {
+			fprintf(stderr,
+					"internal error: previous = %ld, current = %ld, new = %ld\n",
+					previous_size, current_size, new_size);
+			return 1;
+		}
+
+		if (i % print_every == 0) {
+			char* time = get_time();
+			size_t rss = get_rss();
+			printf("%s :: %ld MiB + %ld KiB, rss = %ld\n",
+					time,
+					new_size / (1 << 20),
+					(new_size % (1 << 20)) / (1 << 10),
+					rss);
+		}
+
+		previous_size = current_size;
+		current_size = new_size;
+
+		struct timespec ts;
+		ts.tv_sec = 0;
+		ts.tv_nsec = step_wait_ns;
+		nanosleep(&ts, NULL);
+	}
+
+	return 0;
+}
+
+size_t step(size_t current, size_t previous, size_t min, size_t max) {
+	if (current == min) {
+		return current + step_size;
+	} else if (current == max) {
+		return current - step_size;
+	} else {
+		return current + (current - previous);
+	}
+}
+
+// note: the returned string points into a static variable. Do not use old return values across
+// calls to this function.
+char* get_time() {
+	static char time[64] = {0};
+
+	struct timeval now;
+	gettimeofday(&now, NULL);
+	int milli = now.tv_usec / 1000;
+
+	char buf[32];
+	strftime(buf, sizeof(buf), "%H:%M:%S", gmtime(&now.tv_sec));
+
+	sprintf(time, "%s.%03d", buf, milli);
+	return time;
+}
+
+size_t get_rss() {
+	char* path;
+	if (asprintf(&path, "/proc/%d/status", getpid()) == -1) {
+		err(errno, "asprintf");
+	}
+
+	FILE* file;
+	if ((file = fopen(path, "r")) == NULL) {
+		err(errno, "fopen");
+	}
+
+	char* vmrss_prefix = "VmRSS:";
+	int prefix_len = strlen(vmrss_prefix);
+
+	char line_buf[256];
+	while (fgets(line_buf, sizeof(line_buf), file)) {
+		if (strncmp(line_buf, vmrss_prefix, prefix_len) == 0) {
+			size_t rss;
+			if (sscanf(line_buf + prefix_len, " %ld", &rss) != 1) {
+				err(errno, "sscanf");
+			}
+
+			fclose(file);
+			free(path);
+			return rss;
+		}
+	}
+
+	fprintf(stderr, "couldn't find VmRSS in %s\n", path);
+	exit(1);
+}

--- a/vm-examples/pg16-disk-test/cgconfig.conf
+++ b/vm-examples/pg16-disk-test/cgconfig.conf
@@ -1,0 +1,14 @@
+# Configuration for cgroups.
+#
+# This file just defines a cgroup for testing.
+group neon-test {
+    perm {
+        admin {
+            uid = vm-monitor;
+        }
+        task {
+            gid = users;
+        }
+    }
+    memory {}
+}

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -1,0 +1,90 @@
+# Input to vm-builder
+---
+commands:
+  - name: cgconfigparser
+    user: root
+    sysvInitAction: sysinit
+    shell: '/usr/sbin/cgconfigparser -l /etc/cgconfig.conf -s 1664'
+  - name: postgres-data
+    user: root
+    sysvInitAction: sysinit
+    shell: 'mkdir -p /run/postgresql && chown -R postgres:postgres /run/postgresql'
+  - name: vm-monitor
+    user: vm-monitor
+    sysvInitAction: respawn
+    shell: 'RUST_LOG=info /bin/vm-monitor --cgroup=neon-test --addr="0.0.0.0:10301"'
+  - name: start-postgres
+    user: postgres
+    sysvInitAction: once
+    shell: 'PGDATA=/var/lib/postgresql pg_ctl start -o "-c config_file=/etc/postgresql.conf -c hba_file=/etc/pg_hba.conf" -l /dev/virtio-ports/tech.neon.log.0'
+files:
+  - filename: postgresql.conf
+    hostPath: postgresql.conf
+  - filename: pg_hba.conf
+    hostPath: pg_hba.conf
+  - filename: allocate-loop.c
+    hostPath: allocate-loop.c
+  - filename: cgconfig.conf
+    hostPath: cgconfig.conf
+build: |
+  # Build vm-monitor
+  FROM rust:1.74-alpine as monitor-builder
+  WORKDIR /workspace
+
+  RUN apk add musl-dev git openssl-dev
+
+  # Which branch to pull from
+  ENV BRANCH main
+
+  # Ensures we reclone upon new commits
+  # https://stackoverflow.com/questions/35134713
+  ADD "https://api.github.com/repos/neondatabase/neon/commits/$BRANCH" latest_commit
+
+  RUN git clone --depth 1 --branch $BRANCH https://github.com/neondatabase/neon.git
+  RUN cargo build --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+  # Move binary so we can cargo clean
+  RUN mkdir -p /workspace/bin && cp /workspace/neon/target/release/vm-monitor /workspace/bin
+  # Cargo clean dramatically reduces the size of the image
+  RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+
+  # Build the allocation tester:
+  FROM alpine:3.16 AS allocate-loop-builder
+  RUN set -e \
+      && apk add gcc musl-dev
+  COPY allocate-loop.c allocate-loop.c
+  RUN set -e \
+      && gcc -g -O allocate-loop.c -o /bin/allocate-loop
+
+merge: |
+  RUN adduser vm-monitor --disabled-password --no-create-home
+
+  COPY cgconfig.conf         /etc/cgconfig.conf
+  COPY postgresql.conf       /etc/postgresql.conf
+  COPY pg_hba.conf           /etc/pg_hba.conf
+
+  # General tools
+  RUN set -e \
+      && apk add --no-cache \
+              ca-certificates \
+              util-linux-misc \
+              coreutils \
+              cgroup-tools
+
+  # postgresql stuff
+  RUN set -e \
+        && apk add --no-cache \
+                su-exec \
+                postgresql16
+
+  # Initialize postgres
+  ENV PGDATA /var/lib/postgresql
+  RUN set -e \
+      && mkdir -p ${PGDATA} /run/postgresql \
+      && chown -R postgres:postgres ${PGDATA} /run/postgresql \
+      && su-exec postgres pg_ctl init
+
+  COPY --from=allocate-loop-builder /bin/allocate-loop        /bin/allocate-loop
+  COPY --from=monitor-builder       /workspace/bin/vm-monitor /bin/vm-monitor
+
+  # set the greeting message on ssh logins
+  RUN echo -e 'Welcome to Alpine!\n ~ This is the VM :) ~' >/etc/motd

--- a/vm-examples/pg16-disk-test/pg_hba.conf
+++ b/vm-examples/pg16-disk-test/pg_hba.conf
@@ -1,0 +1,23 @@
+# ATTENTION
+#
+# USE IT ONLY FOR TESTS (SEE DANGEROUS PART)
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust
+
+
+# DANGEROUS PART! DO NOT USE IN REAL SCENARIO
+host    all             all             10.0.0.0/8              trust
+host    all             all             172.16.0.0/12           trust
+host    all             all             192.168.0.0/16          trust

--- a/vm-examples/pg16-disk-test/postgresql.conf
+++ b/vm-examples/pg16-disk-test/postgresql.conf
@@ -1,0 +1,35 @@
+# DB Version: 14
+# OS Type: linux
+# DB Type: oltp
+# Total Memory (RAM): 1 GB
+# CPUs num: 1
+# Connections num: 32
+# Data Storage: ssd
+
+max_connections = 32
+shared_buffers = 256MB
+effective_cache_size = 768MB
+maintenance_work_mem = 64MB
+checkpoint_completion_target = 0.9
+wal_buffers = 7864kB
+default_statistics_target = 100
+random_page_cost = 1.1
+effective_io_concurrency = 200
+work_mem = 4MB
+min_wal_size = 2GB
+max_wal_size = 8GB
+
+# MANUAL TUNING
+#
+listen_addresses = '*'
+dynamic_shared_memory_type = mmap
+
+min_wal_size = 1GB
+max_wal_size = 3GB
+
+# comment out next setting used for performance
+#max_wal_senders = 0
+#wal_level = minimal
+#fsync = off
+#synchronous_commit = off
+#full_page_writes = off

--- a/vm-examples/pg16-disk-test/vector.yaml
+++ b/vm-examples/pg16-disk-test/vector.yaml
@@ -1,0 +1,21 @@
+data_dir: /tmp
+api:
+  enabled: true
+  address: "0.0.0.0:8686"
+  playground: false
+sources:
+  host_metrics:
+    filesystem:
+      devices:
+        excludes: [binfmt_misc]
+      filesystems:
+        excludes: [binfmt_misc]
+      mountPoints:
+        excludes: ["*/proc/sys/fs/binfmt_misc"]
+    type: host_metrics
+sinks:
+  prom_exporter:
+    type: prometheus_exporter
+    inputs:
+      - host_metrics
+    address: "0.0.0.0:9100"


### PR DESCRIPTION
This pull request adds more example VMs to the autoscaling repo: pg14/15/16, plus an image that contains Postgres tools (of different versions) without starting any Postgres instance.

The config files (`vector.yaml`, `cgconfig.conf`, `pg_hba.conf`, `postgresql.conf`) are copied from the original pg14 vm and it seems backward compatible.

Manually tested and pg_bench runs on all 3 versions of Postgres VM images.