### PR TITLE
neonvm: increase neonvm-controller replicas

### DIFF
--- a/neonvm/config/common/controller/manager.yaml
+++ b/neonvm/config/common/controller/manager.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       control-plane: controller
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Increase neonvm-controller replicas to have highly available deployment for neonvm controller.

We already have leader-election enabled for neonvm-controller: https://github.com/neondatabase/autoscaling/blob/9beedbd2624fc04dcfe4efd600ebc7dd771c355f/neonvm/config/common/controller/manager.yaml#L60

Because of leader election at any point in time, at most one controller can run the reconcile loop. No matter if we're in the middle of a deployment, rollback, or any other case. Increasing the number of replicas doesn't break this safety property. 

Leader election is enabled by default in kube-builder projects and turning it off is unsafe in our case (even with a single replica) since during deployments or rollbacks two replicas may run the reconcile loop.

## Caveats

Kubernetes implements leader-election in the client side (client-go package) using leases and doesn't implement fencing. As a result in case of clock skew, we might end up having two leaders running in the cluster. This is an interesting design choice. We have to make sure we have clock sync in our k8s nodes.

More about client-go leader election: https://pkg.go.dev/k8s.io/client-go/tools/leaderelection

Resolves #762 