### PR TITLE
plugin: Use multiple event handler threads

### DIFF
--- a/deploy/scheduler/config_map.yaml
+++ b/deploy/scheduler/config_map.yaml
@@ -33,6 +33,7 @@ data:
         "scorePeak": 0.8
       },
       "schedulerName": "autoscale-scheduler",
+      "eventQueueWorkers": 16,
       "dumpState": {
         "port": 10298,
         "timeoutSeconds": 5

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -26,6 +26,10 @@ type Config struct {
 	// version handled.
 	SchedulerName string `json:"schedulerName"`
 
+	// EventQueueWorkers sets the number of worker threads responsible for handling items from the
+	// event queue.
+	EventQueueWorkers int `json:"eventQueueWorkers"`
+
 	// RandomizeScores, if true, will cause the scheduler to score a node with a random number in
 	// the range [minScore + 1, trueScore], instead of the trueScore
 	RandomizeScores bool `json:"randomizeScores"`
@@ -122,6 +126,10 @@ func (c *Config) validate() (string, error) {
 
 	if c.SchedulerName == "" {
 		return "schedulerName", errors.New("string cannot be empty")
+	}
+
+	if c.EventQueueWorkers <= 0 {
+		return "eventQueueWorkers", errors.New("value must be > 0")
 	}
 
 	if c.DumpState != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -212,7 +212,7 @@ func makeAutoscaleEnforcerPlugin(
 
 	for i := 0; i < config.EventQueueWorkers; i += 1 {
 		// copy the loop variable to avoid it escaping pre Go 1.22
-		go func(idx int) {
+		go func(ctx context.Context, idx int) {
 			for {
 				callback, err := queueSet.wait(ctx, idx) // NB: wait pulls from the front of the queue
 				if err != nil {
@@ -222,7 +222,7 @@ func makeAutoscaleEnforcerPlugin(
 
 				callback()
 			}
-		}(i)
+		}(ctx, i)
 	}
 
 	if err := util.StartPrometheusMetricsServer(ctx, logger.Named("prometheus"), 9100, promReg); err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"math/rand"
 	"time"
 
@@ -117,9 +118,10 @@ func makeAutoscaleEnforcerPlugin(
 	}
 
 	// Start watching Pod/VM events, adding them to a shared queue to process them in order
-	queue := pubsub.NewUnlimitedQueue[func()]()
-	pushToQueue := func(logger *zap.Logger, f func()) {
-		if err := queue.Add(f); err != nil {
+	queueSet := newEventQueueSet[func()](config.EventQueueWorkers)
+
+	pushToQueue := func(logger *zap.Logger, key string, f func()) {
+		if err := queueSet.enqueue(key, f); err != nil {
 			logger.Warn("Error adding to pod/VM event queue", zap.Error(err))
 		}
 	}
@@ -127,32 +129,35 @@ func makeAutoscaleEnforcerPlugin(
 	hlogger := logger.Named("handlers")
 	nwc := nodeWatchCallbacks{
 		submitNodeDeletion: func(logger *zap.Logger, nodeName string) {
-			pushToQueue(logger, func() { p.handleNodeDeletion(hlogger, nodeName) })
+			pushToQueue(logger, nodeName, func() { p.handleNodeDeletion(hlogger, nodeName) })
 		},
 	}
 	pwc := podWatchCallbacks{
 		submitStarted: func(logger *zap.Logger, pod *corev1.Pod) {
-			pushToQueue(logger, func() { p.handleStarted(hlogger, pod) })
+			pushToQueue(logger, pod.Name, func() { p.handleStarted(hlogger, pod) })
 		},
 		submitDeletion: func(logger *zap.Logger, name util.NamespacedName) {
-			pushToQueue(logger, func() { p.handleDeletion(hlogger, name) })
+			// NOTE: It's important that the name we use here is the same as the one we use for
+			// submitStarted - otherwise we can end up with out of order handling for start/stop
+			// events.
+			pushToQueue(logger, name.Name, func() { p.handleDeletion(hlogger, name) })
 		},
 		submitStartMigration: func(logger *zap.Logger, podName, migrationName util.NamespacedName, source bool) {
-			pushToQueue(logger, func() { p.handlePodStartMigration(logger, podName, migrationName, source) })
+			pushToQueue(logger, migrationName.Name, func() { p.handlePodStartMigration(logger, podName, migrationName, source) })
 		},
 		submitEndMigration: func(logger *zap.Logger, podName, migrationName util.NamespacedName) {
-			pushToQueue(logger, func() { p.handlePodEndMigration(logger, podName, migrationName) })
+			pushToQueue(logger, migrationName.Name, func() { p.handlePodEndMigration(logger, podName, migrationName) })
 		},
 	}
 	vwc := vmWatchCallbacks{
 		submitDisabledScaling: func(logger *zap.Logger, pod util.NamespacedName) {
-			pushToQueue(logger, func() { p.handleVMDisabledScaling(hlogger, pod) })
+			pushToQueue(logger, pod.Name, func() { p.handleVMDisabledScaling(hlogger, pod) })
 		},
 		submitBoundsChanged: func(logger *zap.Logger, vm *api.VmInfo, podName string) {
-			pushToQueue(logger, func() { p.handleUpdatedScalingBounds(hlogger, vm, podName) })
+			pushToQueue(logger, vm.Name, func() { p.handleUpdatedScalingBounds(hlogger, vm, podName) })
 		},
 		submitNonAutoscalingVmUsageChanged: func(logger *zap.Logger, vm *api.VmInfo, podName string) {
-			pushToQueue(logger, func() { p.handleNonAutoscalingUsageChange(hlogger, vm, podName) })
+			pushToQueue(logger, vm.Name, func() { p.handleNonAutoscalingUsageChange(hlogger, vm, podName) })
 		},
 	}
 	mwc := migrationWatchCallbacks{
@@ -205,17 +210,20 @@ func makeAutoscaleEnforcerPlugin(
 		return nil, fmt.Errorf("Error reading cluster state: %w", err)
 	}
 
-	go func() {
-		for {
-			callback, err := queue.Wait(ctx) // NB: Wait pulls from the front of the queue
-			if err != nil {
-				logger.Info("Stopped waiting on pod/VM queue", zap.Error(err))
-				break
-			}
+	for i := 0; i < config.EventQueueWorkers; i += 1 {
+		// copy the loop variable to avoid it escaping pre Go 1.22
+		go func(idx int) {
+			for {
+				callback, err := queueSet.wait(ctx, idx) // NB: wait pulls from the front of the queue
+				if err != nil {
+					logger.Info("Stopped waiting on pod/VM queue", zap.Error(err))
+					break
+				}
 
-			callback()
-		}
-	}()
+				callback()
+			}
+		}(i)
+	}
 
 	if err := util.StartPrometheusMetricsServer(ctx, logger.Named("prometheus"), 9100, promReg); err != nil {
 		return nil, fmt.Errorf("Error starting prometheus server: %w", err)
@@ -238,6 +246,32 @@ func makeAutoscaleEnforcerPlugin(
 
 	logger.Info("Plugin initialization complete")
 	return &p, nil
+}
+
+type eventQueueSet[T any] struct {
+	queues []*pubsub.Queue[T]
+}
+
+func newEventQueueSet[T any](size int) eventQueueSet[T] {
+	queues := make([]*pubsub.Queue[T], size)
+	for i := 0; i < size; i += 1 {
+		queues[i] = pubsub.NewUnlimitedQueue[T]()
+	}
+	return eventQueueSet[T]{queues: queues}
+}
+
+func (s eventQueueSet[T]) enqueue(key string, item T) error {
+	hasher := fnv.New64()
+	// nb: Hash guarantees that Write never returns an error
+	_, _ = hasher.Write([]byte(key))
+	hash := hasher.Sum64()
+
+	idx := int(hash % uint64(len(s.queues)))
+	return s.queues[idx].Add(item)
+}
+
+func (s eventQueueSet[T]) wait(ctx context.Context, idx int) (T, error) {
+	return s.queues[idx].Wait(ctx)
 }
 
 // Name returns the name of the AutoscaleEnforcer plugin


### PR DESCRIPTION
Each handler has its own queue, and we distribute events by hashing the name of the object we're sending through, so that pod start and stop event ordering is preserved by going in through the same queue.

This will help reduce the impact of any future issues where the event queue gets backed up.

Part of #851.

---

Like #853, I'll probably put this on staging for testing over the weekend, so we can (optimistically) do a hotfix early next week.