### PR TITLE
agent/dispatcher: Fix inbound monitor msg metrics

### DIFF
--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -556,7 +556,7 @@ func (disp *Dispatcher) run(ctx context.Context, logger *zap.Logger, upscaleRequ
 	handleUpscaleRequest := func(req api.UpscaleRequest) {
 		// TODO: it shouldn't be this function's responsibility to update metrics.
 		defer func() {
-			disp.runner.global.metrics.monitorRequestsInbound.WithLabelValues("UpscaleRequest", "ok")
+			disp.runner.global.metrics.monitorRequestsInbound.WithLabelValues("UpscaleRequest", "ok").Inc()
 		}()
 
 		resourceReq := api.MoreResources{


### PR DESCRIPTION
Tested locally with pg16-disk-test and the allocate-loop (see the README for more on this).

Really silly bug, this one.

Fixes #807