### PR TITLE
agent: don't treat downscale denies as failed request

### DIFF
--- a/pkg/agent/execbridge.go
+++ b/pkg/agent/execbridge.go
@@ -169,8 +169,10 @@ func (h *execMonitorHandle) Downscale(
 
 	result, err := doMonitorDownscale(ctx, logger, h.monitor.dispatcher, target)
 
-	if err == nil && result.Ok {
-		h.runner.recordResourceChange(current, target, h.runner.global.metrics.monitorApprovedChange)
+	if err == nil {
+		if result.Ok {
+			h.runner.recordResourceChange(current, target, h.runner.global.metrics.monitorApprovedChange)
+		}
 	} else {
 		h.runner.status.update(h.runner.global, func(ps podStatus) podStatus {
 			ps.failedMonitorRequestCounter.Inc()


### PR DESCRIPTION
Fixes #926, a follow-up for the #770.

The defintion for the VM stuckness was changed to include denied downscale request in the following commit:

    commit fdf01331d233985128ac9313ad77681162871bf0
    Author: Shayan Hosseini <shayan@neon.tech>
    Date:   Sat Apr 6 09:25:01 2024 -0400

    agent: track more liveness in vm-stuck metrics (#855)

This resulted in the consistent firing of the alert.

We should actually treat the denied downscale as part of the normal operation. This can happen due to mismatching policy of what is an acceptable level memory usage in autoscaler-agent vs vm_monitor. 