### PR TITLE
neonvm: Add neonvm-runner image loader

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -152,6 +152,8 @@ jobs:
           kubectl -n kube-system rollout status daemonset kube-multus-ds
           kubectl apply -f $(rendered whereabouts.yaml)
           kubectl -n kube-system rollout status daemonset whereabouts
+          kubectl apply -f $(rendered neonvm-runner-image-loader.yaml)
+          kubectl -n neonvm-system rollout status daemonset neonvm-runner-image-loader
           kubectl apply -f $(rendered neonvm.yaml)
           kubectl -n neonvm-system rollout status daemonset  neonvm-device-plugin
           kubectl -n neonvm-system rollout status daemonset  neonvm-vxlan-controller

--- a/neonvm/runner-image-loader/daemonset.yaml
+++ b/neonvm/runner-image-loader/daemonset.yaml
@@ -1,8 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: neonvm-runner-image-loader
-  namespace: neonvm-system
+  name: runner-image-loader
 spec:
   selector:
     matchLabels:

--- a/neonvm/runner-image-loader/daemonset.yaml
+++ b/neonvm/runner-image-loader/daemonset.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: neonvm-runner-image-loader
+  namespace: neonvm-system
+spec:
+  selector:
+    matchLabels:
+      name: neonvm-runner-image-loader
+  template:
+    metadata:
+      labels:
+        name: neonvm-runner-image-loader
+    spec:
+      containers:
+      - image: runner:dev
+        name: neonvm-runner-loader
+        command: ["sh", "-c", "echo 'image loaded and container started' && sleep 100d"]
+        resources:
+          limits:
+            cpu: 10m
+            memory: 10Mi
+      # Sleep never gracefully terminates. No point waiting for it to.
+      terminationGracePeriodSeconds: 0

--- a/neonvm/runner-image-loader/kustomization.yaml
+++ b/neonvm/runner-image-loader/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- daemonset.yaml
+
+images:
+- name: runner
+  newName: runner
+  newTag: dev

--- a/neonvm/runner-image-loader/kustomization.yaml
+++ b/neonvm/runner-image-loader/kustomization.yaml
@@ -1,8 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# Add neonvm-system namespace to all resources
+namespace: neonvm-system
+# Prepend 'neonvm-' to all resource names.
+namePrefix: neonvm-
+
 resources:
 - daemonset.yaml
+- ../config/namespace
 
 images:
 - name: runner


### PR DESCRIPTION
When rolling out an update to neonvm, we currently don't pre-load the neonvm-runner images. This has a couple effects:

1. For a brief period, new VM runner pods are additionally blocked on pulling the runner image (which can take a while); and
2. If there's issues with pulling the runner image, we only detect that once we're actually attempting to use it.

This PR adds a new daemonset to just keep the neonvm-runner image around on each node. Before rolling out a neonvm update, we can update the runner image in the daemonset to make sure that the new image is loaded on all the nodes.

Part of neondatabase/cloud#11232