### PR TITLE
Generate manifests via `make generate`, remove `make manifests`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,29 +51,8 @@ jobs:
             exit 1
           fi
 
-  manifests:
-    name: check generated manifests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
-      - name: make manifests
-        run: |
-          make manifests
-      - name: check diff
-        run: |
-          if ! test -z "$(git ls-files --exclude-standard --others .)$(git diff .)"; then
-            git ls-files --exclude-standard --others .
-            git diff .
-            echo "ERROR: 'make manifests' modified the source tree."
-            exit 1
-          fi
-
-  generated-go:
-    name: check generated go files
+  generated:
+    name: check generated files
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -86,7 +86,7 @@ type VirtualMachineReconciler struct {
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
-// when controller-gen (used by 'make manifests') is executed.
+// when controller-gen (used by 'make generate') is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
 //+kubebuilder:rbac:groups=vm.neon.tech,resources=virtualmachines,verbs=get;list;watch;create;update;patch;delete

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -86,7 +86,7 @@ type VirtualMachineReconciler struct {
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
-// when the command <make manifests> is executed.
+// when controller-gen (used by 'make manifests') is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
 //+kubebuilder:rbac:groups=vm.neon.tech,resources=virtualmachines,verbs=get;list;watch;create;update;patch;delete

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -63,7 +63,7 @@ type VirtualMachineMigrationReconciler struct {
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
-// when the command <make manifests> is executed.
+// when controller-gen (used by 'make manifests') is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
 //+kubebuilder:rbac:groups=vm.neon.tech,resources=virtualmachinemigrations,verbs=get;list;watch;create;update;patch;delete

--- a/neonvm/controllers/virtualmachinemigration_controller.go
+++ b/neonvm/controllers/virtualmachinemigration_controller.go
@@ -63,7 +63,7 @@ type VirtualMachineMigrationReconciler struct {
 }
 
 // The following markers are used to generate the rules permissions (RBAC) on config/rbac using controller-gen
-// when controller-gen (used by 'make manifests') is executed.
+// when controller-gen (used by 'make generate') is executed.
 // To know more about markers see: https://book.kubebuilder.io/reference/markers.html
 
 //+kubebuilder:rbac:groups=vm.neon.tech,resources=virtualmachinemigrations,verbs=get;list;watch;create;update;patch;delete

--- a/neonvm/hack/generate.sh
+++ b/neonvm/hack/generate.sh
@@ -11,3 +11,8 @@ bash $GOPATH/src/k8s.io/code-generator/generate-groups.sh "deepcopy,client,infor
     --go-header-file neonvm/hack/boilerplate.go.txt
 
 controller-gen object:headerFile="neonvm/hack/boilerplate.go.txt" paths="./neonvm/apis/..."
+
+controller-gen rbac:roleName=manager-role crd webhook paths="./neonvm/..." \
+	output:crd:artifacts:config=neonvm/config/crd/bases \
+	output:rbac:artifacts:config=neonvm/config/rbac \
+	output:webhook:artifacts:config=neonvm/config/webhook


### PR DESCRIPTION
We currently see issues with Go >1.21 and our current controller-gen version, so a reasonable workaround is to always run with Go 1.21 instead of using whatever the system happens to have install.

Easiest way to do that is by doing the manifest generation inside a container, and `make generate` already serves that purpose, so this commit changes the generation script to *also* generate the manifests.

This commit also removes all prior occurrences of `make manifests`.

Fixes #885.