### PR TITLE
Sync versioning in VERSIONING.md and plugin

### DIFF
--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -17,6 +17,7 @@ first checking if the /register endpoint returned a 404.
 | Release | autoscaler-agent | VM monitor |
 |---------|------------------|------------|
 | _Current_ | v1.0 only | v1.0 only |
+| v0.27.0 | v1.0 only | v1.0 only |
 | v0.26.0 | v1.0 only | v1.0 only |
 | v0.25.0 | v1.0 only | v1.0 only |
 | v0.24.0 | v1.0 only | v1.0 only |
@@ -40,7 +41,8 @@ number.
 | Release | autoscaler-agent | Scheduler plugin |
 |---------|------------------|------------------|
 | _Current_ | v4.0 only | v3.0-v4.0 |
-| v0.26.0 | v4.0 only | v3.0-v4.0 |
+| v0.27.0 | v4.0 only | v3.0-v4.0 |
+| v0.26.0 | v4.0 only | **v3.0-v4.0** |
 | v0.25.0 | v4.0 only | v1.0-v4.0 |
 | v0.24.0 | v4.0 only | v1.0-v4.0 |
 | v0.23.0 | **v4.0 only** | **v1.0-v4.0** |
@@ -98,6 +100,7 @@ Note: Components v0.6.0 and below did not have a versioned protocol between the 
 | Release | controller | runner |
 |---------|------------|--------|
 | _Current_ | 1 | 1 |
+| v0.27.0 | 0 - 1 | 1 |
 | v0.26.0 | 0 - 1 | 1 |
 | v0.25.0 | 0 - 1 | 1 |
 | v0.24.0 | 0 - 1 | 1 |

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -22,11 +22,11 @@ const (
 	ContentTypeError string = "text/plain"
 )
 
-// The scheduler plugin currently supports v1.0 to v4.0 of the agent<->scheduler plugin protocol.
+// The scheduler plugin currently supports v3.0 to v4.0 of the agent<->scheduler plugin protocol.
 //
 // If you update either of these values, make sure to also update VERSIONING.md.
 const (
-	MinPluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV1_0
+	MinPluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV3_0
 	MaxPluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV4_0
 )
 


### PR DESCRIPTION
Looked at rebasing #750 and realized:

1. The scheduler plugin's range of accepted versions in the code was wider than documented in VERSIONING.md
2. v0.27.0 was not present.

This commit fixes both of those.

To be clear: This commit DISALLOWS VERISONS <v3.0. This should have been done in #743 but must have been missed then.

---

This sort of thing is perhaps good motivation for #888.