### PR TITLE
vm-builder: add SQL exporter to vector

### DIFF
--- a/neonvm/tools/vm-builder/files/vector.yaml
+++ b/neonvm/tools/vm-builder/files/vector.yaml
@@ -15,6 +15,12 @@ sources:
         excludes: ["*/proc/sys/fs/binfmt_misc"]
     type: host_metrics
     scrape_interval_secs: 1 # default is 15, but we scrape every 5s in autoscaler-agent
+  sql_exporter_metrics:
+    type: prometheus_scrape
+    # sql_exporter listen addr, exporting LFC statistics.
+    # This statistics will only be available when using the neon vm image. A custom image
+    # does not have this exporter by default.
+    endpoints: ["http://localhost:9399/metrics"]
 sinks:
   prom_exporter:
     type: prometheus_exporter

--- a/neonvm/tools/vm-builder/files/vector.yaml
+++ b/neonvm/tools/vm-builder/files/vector.yaml
@@ -18,7 +18,7 @@ sources:
   sql_exporter_metrics:
     type: prometheus_scrape
     # sql_exporter listen addr, exporting LFC statistics.
-    # This statistics will only be available when using the neon vm image. A custom image
+    # This statistics will only be available when using the neon compute image. A custom image
     # does not have this exporter by default.
     endpoints: ["http://127.0.0.1:9399/metrics"]
     # The data might be delayed as we use the default scrape interval. Some SQLs are not

--- a/neonvm/tools/vm-builder/files/vector.yaml
+++ b/neonvm/tools/vm-builder/files/vector.yaml
@@ -20,10 +20,13 @@ sources:
     # sql_exporter listen addr, exporting LFC statistics.
     # This statistics will only be available when using the neon vm image. A custom image
     # does not have this exporter by default.
-    endpoints: ["http://localhost:9399/metrics"]
+    endpoints: ["http://127.0.0.1:9399/metrics"]
+    # The data might be delayed as we use the default scrape interval. Some SQLs are not
+    # trivial to execute, and therefore we don't want them to run every second.
 sinks:
   prom_exporter:
     type: prometheus_exporter
     inputs:
       - host_metrics
+      - sql_exporter_metrics
     address: "0.0.0.0:9100"


### PR DESCRIPTION
ref https://github.com/neondatabase/neon/pull/5949
close https://github.com/neondatabase/autoscaling/issues/872

This pull request makes the LFC metrics available at the vector metrics endpoint. We use the default scrape interval to avoid overload the database.