### PR TITLE
neonvm: metrics for failing reconcile

### DIFF
--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -19,6 +19,9 @@ type ReconcilerMetrics struct {
 	runnerCreationToVMRunningTime  prometheus.Histogram
 	vmCreationToVMRunningTime      prometheus.Histogram
 	vmRestartCounts                prometheus.Counter
+	reconcileDurationSuccessful    prometheus.Histogram
+	reconcileDurationFailure       prometheus.Histogram
+	statusUpdateFailureCount       prometheus.Counter
 }
 
 func MakeReconcilerMetrics() ReconcilerMetrics {
@@ -60,6 +63,26 @@ func MakeReconcilerMetrics() ReconcilerMetrics {
 			prometheus.CounterOpts{
 				Name: "vm_restarts_count",
 				Help: "Total number of VM restarts across the cluster captured by VirtualMachine reconciler",
+			},
+		)),
+		reconcileDurationSuccessful: util.RegisterMetric(metrics.Registry, prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "reconcile_duration_successful_seconds",
+				Help:    "Time duration of successful reconciles",
+				Buckets: buckets,
+			},
+		)),
+		reconcileDurationFailure: util.RegisterMetric(metrics.Registry, prometheus.NewHistogram(
+			prometheus.HistogramOpts{
+				Name:    "reconcile_duration_failure_seconds",
+				Help:    "Time duration of failed reconciles",
+				Buckets: buckets,
+			},
+		)),
+		statusUpdateFailureCount: util.RegisterMetric(metrics.Registry, prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "status_update_failure_count",
+				Help: "Total number of failures to update the status of a VirtualMachine",
 			},
 		)),
 	}

--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -22,6 +22,7 @@ type ReconcilerMetrics struct {
 	reconcileDurationSuccessful    prometheus.Histogram
 	reconcileDurationFailure       prometheus.Histogram
 	statusUpdateFailureCount       prometheus.Counter
+	transientFailureCount          prometheus.Counter
 }
 
 func MakeReconcilerMetrics() ReconcilerMetrics {
@@ -83,6 +84,12 @@ func MakeReconcilerMetrics() ReconcilerMetrics {
 			prometheus.CounterOpts{
 				Name: "status_update_failure_count",
 				Help: "Total number of failures to update the status of a VirtualMachine",
+			},
+		)),
+		transientFailureCount: util.RegisterMetric(metrics.Registry, prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "transient_failure_count",
+				Help: "Total number of transient failures in the VirtualMachine reconciler",
 			},
 		)),
 	}

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -1750,7 +1750,7 @@ func DeepEqual(v1, v2 interface{}) bool {
 // TODO: reimplement to r.Patch()
 func (r *VirtualMachineReconciler) tryUpdateVM(ctx context.Context, virtualmachine *vmv1.VirtualMachine) error {
 	err := r.Update(ctx, virtualmachine)
-	// Simlar to https://github.com/rancher/rancher/blob/6d87a11ea46b7571646d7c3d7af704584c39fd62/pkg/controllers/provisioningv2/provisioninglog/provisioninglog.go#L103
+	// Similar to https://github.com/rancher/rancher/blob/6d87a11ea46b7571646d7c3d7af704584c39fd62/pkg/controllers/provisioningv2/provisioninglog/provisioninglog.go#L103
 	if err != nil && strings.Contains(err.Error(),
 		"the object has been modified; please apply your changes to the latest version and try again") {
 		r.Metrics.transientFailureCount.Inc()

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	nadapiv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -1748,7 +1749,13 @@ func DeepEqual(v1, v2 interface{}) bool {
 
 // TODO: reimplement to r.Patch()
 func (r *VirtualMachineReconciler) tryUpdateVM(ctx context.Context, virtualmachine *vmv1.VirtualMachine) error {
-	return r.Update(ctx, virtualmachine)
+	err := r.Update(ctx, virtualmachine)
+	// Simlar to https://github.com/rancher/rancher/blob/6d87a11ea46b7571646d7c3d7af704584c39fd62/pkg/controllers/provisioningv2/provisioninglog/provisioninglog.go#L103
+	if err != nil && strings.Contains(err.Error(),
+		"the object has been modified; please apply your changes to the latest version and try again") {
+		r.Metrics.transientFailureCount.Inc()
+	}
+	return err
 }
 
 // return Network Attachment Definition name with IPAM settings

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -176,7 +176,7 @@ func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		r.Recorder.Eventf(&virtualmachine, corev1.EventTypeWarning, "Failed",
 			"Failed to reconcile (%s): %s", virtualmachine.Name, err)
 		log.Error(err, "Failed to reconcile VirtualMachine",
-			"virtualmachine", virtualmachine.Name, "duration", since.String())
+			"duration", since.String())
 		r.Metrics.reconcileDurationFailure.Observe(since.Seconds())
 		return ctrl.Result{}, err
 	}

--- a/neonvm/controllers/virtualmachine_controller.go
+++ b/neonvm/controllers/virtualmachine_controller.go
@@ -167,13 +167,9 @@ func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	statusBefore := virtualmachine.Status.DeepCopy()
-
-	err := r.doReconcile(ctx, &virtualmachine)
-
-	if err != nil {
+	if err := r.doReconcile(ctx, &virtualmachine); err != nil {
 		r.Recorder.Eventf(&virtualmachine, corev1.EventTypeWarning, "Failed",
 			"Failed to reconcile (%s): %s", virtualmachine.Name, err)
-
 		return ctrl.Result{}, err
 	}
 
@@ -182,7 +178,6 @@ func (r *VirtualMachineReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err := r.Status().Update(ctx, &virtualmachine); err != nil {
 			log.Error(err, "Failed to update VirtualMachine status after reconcile loop",
 				"virtualmachine", virtualmachine.Name)
-			r.Metrics.statusUpdateFailureCount.Inc()
 			return ctrl.Result{}, err
 		}
 	}


### PR DESCRIPTION
The need for this appeared during the investigation of an elevated level of reconciliation failures after neonvm-controllers were moved to an another node group.

Adds a single metric `reconcile_duration_seconds` with an `outcome` label

\+ relevant log messages

Part of a #916 and #918. Easier to do together because of conflicts. 