### PR TITLE
neonvm-runner: Log parallel errors before returning

### DIFF
--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -663,10 +663,20 @@ func run(logger *zap.Logger) error {
 		}
 	}
 
+	// Helper function to both log an error and return the result of wrapping it with the message.
+	//
+	// This is used below because (*errgroup.Group).Wait() returns at most 1 error, which means
+	// imprecise usage can hide errors. So, we log the errors before they would be returned, to make
+	// sure they're always visible.
+	logWrap := func(msg string, err error) error {
+		logger.Error(msg, zap.Error(err))
+		return fmt.Errorf("%s: %w", msg, err)
+	}
+
 	eg := &errgroup.Group{}
 	eg.Go(func() error {
 		if err := runInitScript(logger, vmSpec.InitScript); err != nil {
-			return fmt.Errorf("failed to run init script: %w", err)
+			return logWrap("failed to run init script", err)
 		}
 		return nil
 	})
@@ -683,7 +693,7 @@ func run(logger *zap.Logger) error {
 			swapSize,
 			shmSize,
 		); err != nil {
-			return fmt.Errorf("failed to create iso9660 disk: %w", err)
+			return logWrap("failed to create iso9660 disk", err)
 		}
 		return nil
 	})
@@ -691,7 +701,7 @@ func run(logger *zap.Logger) error {
 	eg.Go(func() error {
 		// resize rootDisk image of size specified and new size more than current
 		if err := resizeRootDisk(logger, vmSpec); err != nil {
-			return fmt.Errorf("failed to resize rootDisk: %w", err)
+			return logWrap("failed to resize rootDisk", err)
 		}
 		return nil
 	})
@@ -701,7 +711,7 @@ func run(logger *zap.Logger) error {
 		var err error
 		qemuCmd, err = buildQEMUCmd(cfg, logger, vmSpec, &vmStatus, cpus, memory, enableSSH, swapSize)
 		if err != nil {
-			return fmt.Errorf("failed to build QEMU command: %w", err)
+			return logWrap("failed to build QEMU command", err)
 		}
 		return nil
 	})


### PR DESCRIPTION
Explanation taken from the added comment:

> `(*errgroup.Group).Wait()` returns at most 1 error, which means imprecise usage can hide errors. So, we log the errors before they would be returned, to make sure they're always visible.

In particular, this is required to make sure that #887 is sound.