### PR TITLE
plugin: Transaction-based speculative reserve and logic unification

### DIFF
--- a/pkg/util/xact/xact.go
+++ b/pkg/util/xact/xact.go
@@ -1,0 +1,34 @@
+package xact
+
+// Xact represents a single in-memory transaction, to aid with separating calculations from their
+// application.
+type Xact[T any] struct {
+	tmp  T
+	base *T
+}
+
+// New returns a new transaction object (called Xact) operating on the given pointer
+//
+// NOTE: Any copying is shallow -- if T contains pointers, any changes to the values behind those
+// will NOT be delayed until (*Xact[T]).Commit().
+func New[T any](ptr *T) *Xact[T] {
+	return &Xact[T]{
+		tmp:  *ptr,
+		base: ptr,
+	}
+}
+
+// Value returns a pointer to the temporary value stored in the Xact
+//
+// The returned value can be freely modified; it will have no effect until the transaction is
+// committed with Commit().
+func (x *Xact[T]) Value() *T {
+	return &x.tmp
+}
+
+// Commit assigns the temporary value back to the original pointer that the Xact was created with
+//
+// A transaction can be committed multiple times, if it's useful to reuse it.
+func (x *Xact[T]) Commit() {
+	*x.base = x.tmp
+}


### PR DESCRIPTION
Trying out this approach as a potential way to make implementing overcommit (#517) easier, to avoid dealing with rounding errors when responding to the autoscaler-agents.

I think this "speculative reserve" may be a reasonable change in isolation, and reducing the number of separate implementations of the same logic should also help with overcommit (because of how it affects every single resource calculation).

Not 100% sure we want to go this route, but it's my best guess so far.

---

Tested this locally and it seemed to be ok; already fixed a couple bugs based on suspicious logs. There might be more.