### PR TITLE
VERSIONING.md: Bump to v0.28.0

### DIFF
--- a/pkg/api/VERSIONING.md
+++ b/pkg/api/VERSIONING.md
@@ -17,6 +17,7 @@ first checking if the /register endpoint returned a 404.
 | Release | autoscaler-agent | VM monitor |
 |---------|------------------|------------|
 | _Current_ | v1.0 only | v1.0 only |
+| v0.28.0 | v1.0 only | v1.0 only |
 | v0.27.0 | v1.0 only | v1.0 only |
 | v0.26.0 | v1.0 only | v1.0 only |
 | v0.25.0 | v1.0 only | v1.0 only |
@@ -40,7 +41,8 @@ number.
 
 | Release | autoscaler-agent | Scheduler plugin |
 |---------|------------------|------------------|
-| _Current_ | v4.0 only | **v3.0-v5.0** |
+| _Current_ | v5.0 only | v3.0-v5.0 |
+| v0.28.0 | **v5.0** only | **v3.0-v5.0** |
 | v0.27.0 | v4.0 only | v3.0-v4.0 |
 | v0.26.0 | v4.0 only | **v3.0-v4.0** |
 | v0.25.0 | v4.0 only | v1.0-v4.0 |
@@ -100,6 +102,7 @@ Note: Components v0.6.0 and below did not have a versioned protocol between the 
 | Release | controller | runner |
 |---------|------------|--------|
 | _Current_ | 1 | 1 |
+| v0.28.0 | **1** | 1 |
 | v0.27.0 | 0 - 1 | 1 |
 | v0.26.0 | 0 - 1 | 1 |
 | v0.25.0 | 0 - 1 | 1 |


### PR DESCRIPTION
Also, fixes the autoscaler-agent side of the agent<->plugin versioning so it correctly says that the single current supported version is v5.0.

Must have missed this in #750.