### PR TITLE
runner: log forward: wait for QEMU startup and prevent panic

### DIFF
--- a/neonvm/config/default-vxlan/manager_config_patch.yaml
+++ b/neonvm/config/default-vxlan/manager_config_patch.yaml
@@ -17,6 +17,7 @@ spec:
         - "--metrics-bind-address=:8080"
         - "--leader-elect"
         - "--concurrency-limit=128"
+        - "--enable-container-mgr"
         - "--zap-devel=false"
         - "--zap-time-encoding=iso8601"
         - "--zap-log-level=info"

--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -892,7 +892,7 @@ func forwardLogs(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup) {
 	// Wait a bit to reduce the chance we attempt dialing before
 	// QEMU is started
 	select {
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 	case <-ctx.Done():
 		logger.Warn("QEMU shut down too soon to start forwarding logs")
 	}

--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -925,7 +925,9 @@ func forwardLogs(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup) {
 			if conn != nil {
 				conn.Close()
 			}
-			_ = drainLogsReader(reader, logger)
+			if reader != nil {
+				_ = drainLogsReader(reader, logger)
+			}
 			return
 		case <-time.After(b.Duration()):
 		}


### PR DESCRIPTION
Previously, if QEMU failed to startup, the log output contained either:
1. Panic, because of `reader==nil`
2. `"error":"dial unix /vm/log.sock: connect: no such file or directory","stacktrace":"main.forwardLogs.func1\n\t/workspace/neonvm/runner/main.go:897\nmain.forwardLogs\n\t/workspace/neonvm/runner/main.go:921"`

Which was confusing. Not it will have:

`{"level":"warn","ts":1707993260.548491,"logger":"neonvm-runner","caller":"runner/main.go:897","msg":"QEMU shut down too soon to start forwarding logs"}`

Panic was found by the Discord user @ido6668.

Fixes #791 
