### PR TITLE
Update Rust: 1.74 -> 1.78

### DIFF
--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -51,7 +51,7 @@ files:
 
 build: |
   # Build vm-monitor
-  FROM rust:1.74-alpine as monitor-builder
+  FROM rust:1.78-alpine as monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -28,7 +28,7 @@ files:
     hostPath: cgconfig.conf
 build: |
   # Build vm-monitor
-  FROM rust:1.74-alpine as monitor-builder
+  FROM rust:1.78-alpine as monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev


### PR DESCRIPTION
Good to keep in sync with `neondatabase/neon` because we pull in vm-monitor.
Corresponding PR there was neondatabase/neon#7598.