### PR TITLE
replace hardcoded image names with corresponding variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,10 +266,10 @@ render-manifests: $(RENDERED) kustomize
 	$(KUSTOMIZE) build deploy/scheduler > $(RENDERED)/autoscale-scheduler.yaml
 	$(KUSTOMIZE) build deploy/agent > $(RENDERED)/autoscaler-agent.yaml
 	# Cleanup:
-	cd neonvm/config/controller && $(KUSTOMIZE) edit set image controller=controller:dev && $(KUSTOMIZE) edit remove annotation buildtime --ignore-non-existence
-	cd neonvm/config/vxlan-controller && $(KUSTOMIZE) edit set image vxlan-controller=vxlan-controller:dev && $(KUSTOMIZE) edit remove annotation buildtime --ignore-non-existence
-	cd deploy/scheduler && $(KUSTOMIZE) edit set image autoscale-scheduler=autoscale-scheduler:dev && $(KUSTOMIZE) edit remove annotation buildtime --ignore-non-existence
-	cd deploy/agent && $(KUSTOMIZE) edit set image autoscaler-agent=autoscaler-agent:dev && $(KUSTOMIZE) edit remove annotation buildtime --ignore-non-existence
+	cd neonvm/config/controller && $(KUSTOMIZE) edit set image controller=$(IMG_CONTROLLER) && $(KUSTOMIZE) edit remove annotation buildtime --ignore-non-existence
+	cd neonvm/config/vxlan-controller && $(KUSTOMIZE) edit set image vxlan-controller=$(IMG_VXLAN_CONTROLLER) && $(KUSTOMIZE) edit remove annotation buildtime --ignore-non-existence
+	cd deploy/scheduler && $(KUSTOMIZE) edit set image autoscale-scheduler=$(IMG_SCHEDULER) && $(KUSTOMIZE) edit remove annotation buildtime --ignore-non-existence
+	cd deploy/agent && $(KUSTOMIZE) edit set image autoscaler-agent=$(IMG_AUTOSCALER_AGENT) && $(KUSTOMIZE) edit remove annotation buildtime --ignore-non-existence
 
 render-release: $(RENDERED) kustomize
 	# Prepare:
@@ -285,10 +285,10 @@ render-release: $(RENDERED) kustomize
 	$(KUSTOMIZE) build deploy/scheduler > $(RENDERED)/autoscale-scheduler.yaml
 	$(KUSTOMIZE) build deploy/agent > $(RENDERED)/autoscaler-agent.yaml
 	# Cleanup:
-	cd neonvm/config/controller && $(KUSTOMIZE) edit set image controller=controller:dev
-	cd neonvm/config/vxlan-controller && $(KUSTOMIZE) edit set image vxlan-controller=vxlan-controller:dev
-	cd deploy/scheduler && $(KUSTOMIZE) edit set image autoscale-scheduler=autoscale-scheduler:dev
-	cd deploy/agent && $(KUSTOMIZE) edit set image autoscaler-agent=autoscaler-agent:dev
+	cd neonvm/config/controller && $(KUSTOMIZE) edit set image controller=$(IMG_CONTROLLER)
+	cd neonvm/config/vxlan-controller && $(KUSTOMIZE) edit set image vxlan-controller=$(IMG_VXLAN_CONTROLLER)
+	cd deploy/scheduler && $(KUSTOMIZE) edit set image autoscale-scheduler=$(IMG_SCHEDULER)
+	cd deploy/agent && $(KUSTOMIZE) edit set image autoscaler-agent=$(IMG_AUTOSCALER_AGENT)
 
 .PHONY: deploy
 deploy: check-local-context docker-build load-images manifests render-manifests kubectl ## Deploy controller to the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
All the image names have corresponding variables defined at the beginning of the Makefile, but despite this, some hardcoded image names are still being used. This simple patch replaces those hardcoded image names with the corresponding variables for better maintenance.