### PR TITLE
neonvm: Remove controller metrics auth proxy

### DIFF
--- a/neonvm/config/controller/deployment.yaml
+++ b/neonvm/config/controller/deployment.yaml
@@ -114,29 +114,6 @@ spec:
           requests:
             cpu: 2
             memory: 1Gi
-      - name: kube-rbac-proxy
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
-        args:
-        - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
-        - "--logtostderr=true"
-        - "--v=0"
-        ports:
-        - containerPort: 8443
-          protocol: TCP
-          name: https
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
       serviceAccountName: controller
       terminationGracePeriodSeconds: 10
       volumes:


### PR DESCRIPTION
This wasn't being used (not scraping metrics), and then when we started scraping metrics, we just exposed the port directly.

Maybe in the future we'll want to make these metrics more restrictive, but for now there's bigger fish to fry.

---

This is a second attempt at 31383df2209433d66233c0b5a10b80c44a962178 (from #779), built atop #824. A notable difference is that this time around, we're not touching the controller pod's affinity.

**NB: This PR builds on #824, and must not be merged before it.**