### PR TITLE
neonvm-runner: Use diskCacheSettings for swap disk

### DIFF
--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -722,7 +722,7 @@ func main() {
 		if err := createSwap(diskName, dPath, swapSize); err != nil {
 			logger.Fatal("Failed to create swap QCOW2 image", zap.Error(err))
 		}
-		qemuCmd = append(qemuCmd, "-drive", fmt.Sprintf("id=%s,file=%s,if=virtio,media=disk,cache=none,discard=unmap", diskName, dPath))
+		qemuCmd = append(qemuCmd, "-drive", fmt.Sprintf("id=%s,file=%s,if=virtio,media=disk,%s,discard=unmap", diskName, dPath, diskCacheSettings))
 	}
 
 	for _, disk := range vmSpec.Disks {


### PR DESCRIPTION
Must have missed it previously. We definitely want this parameterized by the disk cache settings, because characteristics around swap will have a big impact on lower bounds for performance.

ref https://neondb.slack.com/archives/C03TN5G758R/p1708630454044509?thread_ts=1707675595.221699