### PR TITLE
pg16-disk-test: add mkfifo

### DIFF
--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -13,10 +13,18 @@ commands:
     user: vm-monitor
     sysvInitAction: respawn
     shell: 'RUST_LOG=info /bin/vm-monitor --cgroup=neon-test --addr="0.0.0.0:10301"'
+  - name: create-fifo
+    user: root
+    sysvInitAction: wait
+    shell: 'mkfifo -m 0666 /tmp/neon-logs.fifo'
+  - name: log-redirect
+    user: root
+    sysvInitAction: respawn
+    shell: 'cat /tmp/neon-logs.fifo > /dev/virtio-ports/tech.neon.log.0'
   - name: start-postgres
     user: postgres
     sysvInitAction: once
-    shell: 'PGDATA=/var/lib/postgresql pg_ctl start -o "-c config_file=/etc/postgresql.conf -c hba_file=/etc/pg_hba.conf" -l /dev/virtio-ports/tech.neon.log.0'
+    shell: 'PGDATA=/var/lib/postgresql pg_ctl start -o "-c config_file=/etc/postgresql.conf -c hba_file=/etc/pg_hba.conf" -l /tmp/neon-logs.fifo'
 files:
   - filename: postgresql.conf
     hostPath: postgresql.conf


### PR DESCRIPTION
The virtio-serial interface can be opened only once.
Consider the following scenario:

1. Process A starts writing to the serial device.
2. Process A spawns a fork, Process B. It inherits the open file descriptor.
3. Process A dies; Process B survives and preserves the file descriptor.
4. Process A is restarted but cannot open the serial device again,
    causing it to crash-loop.

To fix it, we are creating FIFO special file, which supports multiple
writers, and spawning cat to redirect it to the virtio-serial.

Part of the #939.