### PR TITLE
neonvm: Make .status.restartCount not a pointer

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -393,7 +393,7 @@ type VirtualMachineStatus struct {
 	Phase VmPhase `json:"phase,omitempty"`
 	// Number of times the VM runner pod has been recreated
 	// +optional
-	RestartCount *int32 `json:"restartCount,omitempty"`
+	RestartCount int32 `json:"restartCount"`
 	// +optional
 	PodName string `json:"podName,omitempty"`
 	// +optional
@@ -477,7 +477,7 @@ func (vm *VirtualMachine) Cleanup() {
 }
 
 func (vm *VirtualMachine) HasRestarted() bool {
-	return vm.Status.RestartCount != nil && *vm.Status.RestartCount > 0
+	return vm.Status.RestartCount > 0
 }
 
 //+kubebuilder:object:root=true

--- a/neonvm/apis/neonvm/v1/zz_generated.deepcopy.go
+++ b/neonvm/apis/neonvm/v1/zz_generated.deepcopy.go
@@ -726,11 +726,6 @@ func (in *VirtualMachineStatus) DeepCopyInto(out *VirtualMachineStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.RestartCount != nil {
-		in, out := &in.RestartCount, &out.RestartCount
-		*out = new(int32)
-		**out = **in
-	}
 	if in.CPUs != nil {
 		in, out := &in.CPUs, &out.CPUs
 		*out = new(MilliCPU)

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -363,7 +363,6 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 		}
 		// VirtualMachine just created, change Phase to "Pending"
 		virtualmachine.Status.Phase = vmv1.VmPending
-		virtualmachine.Status.RestartCount = &[]int32{0}[0] // set value to pointer to 0
 	case vmv1.VmPending:
 		// Check if the runner pod already exists, if not create a new one
 		vmRunner := &corev1.Pod{}
@@ -787,11 +786,7 @@ func (r *VirtualMachineReconciler) doReconcile(ctx context.Context, virtualmachi
 			if shouldRestart {
 				log.Info("Restarting VM runner pod", "VM.Phase", virtualmachine.Status.Phase, "RestartPolicy", virtualmachine.Spec.RestartPolicy)
 				virtualmachine.Status.Phase = vmv1.VmPending // reset to trigger restart
-				if virtualmachine.Status.RestartCount == nil {
-					var zero int32 = 0
-					virtualmachine.Status.RestartCount = &zero
-				}
-				*virtualmachine.Status.RestartCount += 1 // increment restart count
+				virtualmachine.Status.RestartCount += 1      // increment restart count
 				r.Metrics.vmRestartCounts.Inc()
 			}
 

--- a/pkg/agent/watch.go
+++ b/pkg/agent/watch.go
@@ -320,16 +320,13 @@ func makeVMMemMetrics(vm *vmapi.VirtualMachine) []vmMetric {
 // makeVMRestartMetrics makes metrics related to VM restarts. Currently, it
 // only includes one metrics, which is restartCount.
 func makeVMRestartMetrics(vm *vmapi.VirtualMachine) []vmMetric {
-	if vm.Status.RestartCount == nil {
-		return nil
-	}
 	endpointID := vm.Labels[endpointLabel]
 	projectID := vm.Labels[projectLabel]
 	labels := makePerVMMetricsLabels(vm.Namespace, vm.Name, endpointID, projectID, "")
 	return []vmMetric{
 		{
 			labels: labels,
-			value:  float64(*vm.Status.RestartCount),
+			value:  float64(vm.Status.RestartCount),
 		},
 	}
 }


### PR DESCRIPTION
While drawing the state machine we used for RestartCount as part of an incident summary, I realized we actually didn't even need the field to be a pointer. :facepalm:

Coudln't connect to dockerhub, so couldn't run `make generate` - tried to do that manually. We'll see if it works.