### PR TITLE
neonvm-runner-image-loader: Faster rollout

### DIFF
--- a/neonvm/runner-image-loader/daemonset.yaml
+++ b/neonvm/runner-image-loader/daemonset.yaml
@@ -6,6 +6,10 @@ spec:
   selector:
     matchLabels:
       name: neonvm-runner-image-loader
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 3
   template:
     metadata:
       labels:

--- a/neonvm/runner-image-loader/daemonset.yaml
+++ b/neonvm/runner-image-loader/daemonset.yaml
@@ -9,7 +9,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 3
+      maxUnavailable: 100%
   template:
     metadata:
       labels:


### PR DESCRIPTION
Specifically, this PR sets `maxUnavailable = 3`, which allows updating up to 3 copies in parallel.

An issue we see during rollout is that it often takes 30+ seconds to create a new neonvm-runner-image-loader on a node, and doing this for many nodes takes an unreasonable amount of time. This improves that.