### PR TITLE
neonvm-controller: Catch Reconcile() panics

### DIFF
--- a/neonvm/controllers/catch_panic.go
+++ b/neonvm/controllers/catch_panic.go
@@ -1,0 +1,33 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type catchPanicReconciler struct {
+	inner reconcile.Reconciler
+}
+
+func withCatchPanic(r reconcile.Reconciler) reconcile.Reconciler {
+	return &catchPanicReconciler{inner: r}
+}
+
+func (r *catchPanicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	log := log.FromContext(ctx) // TODO: is this valid?
+
+	defer func() {
+		if v := recover(); v != nil {
+			err = fmt.Errorf("Reconcile panicked: %v", v)
+			log.Error(err, "stack", string(debug.Stack()))
+		}
+	}()
+
+	result, err = r.inner.Reconcile(ctx, req)
+	return
+}

--- a/neonvm/controllers/catch_panic.go
+++ b/neonvm/controllers/catch_panic.go
@@ -19,7 +19,7 @@ func withCatchPanic(r reconcile.Reconciler) reconcile.Reconciler {
 }
 
 func (r *catchPanicReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
-	log := log.FromContext(ctx) // TODO: is this valid?
+	log := log.FromContext(ctx)
 
 	defer func() {
 		if v := recover(); v != nil {

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -29,7 +29,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -109,7 +108,7 @@ type VirtualMachineReconciler struct {
 // - About Operator Pattern: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 // - About Controllers: https://kubernetes.io/docs/concepts/architecture/controller/
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
-func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, err error) {
+func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
 	var virtualmachine vmv1.VirtualMachine

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -89,13 +89,6 @@ type VirtualMachineMigrationReconciler struct {
 func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, err error) {
 	log := log.FromContext(ctx)
 
-	defer func() {
-		if v := recover(); v != nil {
-			err = fmt.Errorf("Reconcile panicked: %v", v)
-			log.Error(err, "stack", string(debug.Stack()))
-		}
-	}()
-
 	// Fetch the VirtualMachineMigration instance
 	// The purpose is check if the Custom Resource for the Kind VirtualMachineMigration
 	// is applied on the cluster if not we return nil to stop the reconciliation
@@ -678,7 +671,7 @@ func (r *VirtualMachineMigrationReconciler) doFinalizerOperationsForVirtualMachi
 // desirable state on the cluster
 func (r *VirtualMachineMigrationReconciler) SetupWithManager(mgr ctrl.Manager) (ReconcilerWithMetrics, error) {
 	cntrlName := "virtualmachinemigration"
-	reconciler := WithMetrics(r, r.Metrics, cntrlName)
+	reconciler := WithMetrics(withCatchPanic(r), r.Metrics, cntrlName)
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&vmv1.VirtualMachineMigration{}).
 		Owns(&corev1.Pod{}).

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime/debug"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -85,8 +86,15 @@ type VirtualMachineMigrationReconciler struct {
 // - About Operator Pattern: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 // - About Controllers: https://kubernetes.io/docs/concepts/architecture/controller/
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
-func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, err error) {
 	log := log.FromContext(ctx)
+
+	defer func() {
+		if v := recover(); v != nil {
+			err = fmt.Errorf("Reconcile panicked: %v", v)
+			log.Error(err, "stack", string(debug.Stack()))
+		}
+	}()
 
 	// Fetch the VirtualMachineMigration instance
 	// The purpose is check if the Custom Resource for the Kind VirtualMachineMigration
@@ -147,7 +155,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 
 	// Fetch the corresponding VirtualMachine instance
 	vm := new(vmv1.VirtualMachine)
-	err := r.Get(ctx, types.NamespacedName{Name: migration.Spec.VmName, Namespace: migration.Namespace}, vm)
+	err = r.Get(ctx, types.NamespacedName{Name: migration.Spec.VmName, Namespace: migration.Namespace}, vm)
 	if err != nil {
 		log.Error(err, "Failed to get VM", "VmName", migration.Spec.VmName)
 		if apierrors.IsNotFound(err) {

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"runtime/debug"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -86,7 +85,7 @@ type VirtualMachineMigrationReconciler struct {
 // - About Operator Pattern: https://kubernetes.io/docs/concepts/extend-kubernetes/operator/
 // - About Controllers: https://kubernetes.io/docs/concepts/architecture/controller/
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
-func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, err error) {
+func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
 	// Fetch the VirtualMachineMigration instance
@@ -148,7 +147,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 
 	// Fetch the corresponding VirtualMachine instance
 	vm := new(vmv1.VirtualMachine)
-	err = r.Get(ctx, types.NamespacedName{Name: migration.Spec.VmName, Namespace: migration.Namespace}, vm)
+	err := r.Get(ctx, types.NamespacedName{Name: migration.Spec.VmName, Namespace: migration.Namespace}, vm)
 	if err != nil {
 		log.Error(err, "Failed to get VM", "VmName", migration.Spec.VmName)
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
In theory I think this could be done with some kind of middleware, similarly to our metrics collection. In practice, it's quite small, and probably more effort than it's worth to do the abstraction.

Resolves #827.

---

~~Haven't tested it yet, need to try that locally to check it works.~~