### PR TITLE
plugin: Fix nil deref on nil metrics

### DIFF
--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -168,12 +168,14 @@ func (e *AutoscaleEnforcer) handleAgentRequest(
 	}
 	// check that nil-ness of req.Metrics.{LoadAverage5Min,MemoryUsageBytes} match what's expected
 	// for the protocol version.
-	if (req.Metrics.LoadAverage5Min != nil) != (req.Metrics.MemoryUsageBytes != nil) {
-		return nil, 400, fmt.Errorf("presence of metrics.loadAvg5M must match presence of metrics.memoryUsageBytes")
-	} else if req.Metrics.LoadAverage5Min == nil && req.ProtoVersion.IncludesExtendedMetrics() {
-		return nil, 400, fmt.Errorf("nil metrics.{loadAvg5M,memoryUsageBytes} not supported for protocol version %v", req.ProtoVersion)
-	} else if req.Metrics.LoadAverage5Min != nil && !req.ProtoVersion.IncludesExtendedMetrics() {
-		return nil, 400, fmt.Errorf("non-nil metrics.{loadAvg5M,memoryUsageBytes} not supported for protocol version %v", req.ProtoVersion)
+	if req.Metrics != nil {
+		if (req.Metrics.LoadAverage5Min != nil) != (req.Metrics.MemoryUsageBytes != nil) {
+			return nil, 400, fmt.Errorf("presence of metrics.loadAvg5M must match presence of metrics.memoryUsageBytes")
+		} else if req.Metrics.LoadAverage5Min == nil && req.ProtoVersion.IncludesExtendedMetrics() {
+			return nil, 400, fmt.Errorf("nil metrics.{loadAvg5M,memoryUsageBytes} not supported for protocol version %v", req.ProtoVersion)
+		} else if req.Metrics.LoadAverage5Min != nil && !req.ProtoVersion.IncludesExtendedMetrics() {
+			return nil, 400, fmt.Errorf("non-nil metrics.{loadAvg5M,memoryUsageBytes} not supported for protocol version %v", req.ProtoVersion)
+		}
 	}
 
 	e.state.lock.Lock()


### PR DESCRIPTION
The autoscaler-agent <-> scheduler plugin protocol allows the autoscaler-agent to skip the metrics field if there aren't any, which typically occurs right after the VM is created.

With the changes from #750, we assumed that .Metrics will always be non-nil, meaning that it panics when .Metrics *is* actually nil.

---

Depending on the implementation, this could have been caught by #765.