### PR TITLE
agent: don't check S3.Endpoint for emptyness

### DIFF
--- a/pkg/agent/billing/billing.go
+++ b/pkg/agent/billing/billing.go
@@ -107,14 +107,9 @@ func StartBillingMetricsCollector(
 	if c := conf.Clients.S3; c != nil {
 		client, err := billing.NewS3Client(ctx, c.S3ClientConfig)
 		if err != nil {
-			return fmt.Errorf("Failed to create S3 client: %w", err)
+			return fmt.Errorf("failed to create S3 client: %w", err)
 		}
-		logger.Info("Created S3 client",
-			zap.String("bucket", c.Bucket),
-			zap.String("region", c.Region),
-			zap.String("prefixInBucket", c.PrefixInBucket),
-			zap.String("endpoint", c.Endpoint),
-		)
+		logger.Info("Created S3 client", client.LogFields())
 		clients = append(clients, clientInfo{
 			client: client,
 			name:   "s3",

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -182,7 +182,6 @@ func (c *Config) validate() error {
 		erc.Whenf(ec, c.Billing.Clients.S3.Bucket == "", emptyTmpl, ".billing.clients.s3.bucket")
 		erc.Whenf(ec, c.Billing.Clients.S3.Region == "", emptyTmpl, ".billing.clients.s3.region")
 		erc.Whenf(ec, c.Billing.Clients.S3.PrefixInBucket == "", emptyTmpl, ".billing.clients.s3.prefixInBucket")
-		erc.Whenf(ec, c.Billing.Clients.S3.Endpoint == "", emptyTmpl, ".billing.clients.s3.endpoint")
 	}
 	erc.Whenf(ec, c.DumpState != nil && c.DumpState.Port == 0, zeroTmpl, ".dumpState.port")
 	erc.Whenf(ec, c.DumpState != nil && c.DumpState.TimeoutSeconds == 0, zeroTmpl, ".dumpState.timeoutSeconds")

--- a/pkg/billing/client.go
+++ b/pkg/billing/client.go
@@ -118,7 +118,9 @@ func NewS3Client(ctx context.Context, cfg S3ClientConfig) (*S3Client, error) {
 	}
 
 	client := s3.NewFromConfig(s3Config, func(o *s3.Options) {
-		o.BaseEndpoint = &cfg.Endpoint
+		if cfg.Endpoint != "" {
+			o.BaseEndpoint = &cfg.Endpoint
+		}
 		o.UsePathStyle = true // required for minio
 	})
 


### PR DESCRIPTION
We can actually use the default value in prod, it simplifies configuration.

Also, tiny changes for logs and error formatting.