### PR TITLE
neonvm/api: Fix SwapInfo-related backwards compatibility issues

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -203,6 +203,7 @@ type GuestSettings struct {
 	// *really* a good way to allow both strings and structs in the field without that.
 	//
 	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:validation:Type=any
 	// +optional
 	Swap *SwapInfo `json:"swap,omitempty"`
 }

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -188,11 +188,7 @@ type Guest struct {
 	// Additional settings for the VM.
 	// Cannot be updated.
 	//
-	// Note: kubebuilder generally recommends against having Schemaless validation, but there isn't
-	// *really* a good way to allow both strings and structs in the field without that.
-	//
 	// +optional
-	// +kubebuilder:validation:Schemaless
 	Settings *GuestSettings `json:"settings,omitempty"`
 }
 
@@ -202,6 +198,11 @@ type GuestSettings struct {
 	Sysctl []string `json:"sysctl,omitempty"`
 
 	// Swap controls settings for adding a swap disk to the VM.
+	//
+	// Note: kubebuilder generally recommends against having Schemaless validation, but there isn't
+	// *really* a good way to allow both strings and structs in the field without that.
+	//
+	// +kubebuilder:validation:Schemaless
 	// +optional
 	Swap *SwapInfo `json:"swap,omitempty"`
 }

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -187,7 +187,12 @@ type Guest struct {
 
 	// Additional settings for the VM.
 	// Cannot be updated.
+	//
+	// Note: kubebuilder generally recommends against having Schemaless validation, but there isn't
+	// *really* a good way to allow both strings and structs in the field without that.
+	//
 	// +optional
+	// +kubebuilder:validation:Schemaless
 	Settings *GuestSettings `json:"settings,omitempty"`
 }
 

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -215,6 +215,23 @@ type SwapInfo struct {
 	SkipSwapon *bool `json:"skipSwapon,omitempty"`
 }
 
+// SwapInfo implements MarshalJSON to allow backwards compatibility with a clients using a previous
+// version of NeonVM that expect the type to be a resource.Quantity instead of a struct.
+func (s *SwapInfo) MarshalJSON() ([]byte, error) {
+	if s.SkipSwapon == nil {
+		return json.Marshal(&s.Size)
+	}
+
+	var si struct {
+		Size       resource.Quantity `json:"size"`
+		SkipSwapon *bool             `json:"skipSwapon,omitempty"`
+	}
+	si.Size = s.Size
+	si.SkipSwapon = s.SkipSwapon
+
+	return json.Marshal(&si)
+}
+
 // SwapInfo implements UnmarshalJSON to allow backwards compatibility with a previous version of
 // NeonVM that used a resource.Quantity to control swap, instead of a struct.
 //

--- a/neonvm/apis/neonvm/v1/virtualmachine_types_test.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types_test.go
@@ -49,3 +49,36 @@ func TestSwapInfoBackwardsCompatibility(t *testing.T) {
 		assert.Equal(t, parsedWrapper.Swap, &c.parsed)
 	}
 }
+
+func TestSwapInfoForwardsCompatibility(t *testing.T) {
+	cases := []struct {
+		input  vmv1.SwapInfo
+		output string
+	}{
+		// Forwards compatibility test
+		{
+			input: vmv1.SwapInfo{
+				Size:       resource.MustParse("1Gi"),
+				SkipSwapon: nil,
+			},
+			output: `"1Gi"`,
+		},
+		// Simple test for current output format
+		{
+			input: vmv1.SwapInfo{
+				Size:       resource.MustParse("3Gi"),
+				SkipSwapon: &[]bool{true}[0],
+			},
+			output: `{"size":"3Gi","skipSwapon":true}`,
+		},
+	}
+
+	for i, c := range cases {
+		marshaled, err := json.Marshal(&c.input)
+		if !assert.Nil(t, err, "marshaling failed for case %d", i) {
+			continue
+		}
+
+		assert.Equal(t, string(marshaled), c.output)
+	}
+}

--- a/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -2466,10 +2466,21 @@ spec:
                     - image
                     type: object
                   settings:
-                    description: "Additional settings for the VM. Cannot be updated.
-                      \n Note: kubebuilder generally recommends against having Schemaless
-                      validation, but there isn't *really* a good way to allow both
-                      strings and structs in the field without that."
+                    description: Additional settings for the VM. Cannot be updated.
+                    properties:
+                      swap:
+                        description: "Swap controls settings for adding a swap disk
+                          to the VM. \n Note: kubebuilder generally recommends against
+                          having Schemaless validation, but there isn't *really* a
+                          good way to allow both strings and structs in the field
+                          without that."
+                      sysctl:
+                        description: Individual lines to add to a sysctl.conf file.
+                          See sysctl.conf(5) for more
+                        items:
+                          type: string
+                        type: array
+                    type: object
                 type: object
               imagePullSecrets:
                 items:

--- a/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -2474,6 +2474,7 @@ spec:
                           having Schemaless validation, but there isn't *really* a
                           good way to allow both strings and structs in the field
                           without that."
+                        type: any
                       sysctl:
                         description: Individual lines to add to a sysctl.conf file.
                           See sysctl.conf(5) for more

--- a/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -2466,40 +2466,10 @@ spec:
                     - image
                     type: object
                   settings:
-                    description: Additional settings for the VM. Cannot be updated.
-                    properties:
-                      swap:
-                        description: Swap controls settings for adding a swap disk
-                          to the VM.
-                        properties:
-                          size:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: Size sets the size of the swap in the VM.
-                              The amount of space used on the host may be slightly
-                              more (by a few MiBs). The information reported by `cat
-                              /proc/meminfo` may show slightly less, due to a single
-                              page header (typically 4KiB).
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          skipSwapon:
-                            description: "SkipSwapon instructs the VM to *not* run
-                              swapon for the swap on startup. \n This is intended
-                              to be used in cases where you will *always* resize the
-                              swap post-startup, and don't need it available before
-                              that resizing."
-                            type: boolean
-                        required:
-                        - size
-                        type: object
-                      sysctl:
-                        description: Individual lines to add to a sysctl.conf file.
-                          See sysctl.conf(5) for more
-                        items:
-                          type: string
-                        type: array
-                    type: object
+                    description: "Additional settings for the VM. Cannot be updated.
+                      \n Note: kubebuilder generally recommends against having Schemaless
+                      validation, but there isn't *really* a good way to allow both
+                      strings and structs in the field without that."
                 type: object
               imagePullSecrets:
                 items:

--- a/tests/e2e/swap/00-create-vm.yaml
+++ b/tests/e2e/swap/00-create-vm.yaml
@@ -22,5 +22,4 @@ spec:
       image: vm-postgres:15-bullseye
       size: 1Gi
     settings:
-      swap:
-        size: 1Gi
+      swap: 1Gi


### PR DESCRIPTION
In short, the PR switching swap to *SwapInfo (#887) added checks for backwards compatibility, but an older client operating with newer NeonVM could still break because after reconciling the controller would replace the *resource.Quantity for swap with a struct, and then because the type is different from expected, the older client would fail to fetch the VM if it tried to do that in the future.

_In addition to that_, the CRD change prevented creating VMs with the old, string-based swap field.

ref https://neondb.slack.com/archives/C033A2WE6BZ/p1713290569648829