### PR TITLE
plugin: eventqueue metrics

### DIFF
--- a/pkg/plugin/eventqueueset.go
+++ b/pkg/plugin/eventqueueset.go
@@ -1,0 +1,34 @@
+package plugin
+
+import (
+	"context"
+	"hash/fnv"
+
+	"github.com/tychoish/fun/pubsub"
+)
+
+type eventQueueSet[T any] struct {
+	queues []*pubsub.Queue[T]
+}
+
+func newEventQueueSet[T any](size int) eventQueueSet[T] {
+	queues := make([]*pubsub.Queue[T], size)
+	for i := 0; i < size; i += 1 {
+		queues[i] = pubsub.NewUnlimitedQueue[T]()
+	}
+	return eventQueueSet[T]{queues: queues}
+}
+
+func (s eventQueueSet[T]) enqueue(key string, item T) error {
+	hasher := fnv.New64()
+	// nb: Hash guarantees that Write never returns an error
+	_, _ = hasher.Write([]byte(key))
+	hash := hasher.Sum64()
+
+	idx := int(hash % uint64(len(s.queues)))
+	return s.queues[idx].Add(item)
+}
+
+func (s eventQueueSet[T]) wait(ctx context.Context, idx int) (T, error) {
+	return s.queues[idx].Wait(ctx)
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -3,11 +3,9 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
 	"math/rand"
 	"time"
 
-	"github.com/tychoish/fun/pubsub"
 	"go.uber.org/zap"
 
 	corev1 "k8s.io/api/core/v1"
@@ -245,32 +243,6 @@ func makeAutoscaleEnforcerPlugin(
 
 	logger.Info("Plugin initialization complete")
 	return &p, nil
-}
-
-type eventQueueSet[T any] struct {
-	queues []*pubsub.Queue[T]
-}
-
-func newEventQueueSet[T any](size int) eventQueueSet[T] {
-	queues := make([]*pubsub.Queue[T], size)
-	for i := 0; i < size; i += 1 {
-		queues[i] = pubsub.NewUnlimitedQueue[T]()
-	}
-	return eventQueueSet[T]{queues: queues}
-}
-
-func (s eventQueueSet[T]) enqueue(key string, item T) error {
-	hasher := fnv.New64()
-	// nb: Hash guarantees that Write never returns an error
-	_, _ = hasher.Write([]byte(key))
-	hash := hasher.Sum64()
-
-	idx := int(hash % uint64(len(s.queues)))
-	return s.queues[idx].Add(item)
-}
-
-func (s eventQueueSet[T]) wait(ctx context.Context, idx int) (T, error) {
-	return s.queues[idx].Wait(ctx)
 }
 
 // Name returns the name of the AutoscaleEnforcer plugin

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -26,6 +26,9 @@ type PromMetrics struct {
 	migrationCreateFails  prometheus.Counter
 	migrationDeleteFails  *prometheus.CounterVec
 	reserveShouldDeny     *prometheus.CounterVec
+	eventQueueDepth       prometheus.Gauge
+	eventQueueAddsTotal   prometheus.Counter
+	eventQueueLatency     prometheus.Histogram
 }
 
 func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
@@ -115,6 +118,25 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 				Help: "Number of times the plugin should deny a reservation",
 			},
 			[]string{"availability_zone", "node", "node_group"},
+		)),
+		eventQueueDepth: util.RegisterMetric(reg, prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "autoscaling_plugin_eventqueue_depth",
+				Help: "Current sum depth of all event queues",
+			},
+		)),
+		eventQueueAddsTotal: util.RegisterMetric(reg, prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "autoscaling_plugin_eventqueue_adds_total",
+				Help: "Total number of events added to event queues",
+			},
+		)),
+		eventQueueLatency: util.RegisterMetric(reg, prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "autoscaling_plugin_eventqueue_duration_seconds",
+				Help:    "How long in seconds an item stays in an event queue before being processed",
+				Buckets: prometheus.ExponentialBuckets(10e-9, 10, 12),
+			},
 		)),
 	}
 


### PR DESCRIPTION
Scheduler plugin has a set of queue for events (eventqueue) it receives from k8s API server. This PR adds the following set of metrics related to  eventqueue:
- `autoscaling_plugin_eventqueue_depth`: Current depth of eventqueue.
- `autoscaling_plugin_eventqueue_adds_total`: Total number of events added to eventqueue.
- `autoscaling_plugin_eventqueue_duration_seconds`: How long in seconds an item stays in eventqueue before being processed.

Inspired by [controller-runtime workqueue metrics](https://book.kubebuilder.io/reference/metrics-reference).

This is a small PR but might be easier to review it commit by commit.

Fixes #862.