### PR TITLE
plugin: Remove client_addr metrics label

### DIFF
--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -58,7 +58,7 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 				Name: "autoscaling_plugin_resource_requests_total",
 				Help: "Number of resource requests received by the scheduler plugin",
 			},
-			[]string{"client_addr", "code"},
+			[]string{"code"},
 		)),
 		validResourceRequests: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -38,7 +38,7 @@ func (e *AutoscaleEnforcer) startPermitHandler(ctx context.Context, logger *zap.
 
 		var finalStatus int
 		defer func() {
-			e.metrics.resourceRequests.WithLabelValues(r.RemoteAddr, strconv.Itoa(finalStatus)).Inc()
+			e.metrics.resourceRequests.WithLabelValues(strconv.Itoa(finalStatus)).Inc()
 		}()
 
 		// Catch any potential panics and report them as 500s


### PR DESCRIPTION
It's unnecessarily high-cardinality and never used.

Ref https://neondb.slack.com/archives/C03TN5G758R/p1708344983594829