### PR TITLE
agent: Refactor metrics definitions

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -175,6 +175,7 @@ func (c *Config) validate() error {
 	erc.Whenf(ec, c.DumpState != nil && c.DumpState.TimeoutSeconds == 0, zeroTmpl, ".dumpState.timeoutSeconds")
 	erc.Whenf(ec, c.Metrics.Port == 0, zeroTmpl, ".metrics.port")
 	erc.Whenf(ec, c.Metrics.LoadMetricPrefix == "", emptyTmpl, ".metrics.loadMetricPrefix")
+	erc.Whenf(ec, c.Metrics.RequestTimeoutSeconds == 0, zeroTmpl, ".metrics.requestTimeoutSeconds")
 	erc.Whenf(ec, c.Metrics.SecondsBetweenRequests == 0, zeroTmpl, ".metrics.secondsBetweenRequests")
 	erc.Whenf(ec, c.Scaling.ComputeUnit.VCPU == 0, zeroTmpl, ".scaling.computeUnit.vCPUs")
 	erc.Whenf(ec, c.Scaling.ComputeUnit.Mem == 0, zeroTmpl, ".scaling.computeUnit.mem")

--- a/pkg/agent/core/dumpstate.go
+++ b/pkg/agent/core/dumpstate.go
@@ -39,7 +39,7 @@ func (s *State) Dump() StateDump {
 			Plugin:  s.internal.Plugin.deepCopy(),
 			Monitor: s.internal.Monitor.deepCopy(),
 			NeonVM:  s.internal.NeonVM.deepCopy(),
-			Metrics: shallowCopy[api.Metrics](s.internal.Metrics),
+			Metrics: shallowCopy[Metrics](s.internal.Metrics),
 		},
 	}
 }

--- a/pkg/agent/core/metrics.go
+++ b/pkg/agent/core/metrics.go
@@ -1,4 +1,4 @@
-package api
+package core
 
 // Definition of the Metrics type, plus reading it from vector.dev's prometheus format host metrics
 
@@ -6,14 +6,22 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/neondatabase/autoscaling/pkg/api"
 )
 
-// Metrics gives the information pulled from vector.dev that the scheduler may use to prioritize
-// which pods it should migrate.
 type Metrics struct {
-	LoadAverage1Min  float32 `json:"loadAvg1M"`
-	LoadAverage5Min  float32 `json:"loadAvg5M"`
-	MemoryUsageBytes float32 `json:"memoryUsageBytes"`
+	LoadAverage1Min  float32
+	LoadAverage5Min  float32 // unused. To be removed when api.Metrics.LoadAverage5Min is removed.
+	MemoryUsageBytes float32
+}
+
+func (m Metrics) ToAPI() api.Metrics {
+	return api.Metrics{
+		LoadAverage1Min:  m.LoadAverage1Min,
+		LoadAverage5Min:  m.LoadAverage5Min,
+		MemoryUsageBytes: m.MemoryUsageBytes,
+	}
 }
 
 // ReadMetrics generates Metrics from vector.dev's host metrics output, or returns error on failure

--- a/pkg/agent/core/state.go
+++ b/pkg/agent/core/state.go
@@ -112,7 +112,7 @@ type state struct {
 	// NeonVM records all state relevant to the NeonVM k8s API
 	NeonVM neonvmState
 
-	Metrics *api.Metrics
+	Metrics *Metrics
 }
 
 type pluginState struct {
@@ -400,7 +400,15 @@ func (s *state) calculatePluginAction(
 		return &ActionPluginRequest{
 			LastPermit: s.Plugin.Permit,
 			Target:     permittedRequestResources,
-			Metrics:    s.Metrics,
+			// convert maybe-nil '*Metrics' to maybe-nil '*core.Metrics'
+			Metrics: func() *api.Metrics {
+				if s.Metrics != nil {
+					m := s.Metrics.ToAPI()
+					return &m
+				} else {
+					return nil
+				}
+			}(),
 		}, nil
 	} else {
 		if wantToRequestNewResources && waitingOnRetryBackoff {
@@ -929,7 +937,7 @@ func (s *State) UpdatedVM(vm api.VmInfo) {
 	s.internal.VM = vm
 }
 
-func (s *State) UpdateMetrics(metrics api.Metrics) {
+func (s *State) UpdateMetrics(metrics Metrics) {
 	s.internal.Metrics = &metrics
 }
 

--- a/pkg/agent/executor/core.go
+++ b/pkg/agent/executor/core.go
@@ -162,7 +162,7 @@ type ExecutorCoreUpdater struct {
 
 // UpdateMetrics calls (*core.State).UpdateMetrics() on the inner core.State and runs withLock while
 // holding the lock.
-func (c ExecutorCoreUpdater) UpdateMetrics(metrics api.Metrics, withLock func()) {
+func (c ExecutorCoreUpdater) UpdateMetrics(metrics core.Metrics, withLock func()) {
 	c.core.update(func(state *core.State) {
 		state.UpdateMetrics(metrics)
 		withLock()

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -251,7 +251,7 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger, vmInfoUpdated util
 		}
 	})
 	r.spawnBackgroundWorker(ctx, logger, "get metrics", func(c context.Context, l *zap.Logger) {
-		r.getMetricsLoop(c, l, func(metrics api.Metrics, withLock func()) {
+		r.getMetricsLoop(c, l, func(metrics core.Metrics, withLock func()) {
 			ecwc.Updater().UpdateMetrics(metrics, withLock)
 		})
 	})
@@ -349,7 +349,7 @@ func (r *Runner) spawnBackgroundWorker(ctx context.Context, logger *zap.Logger, 
 func (r *Runner) getMetricsLoop(
 	ctx context.Context,
 	logger *zap.Logger,
-	newMetrics func(metrics api.Metrics, withLock func()),
+	newMetrics func(metrics core.Metrics, withLock func()),
 ) {
 	timeout := time.Second * time.Duration(r.global.config.Metrics.RequestTimeoutSeconds)
 	waitBetweenDuration := time.Second * time.Duration(r.global.config.Metrics.SecondsBetweenRequests)
@@ -516,7 +516,7 @@ func (r *Runner) doMetricsRequest(
 	ctx context.Context,
 	logger *zap.Logger,
 	timeout time.Duration,
-) (*api.Metrics, error) {
+) (*core.Metrics, error) {
 	url := fmt.Sprintf("http://%s:%d/metrics", r.podIP, r.global.config.Metrics.Port)
 
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
@@ -546,7 +546,7 @@ func (r *Runner) doMetricsRequest(
 		return nil, fmt.Errorf("Unsuccessful response status %d: %s", resp.StatusCode, string(body))
 	}
 
-	m, err := api.ReadMetrics(body, r.global.config.Metrics.LoadMetricPrefix)
+	m, err := core.ReadMetrics(body, r.global.config.Metrics.LoadMetricPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading metrics from prometheus output: %w", err)
 	}

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1,6 +1,6 @@
 package api
 
-// Definition of the Metrics type, plus reading it from node_exporter output
+// Definition of the Metrics type, plus reading it from vector.dev's prometheus format host metrics
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// Metrics gives the information pulled from node_exporter that the scheduler may use to prioritize
+// Metrics gives the information pulled from vector.dev that the scheduler may use to prioritize
 // which pods it should migrate.
 type Metrics struct {
 	LoadAverage1Min  float32 `json:"loadAvg1M"`
@@ -16,7 +16,7 @@ type Metrics struct {
 	MemoryUsageBytes float32 `json:"memoryUsageBytes"`
 }
 
-// ReadMetrics generates Metrics from node_exporter output, or returns error on failure
+// ReadMetrics generates Metrics from vector.dev's host metrics output, or returns error on failure
 //
 // This function could be more efficient, but realistically it doesn't matter. The size of the
 // output from node_exporter/vector is so small anyways.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -190,6 +190,14 @@ type AgentRequest struct {
 	Metrics *Metrics `json:"metrics"`
 }
 
+// Metrics gives the information pulled from vector.dev that the scheduler may use to prioritize
+// which pods it should migrate.
+type Metrics struct {
+	LoadAverage1Min  float32 `json:"loadAvg1M"`
+	LoadAverage5Min  float32 `json:"loadAvg5M"`
+	MemoryUsageBytes float32 `json:"memoryUsageBytes"`
+}
+
 // ProtocolRange returns a VersionRange exactly equal to r.ProtoVersion
 func (r AgentRequest) ProtocolRange() VersionRange[PluginProtoVersion] {
 	return VersionRange[PluginProtoVersion]{


### PR DESCRIPTION
Mostly just extracted from #737, thought it would be useful for https://github.com/neondatabase/autoscaling/pull/878#issuecomment-2033387609, and in general nice to have.

We can also rebase #750 on top of this now.

---

Changes are separated into three commits, best reviewed separately. I think they're _probably_ best merged via rebase, but I also don't want to spam the repo history :sweat_smile:

LMK what you think.