### PR TITLE
neonvm-controller: Rework zap setup & disable sampling

### DIFF
--- a/neonvm/config/controller/deployment.yaml
+++ b/neonvm/config/controller/deployment.yaml
@@ -54,10 +54,6 @@ spec:
         - "--leader-elect"
         - "--concurrency-limit=128"
         - "--enable-container-mgr"
-        - "--zap-devel=false"
-        - "--zap-time-encoding=iso8601"
-        - "--zap-log-level=info"
-        - "--zap-stacktrace-level=panic"
         # See #775 and its links.
         # * cache.writeback=on - don't set O_DSYNC (don't flush every write)
         # * cache.direct=on    - use O_DIRECT (don't abuse host's page cache!)

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"net/http"

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -116,7 +116,7 @@ func main() {
 		zap.AddStacktrace(zapcore.PanicLevel), // enable stack traces at panic or above
 	))
 	// There's no direct way to go from a zap.Logger to a logr.Logger, or even a zapcore.Core to a
-	// logr.Logger, so we need the roundabout method of letting logr do the intial setup and then
+	// logr.Logger, so we need the roundabout method of letting logr do the initial setup and then
 	// replacing the zapcore.Core with our own.
 	logger := ctrlzap.New(ctrlzap.RawZapOpts(zap.WrapCore(
 		func(c zapcore.Core) zapcore.Core {

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -126,7 +126,7 @@ func main() {
 
 	ctrl.SetLogger(logger)
 	// define klog settings (used in LeaderElector)
-	klog.SetLogger(logger)
+	klog.SetLogger(logger.V(2))
 
 	// tune k8s client for manager
 	cfg := ctrl.GetConfigOrDie()


### PR DESCRIPTION
By default, zap enables "log sampling" when not in development mode. Unsurprisingly, we're finding that neonvm-controller logs are being dropped in production as a result of this.

I couldn't find a clean way to disable sampling without entirely constructing the `zap.Logger` from scratch, so that's what I did.

Notable changes:

* neonvm-controller's `--zap-*` flags have been removed
* neonvm-controller now hard-codes the logger config we were using before -- info log level, stack traces on panic, and ISO8601 time

More context here: https://neondb.slack.com/archives/C03TN5G758R/p1716775758112349?thread_ts=1716765298.436929
See also: #475