### PR TITLE
plugin: Add pod desired AZ to plugin method metrics

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -366,9 +366,9 @@ func (e *AutoscaleEnforcer) PreFilter(
 ) (_ *framework.PreFilterResult, status *framework.Status) {
 	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
 
-	e.metrics.IncMethodCall("PreFilter", ignored)
+	e.metrics.IncMethodCall("PreFilter", pod, ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("PreFilter", ignored, status)
+		e.metrics.IncFailIfNotSuccess("PreFilter", pod, ignored, status)
 	}()
 
 	return nil, nil
@@ -396,9 +396,9 @@ func (e *AutoscaleEnforcer) PostFilter(
 ) (_ *framework.PostFilterResult, status *framework.Status) {
 	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
 
-	e.metrics.IncMethodCall("PostFilter", ignored)
+	e.metrics.IncMethodCall("PostFilter", pod, ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("PostFilter", ignored, status)
+		e.metrics.IncFailIfNotSuccess("PostFilter", pod, ignored, status)
 	}()
 
 	logger := e.logger.With(zap.String("method", "Filter"), util.PodNameFields(pod))
@@ -418,9 +418,9 @@ func (e *AutoscaleEnforcer) Filter(
 ) (status *framework.Status) {
 	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
 
-	e.metrics.IncMethodCall("Filter", ignored)
+	e.metrics.IncMethodCall("Filter", pod, ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("Filter", ignored, status)
+		e.metrics.IncFailIfNotSuccess("Filter", pod, ignored, status)
 	}()
 
 	nodeName := nodeInfo.Node().Name // TODO: nodes also have namespaces? are they used at all?
@@ -613,9 +613,9 @@ func (e *AutoscaleEnforcer) Score(
 ) (_ int64, status *framework.Status) {
 	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
 
-	e.metrics.IncMethodCall("Score", ignored)
+	e.metrics.IncMethodCall("Score", pod, ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("Score", ignored, status)
+		e.metrics.IncFailIfNotSuccess("Score", pod, ignored, status)
 	}()
 
 	logger := e.logger.With(zap.String("method", "Score"), zap.String("node", nodeName), util.PodNameFields(pod))
@@ -724,9 +724,9 @@ func (e *AutoscaleEnforcer) NormalizeScore(
 ) (status *framework.Status) {
 	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
 
-	e.metrics.IncMethodCall("NormalizeScore", ignored)
+	e.metrics.IncMethodCall("NormalizeScore", pod, ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("NormalizeScore", ignored, status)
+		e.metrics.IncFailIfNotSuccess("NormalizeScore", pod, ignored, status)
 	}()
 
 	logger := e.logger.With(zap.String("method", "NormalizeScore"), util.PodNameFields(pod))
@@ -786,9 +786,9 @@ func (e *AutoscaleEnforcer) Reserve(
 ) (status *framework.Status) {
 	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
 
-	e.metrics.IncMethodCall("Reserve", ignored)
+	e.metrics.IncMethodCall("Reserve", pod, ignored)
 	defer func() {
-		e.metrics.IncFailIfNotSuccess("Reserve", ignored, status)
+		e.metrics.IncFailIfNotSuccess("Reserve", pod, ignored, status)
 	}()
 
 	logger := e.logger.With(zap.String("method", "Reserve"), zap.String("node", nodeName), util.PodNameFields(pod))
@@ -837,7 +837,7 @@ func (e *AutoscaleEnforcer) Unreserve(
 	nodeName string,
 ) {
 	ignored := e.state.conf.ignoredNamespace(pod.Namespace)
-	e.metrics.IncMethodCall("Unreserve", ignored)
+	e.metrics.IncMethodCall("Unreserve", pod, ignored)
 
 	podName := util.GetNamespacedName(pod)
 

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -114,7 +114,7 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 }
 
 func (m *PromMetrics) IncMethodCall(method string, pod *corev1.Pod, ignored bool) {
-	m.pluginCalls.WithLabelValues(method, util.TryPodPreferredAZ(pod), strconv.FormatBool(ignored)).Inc()
+	m.pluginCalls.WithLabelValues(method, util.PodPreferredAZIfPresent(pod), strconv.FormatBool(ignored)).Inc()
 }
 
 func (m *PromMetrics) IncFailIfNotSuccess(method string, pod *corev1.Pod, ignored bool, status *framework.Status) {
@@ -122,5 +122,5 @@ func (m *PromMetrics) IncFailIfNotSuccess(method string, pod *corev1.Pod, ignore
 		return
 	}
 
-	m.pluginCallFails.WithLabelValues(method, util.TryPodPreferredAZ(pod), strconv.FormatBool(ignored), status.Code().String())
+	m.pluginCallFails.WithLabelValues(method, util.PodPreferredAZIfPresent(pod), strconv.FormatBool(ignored), status.Code().String())
 }

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
 	"github.com/neondatabase/autoscaling/pkg/util"
@@ -44,14 +45,14 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 				Name: "autoscaling_plugin_extension_calls_total",
 				Help: "Number of calls to scheduler plugin extension points",
 			},
-			[]string{"method", "ignored_namespace"},
+			[]string{"method", "desired_availability_zone", "ignored_namespace"},
 		)),
 		pluginCallFails: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "autoscaling_plugin_extension_call_fails_total",
 				Help: "Number of unsuccessful calls to scheduler plugin extension points",
 			},
-			[]string{"method", "ignored_namespace", "status"},
+			[]string{"method", "desired_availability_zone", "ignored_namespace", "status"},
 		)),
 		resourceRequests: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -112,14 +113,14 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 	return reg
 }
 
-func (m *PromMetrics) IncMethodCall(method string, ignored bool) {
-	m.pluginCalls.WithLabelValues(method, strconv.FormatBool(ignored)).Inc()
+func (m *PromMetrics) IncMethodCall(method string, pod *corev1.Pod, ignored bool) {
+	m.pluginCalls.WithLabelValues(method, util.TryPodPreferredAZ(pod), strconv.FormatBool(ignored)).Inc()
 }
 
-func (m *PromMetrics) IncFailIfNotSuccess(method string, ignored bool, status *framework.Status) {
+func (m *PromMetrics) IncFailIfNotSuccess(method string, pod *corev1.Pod, ignored bool, status *framework.Status) {
 	if !status.IsSuccess() {
 		return
 	}
 
-	m.pluginCallFails.WithLabelValues(method, strconv.FormatBool(ignored), status.Code().String())
+	m.pluginCallFails.WithLabelValues(method, util.TryPodPreferredAZ(pod), strconv.FormatBool(ignored), status.Code().String())
 }

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -67,13 +67,8 @@ func TryPodPreferredAZ(pod *corev1.Pod) string {
 		}
 	}
 
-	if affinity := pod.Spec.Affinity; affinity != nil {
-		if affinity.NodeAffinity != nil {
-			panic("todo")
-		}
-	}
-
-	panic("todo")
+	// no AZ present
+	return ""
 }
 
 // TryPodOwnerVirtualMachine returns the name of the VirtualMachine that owns the pod, if there is

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -30,8 +30,8 @@ func PodStartedBefore(p, q *corev1.Pod) bool {
 	return p.Status.StartTime.Before(q.Status.StartTime)
 }
 
-// TryPodPreferredAZ returns the desired availability zone of the Pod, if it has one
-func TryPodPreferredAZ(pod *corev1.Pod) string {
+// PodPreferredAZIfPresent returns the desired availability zone of the Pod, if it has one
+func PodPreferredAZIfPresent(pod *corev1.Pod) string {
 	if pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil {
 		return ""
 	}


### PR DESCRIPTION
- Adds `util.PodPreferredAZIfPresent` to determine the AZ
- Adds the `desired_availability_zone` label to the plugin method metrics
- Passes the `*corev1.Pod` through to `IncMethodCall` and `IncFailIfNotSuccess` to inclulde the AZ

Closes #861.