### PR TITLE
plugin: Deduplicate Relist()s triggered by VM pod start events

### DIFF
--- a/pkg/util/watch/README.md
+++ b/pkg/util/watch/README.md
@@ -90,8 +90,8 @@ of the store are at least as recent as the request to relist.
 Concretely, this allows the scheduler to always fetch the VirtualMachine associated with a Pod by
 relisting if the VM is not immediately found (the store is probably just out of date!).
 
-The details of this implementation can be found in the relisting portion of the `watch.Watch`
-function, and in `(*watch.Store[T]).Relist()`.
+The details of this implementation can be found in `relist.go`, as well as the places where its
+functions are called in `watch.Watch` and `(*watch.Store[T]).Relist()`.
 
 ## Our changes: Custom indexes
 

--- a/pkg/util/watch/relist.go
+++ b/pkg/util/watch/relist.go
@@ -24,6 +24,9 @@ type relistInfo struct {
 
 	// relistCount is the number of instances of relisted that have been closed.
 	//
+	// It acts as a logical clock, allowing us to establish a happens-before relationship between
+	// events from *other* watch instances and relist requests.
+	//
 	// Externally, we only guarantee that this is monotonically increasing; internally, it's
 	// associated each time with a single instance of `relisted`, so that RelistIfHaventSince can
 	// hook into ongoing execution.

--- a/pkg/util/watch/relist.go
+++ b/pkg/util/watch/relist.go
@@ -1,0 +1,129 @@
+package watch
+
+import (
+	"sync"
+)
+
+// relistInfo encapsulates the logic backing (*Store[T]).Relist()
+type relistInfo struct {
+	mu sync.Mutex
+
+	incRequestedMetric func()
+
+	// triggerRelist has capacity=1 and *if* the channel contains an item, then relisting has been
+	// requested by some call to (*relistInfo).Relist().
+	triggerRelist chan struct{}
+	// relisted is replaced whenever a new list request *starts* and closed once one completes
+	// successfully.
+	// Each time listing fails, we store the old channel in the relistExecutor, closing all the
+	// channels at once only when listing is successful.
+	//
+	// Refer to the usage in (*relistExecutor).CollectTriggeredRequests() for more.
+	relisted chan struct{}
+}
+
+func newRelistInfo(incRequestedMetric func()) *relistInfo {
+	return &relistInfo{
+		mu:                 sync.Mutex{},
+		incRequestedMetric: incRequestedMetric,
+		triggerRelist:      make(chan struct{}, 1), // ensure sends are non-blocking
+		relisted:           make(chan struct{}),
+	}
+}
+
+// Triggered returns a channel that contains a value when relisting has been requested
+func (r *relistInfo) Triggered() <-chan struct{} {
+	return r.triggerRelist
+}
+
+func (r *relistInfo) Relist() <-chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Because triggerRelist has capacity=1, failing to immediately send to the channel means that
+	// there's already a signal to request relisting that has not yet been processed.
+	select {
+	case r.triggerRelist <- struct{}{}:
+		// Only increment the metric if it's a "fresh" request (i.e. deduplicate before the metric).
+		// TODO: this is only for compatibility with the original definition of the metric; we
+		// should do this on every call to Relist().
+		r.incRequestedMetric()
+	default:
+	}
+
+	// note: r.relisted is replaced immediately before every attempt at the API call for relisting,
+	// so that there's a strict happens-before relation that guarantees that *when* r.relisted is
+	// closed, the relevant List call *must* have happened after any attempted send on
+	// r.triggerRelist.
+	return r.relisted
+}
+
+type relistExecutor struct {
+	r *relistInfo
+
+	// Every time we make a new request, we create a channel for it. That's because we need
+	// to make sure that any user's call to WatchStore.Relist() that happens *while* we're
+	// actually making the request to K8s won't get overwritten by that request. Basically,
+	// we need to make sure that relisting is only marked as complete if there was a request
+	// that occurred *after* the call to Relist() returned.
+	//
+	// There's probably other ways we could do this - it's an area for possible improvement.
+	//
+	// Note: if we didn't do this at all, the alternative would be to ignore additional
+	// relist requests, having them handled naturally as we get around to watching again.
+	// This can amplify request failures - particularly if the K8s API server is overloaded.
+	signalComplete []chan struct{}
+
+	// firstIteration is true on the first call to
+	firstIteration bool
+}
+
+// Executor returns a helper to handle the process of actually performing the relisting
+//
+// The reason this is its own type is because we need to take care to handle new requests properly,
+// and part of that is storing any individual request channels that get collected as part of
+// retrying on failure.
+func (r *relistInfo) Executor() *relistExecutor {
+	return &relistExecutor{
+		r:              r,
+		signalComplete: make([]chan struct{}, 0, 1),
+		firstIteration: true,
+	}
+}
+
+// CollectTriggeredRequests SHOULD be called before each attempt at relisting, until one is
+// successful.
+func (e *relistExecutor) CollectTriggeredRequests() {
+	e.r.mu.Lock()
+	defer e.r.mu.Unlock()
+
+	newRelistTriggered := false
+
+	// Consume any additional relist request.
+	// All usage of triggerRelist from within (*Store[T]).Relist() is asynchronous,
+	// because triggerRelist has capacity=1 and has an item in it iff relisting has
+	// been requested, so if Relist() *would* block on sending, the signal has
+	// already been given.
+	// That's all to say: Receiving only once from triggerRelist is sufficient.
+	select {
+	case <-e.r.Triggered():
+		newRelistTriggered = true
+	default:
+	}
+
+	if e.firstIteration || newRelistTriggered {
+		e.signalComplete = append(e.signalComplete, e.r.relisted)
+		e.r.relisted = make(chan struct{})
+	}
+
+	e.firstIteration = false
+}
+
+// Complete closes any and all channels that were previously returned by (*relistInfo).relist() and
+// collected as part of this executor.
+func (r *relistExecutor) Complete() {
+	for _, ch := range r.signalComplete {
+		close(ch)
+	}
+	r.signalComplete = nil
+}


### PR DESCRIPTION
Fixes #851, refer there for more context.

---

This PR adds a new feature to `util/watch` - the ability to fetch the upper bound on the number of `Relist`s that have taken place so far (approximately), and trigger relisting only if there hasn't been any more.

More symbolically, it adds the ability to fetch a "timestamp"-like token from `watch.Store`, and say "please relist if you haven't yet, since this timestamp".

This allows us to fix the duplicate `Relist()`s issue by attaching this token to each pod start event as they come in, meaning that only pod events _received_ after the most recent `Relist()` started will trigger another one. Quoting one of the commits:

> With this change, the amount of required Relist()s are determined not by the number of events, but by the actual time it takes to complete the Relist() (a new one is only necessary if an event came in after the previous one completed - so events are delayed by at most 2x the duration of a single Relist() call, assuming negligible other handling).

---

I tested this locally and have confirmed that it fixes #851. Details collapsed below:

<details>

<summary>Testing details</summary>

<br>

In general, the testing plan was:

1. Add artificial delay to processing pod start events
2. Create two VMs at the same time, that _don't_ go through the scheduler (so they won't exist in local state)
3. After the VM pod start events are queued, delete the VMs
4. Profit? (jk)

I used this patch to modify the scheduler:

```diff
diff --git a/pkg/plugin/plugin.go b/pkg/plugin/plugin.go
index 7c76c50..d07d833 100644
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -133,7 +133,12 @@ func makeAutoscaleEnforcerPlugin(
 	}
 	pwc := podWatchCallbacks{
 		submitStarted: func(logger *zap.Logger, pod *corev1.Pod, vmRelistCount watch.RelistCount) {
-			pushToQueue(logger, func() { p.handleStarted(hlogger, pod, vmRelistCount) })
+			pushToQueue(logger, func() {
+				hlogger.Info("DEBUG: SLEEPING FOR 10 SECONDS", util.PodNameFields(pod))
+				time.Sleep(time.Second * 10)
+				hlogger.Info("DEBUG: DONE SLEEPING", util.PodNameFields(pod))
+				p.handleStarted(hlogger, pod, vmRelistCount)
+			})
 		},
 		submitDeletion: func(logger *zap.Logger, name util.NamespacedName) {
 			pushToQueue(logger, func() { p.handleDeletion(hlogger, name) })
```

... and this one, to modify `vm-deploy.yaml`:

```diff
diff --git a/vm-deploy.yaml b/vm-deploy.yaml
index e549f6e..bdae573 100644
--- a/vm-deploy.yaml
+++ b/vm-deploy.yaml
@@ -11,7 +11,6 @@ metadata:
     # Set to "true" to continuously migrate the VM (TESTING ONLY)
     autoscaling.neon.tech/testing-only-always-migrate: "false"
 spec:
-  schedulerName: autoscale-scheduler
   enableSSH: true
   guest:
     cpus: { min: 0.25, use: 0.25, max: 1.25 }
```

I also created a copy of `vm-deploy.yaml` with a different name, to act as the second VM.

Commands for testing were:

```sh
kubectl apply -f vm-deploy.yaml && kubectl apply -f vm-deploy2.yaml
kubectl delete neonvm postgres16-disk-test postgres16-disk-test-2
```

and this was the scheduler's log output, showing that it relisted only once, even though both VMs were missing:

```
{"level":"info","ts":1709965015.6497762,"logger":"autoscale-scheduler.vm-watch","caller":"plugin/watch.go:291","msg":"Skipping update for VM because .status.podName is empty","virtualmachine":{"namespace":"default","name":"postgres16-disk-test"}}
{"level":"info","ts":1709965015.7465107,"logger":"autoscale-scheduler.vm-watch","caller":"plugin/watch.go:291","msg":"Skipping update for VM because .status.podName is empty","virtualmachine":{"namespace":"default","name":"postgres16-disk-test-2"}}
{"level":"info","ts":1709965018.1640103,"logger":"autoscale-scheduler.pod-watch","caller":"plugin/watch.go:140","msg":"Received update event for Pod now running","pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"}}
{"level":"info","ts":1709965018.1640441,"logger":"autoscale-scheduler.handlers","caller":"plugin/plugin.go:137","msg":"DEBUG: SLEEPING FOR 10 SECONDS","virtualmachine":{"namespace":"default","name":"postgres16-disk-test"},"pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"}}
{"level":"info","ts":1709965018.1794043,"logger":"autoscale-scheduler.pod-watch","caller":"plugin/watch.go:140","msg":"Received update event for Pod now running","pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"}}
{"level":"info","ts":1709965024.2002063,"logger":"autoscale-scheduler.pod-watch","caller":"plugin/watch.go:146","msg":"Received update event for completion of Pod","pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"}}
{"level":"info","ts":1709965024.2221467,"logger":"autoscale-scheduler.pod-watch","caller":"plugin/watch.go:173","msg":"Received delete event for completed Pod","pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"}}
{"level":"info","ts":1709965024.2392888,"logger":"autoscale-scheduler.pod-watch","caller":"plugin/watch.go:146","msg":"Received update event for completion of Pod","pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"}}
{"level":"info","ts":1709965024.2548335,"logger":"autoscale-scheduler.pod-watch","caller":"plugin/watch.go:173","msg":"Received delete event for completed Pod","pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"}}
{"level":"info","ts":1709965028.16438,"logger":"autoscale-scheduler.handlers","caller":"plugin/plugin.go:139","msg":"DEBUG: DONE SLEEPING","virtualmachine":{"namespace":"default","name":"postgres16-disk-test"},"pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"}}
{"level":"info","ts":1709965028.1644406,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:587","msg":"Handling Pod start event","action":"Pod started","node":"neonvm-root-worker","virtualmachine":{"namespace":"default","name":"postgres16-disk-test"},"pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"}}
{"level":"warn","ts":1709965028.1644697,"logger":"autoscale-scheduler.handlers","caller":"plugin/plugin.go:284","msg":"VM is missing from local store. Relisting if it hasn't already been done","action":"Pod started","node":"neonvm-root-worker","virtualmachine":{"namespace":"default","name":"postgres16-disk-test"},"pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"},"pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"},"virtualmachine":{"namespace":"default","name":"postgres16-disk-test"}}
{"level":"info","ts":1709965028.1646848,"logger":"autoscale-scheduler.vm-watch.watch","caller":"watch/watch.go:334","msg":"Relisting"}
{"level":"info","ts":1709965028.166872,"logger":"autoscale-scheduler.vm-watch.watch","caller":"watch/watch.go:427","msg":"Relist complete, restarting watcher"}
{"level":"error","ts":1709965028.1670778,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:617","msg":"Error getting VM info for Pod","action":"Pod started","node":"neonvm-root-worker","virtualmachine":{"namespace":"default","name":"postgres16-disk-test"},"pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"},"error":"Could not find VM for pod, even after relist","stacktrace":"github.com/neondatabase/autoscaling/pkg/plugin.(*AutoscaleEnforcer).reserveResources\n\t/workspace/pkg/plugin/state.go:617\ngithub.com/neondatabase/autoscaling/pkg/plugin.(*AutoscaleEnforcer).handleStarted\n\t/workspace/pkg/plugin/state.go:589\ngithub.com/neondatabase/autoscaling/pkg/plugin.makeAutoscaleEnforcerPlugin.func3.1\n\t/workspace/pkg/plugin/plugin.go:140\ngithub.com/neondatabase/autoscaling/pkg/plugin.makeAutoscaleEnforcerPlugin.func11\n\t/workspace/pkg/plugin/plugin.go:225"}
{"level":"info","ts":1709965028.167148,"logger":"autoscale-scheduler.handlers","caller":"plugin/plugin.go:137","msg":"DEBUG: SLEEPING FOR 10 SECONDS","virtualmachine":{"namespace":"default","name":"postgres16-disk-test-2"},"pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"}}
{"level":"info","ts":1709965038.1678114,"logger":"autoscale-scheduler.handlers","caller":"plugin/plugin.go:139","msg":"DEBUG: DONE SLEEPING","virtualmachine":{"namespace":"default","name":"postgres16-disk-test-2"},"pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"}}
{"level":"info","ts":1709965038.1678467,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:587","msg":"Handling Pod start event","action":"Pod started","node":"neonvm-root-worker","virtualmachine":{"namespace":"default","name":"postgres16-disk-test-2"},"pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"}}
{"level":"warn","ts":1709965038.1678603,"logger":"autoscale-scheduler.handlers","caller":"plugin/plugin.go:284","msg":"VM is missing from local store. Relisting if it hasn't already been done","action":"Pod started","node":"neonvm-root-worker","virtualmachine":{"namespace":"default","name":"postgres16-disk-test-2"},"pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"},"pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"},"virtualmachine":{"namespace":"default","name":"postgres16-disk-test-2"}}
{"level":"error","ts":1709965038.167872,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:617","msg":"Error getting VM info for Pod","action":"Pod started","node":"neonvm-root-worker","virtualmachine":{"namespace":"default","name":"postgres16-disk-test-2"},"pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"},"error":"Could not find VM for pod, even after relist","stacktrace":"github.com/neondatabase/autoscaling/pkg/plugin.(*AutoscaleEnforcer).reserveResources\n\t/workspace/pkg/plugin/state.go:617\ngithub.com/neondatabase/autoscaling/pkg/plugin.(*AutoscaleEnforcer).handleStarted\n\t/workspace/pkg/plugin/state.go:589\ngithub.com/neondatabase/autoscaling/pkg/plugin.makeAutoscaleEnforcerPlugin.func3.1\n\t/workspace/pkg/plugin/plugin.go:140\ngithub.com/neondatabase/autoscaling/pkg/plugin.makeAutoscaleEnforcerPlugin.func11\n\t/workspace/pkg/plugin/plugin.go:225"}
{"level":"info","ts":1709965038.1678982,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:767","msg":"Handling deletion of VM pod","action":"VM deletion","pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"}}
{"level":"warn","ts":1709965038.1679075,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:796","msg":"Cannot find Pod in global pods map","action":"VM deletion","pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"}}
{"level":"info","ts":1709965038.167914,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:771","msg":"Deleted  Pod","action":"VM deletion","pod":{"namespace":"default","name":"postgres16-disk-test-n6wkf"},"migrating":false,"verdict":{"cpu":"","mem":""}}
{"level":"info","ts":1709965038.1679213,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:767","msg":"Handling deletion of VM pod","action":"VM deletion","pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"}}
{"level":"warn","ts":1709965038.1679294,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:796","msg":"Cannot find Pod in global pods map","action":"VM deletion","pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"}}
{"level":"info","ts":1709965038.1679342,"logger":"autoscale-scheduler.handlers","caller":"plugin/state.go:771","msg":"Deleted  Pod","action":"VM deletion","pod":{"namespace":"default","name":"postgres16-disk-test-2-2z8j7"},"migrating":false,"verdict":{"cpu":"","mem":""}}
```

</details>

---

**NB: I intend to merge this PR via "rebase and merge" to keep the separate commits.**

**Notes for reviewers:** Probably easiest to review each commit one by one. Happy to receive suggestions for alternate naming — not a huge fan of `RelistCount`; ideally it'd make the implications a little more clear, idk.
This PR also ended up much larger than I thought it would, but I think about as complex as @shayanh expected :sweat_smile:

Also, I'll probably build locally & deploy to staging for testing, so we can do a hotfix early next week.