### PR TITLE
api,agent/core: Make required ScalingConfig fields optional per-VM

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -206,7 +206,7 @@ func (c *Config) validate() error {
 	erc.Whenf(ec, c.Monitor.RequestedUpscaleValidSeconds == 0, zeroTmpl, ".monitor.requestedUpscaleValidSeconds")
 	erc.Whenf(ec, c.Monitor.MaxFailedRequestRate.IntervalSeconds == 0, zeroTmpl, ".monitor.maxFailedRequestRate.intervalSeconds")
 	// add all errors if there are any: https://github.com/neondatabase/autoscaling/pull/195#discussion_r1170893494
-	ec.Add(c.Scaling.DefaultConfig.Validate())
+	ec.Add(c.Scaling.DefaultConfig.ValidateDefaults())
 	erc.Whenf(ec, c.Scheduler.RequestPort == 0, zeroTmpl, ".scheduler.requestPort")
 	erc.Whenf(ec, c.Scheduler.RequestTimeoutSeconds == 0, zeroTmpl, ".scheduler.requestTimeoutSeconds")
 	erc.Whenf(ec, c.Scheduler.RequestAtLeastEverySeconds == 0, zeroTmpl, ".scheduler.requestAtLeastEverySeconds")

--- a/pkg/agent/core/state.go
+++ b/pkg/agent/core/state.go
@@ -633,11 +633,8 @@ func (s *state) calculateMonitorDownscaleAction(
 }
 
 func (s *state) scalingConfig() api.ScalingConfig {
-	if s.VM.Config.ScalingConfig != nil {
-		return *s.VM.Config.ScalingConfig
-	} else {
-		return s.Config.DefaultScalingConfig
-	}
+	// nb: WithOverrides allows its arg to be nil, in which case it does nothing.
+	return s.Config.DefaultScalingConfig.WithOverrides(s.VM.Config.ScalingConfig)
 }
 
 // public version, for testing.
@@ -676,7 +673,7 @@ func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 		// Goal compute unit is at the point where (CPUs) × (LoadAverageFractionTarget) == (load
 		// average),
 		// which we can get by dividing LA by LAFT, and then dividing by the number of CPUs per CU
-		goalCPUs := float64(s.Metrics.LoadAverage1Min) / s.scalingConfig().LoadAverageFractionTarget
+		goalCPUs := float64(s.Metrics.LoadAverage1Min) / *s.scalingConfig().LoadAverageFractionTarget
 		cpuGoalCU := uint32(math.Round(goalCPUs / s.Config.ComputeUnit.VCPU.AsFloat64()))
 
 		// For Mem:
@@ -685,7 +682,7 @@ func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 		// that to CUs
 		//
 		// NOTE: use uint64 for calculations on bytes as uint32 can overflow
-		memGoalBytes := api.Bytes(math.Round(float64(s.Metrics.MemoryUsageBytes) / s.scalingConfig().MemoryUsageFractionTarget))
+		memGoalBytes := api.Bytes(math.Round(float64(s.Metrics.MemoryUsageBytes) / *s.scalingConfig().MemoryUsageFractionTarget))
 		memGoalCU := uint32(memGoalBytes / s.Config.ComputeUnit.Mem)
 
 		goalCU = util.Max(cpuGoalCU, memGoalCU)

--- a/pkg/agent/core/state_test.go
+++ b/pkg/agent/core/state_test.go
@@ -107,8 +107,8 @@ func Test_DesiredResourcesFromMetricsOrRequestedUpscaling(t *testing.T) {
 			core.Config{
 				ComputeUnit: api.Resources{VCPU: 250, Mem: 1 * slotSize},
 				DefaultScalingConfig: api.ScalingConfig{
-					LoadAverageFractionTarget: 0.5,
-					MemoryUsageFractionTarget: 0.5,
+					LoadAverageFractionTarget: ptr(0.5),
+					MemoryUsageFractionTarget: ptr(0.5),
 				},
 				// these don't really matter, because we're not using (*State).NextActions()
 				NeonVMRetryWait:                    time.Second,
@@ -177,8 +177,8 @@ var DefaultInitialStateConfig = helpers.InitialStateConfig{
 	Core: core.Config{
 		ComputeUnit: DefaultComputeUnit,
 		DefaultScalingConfig: api.ScalingConfig{
-			LoadAverageFractionTarget: 0.5,
-			MemoryUsageFractionTarget: 0.5,
+			LoadAverageFractionTarget: ptr(0.5),
+			MemoryUsageFractionTarget: ptr(0.5),
 		},
 		NeonVMRetryWait:                    5 * time.Second,
 		PluginRequestTick:                  5 * time.Second,

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -389,7 +389,7 @@ func (c *ScalingConfig) ValidateOverrides() error {
 	return c.validate(false)
 }
 
-func (c *ScalingConfig) validate(requireAllRequiredFields bool) error {
+func (c *ScalingConfig) validate(requireAll bool) error {
 	ec := &erc.Collector{}
 
 	// Check c.LoadAverageFractionTarget is between 0 and 2. We don't *strictly* need the upper
@@ -397,7 +397,7 @@ func (c *ScalingConfig) validate(requireAllRequiredFields bool) error {
 	if c.LoadAverageFractionTarget != nil {
 		erc.Whenf(ec, *c.LoadAverageFractionTarget < 0.0, "%s must be set to value >= 0", ".loadAverageFractionTarget")
 		erc.Whenf(ec, *c.LoadAverageFractionTarget >= 2.0, "%s must be set to value < 2 ", ".loadAverageFractionTarget")
-	} else if requireAllRequiredFields {
+	} else if requireAll {
 		ec.Add(fmt.Errorf("%s is a required field", ".loadAverageFractionTarget"))
 	}
 
@@ -405,7 +405,7 @@ func (c *ScalingConfig) validate(requireAllRequiredFields bool) error {
 	if c.MemoryUsageFractionTarget != nil {
 		erc.Whenf(ec, *c.MemoryUsageFractionTarget < 0.0, "%s must be set to value >= 0", ".memoryUsageFractionTarget")
 		erc.Whenf(ec, *c.MemoryUsageFractionTarget >= 1.0, "%s must be set to value < 1 ", ".memoryUsageFractionTarget")
-	} else if requireAllRequiredFields {
+	} else if requireAll {
 		ec.Add(fmt.Errorf("%s is a required field", ".memoryUsageFractionTarget"))
 	}
 

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -392,7 +392,7 @@ func (c *ScalingConfig) ValidateOverrides() error {
 func (c *ScalingConfig) validate(requireAllRequiredFields bool) error {
 	ec := &erc.Collector{}
 
-	// Check c.loadAverageFractionTarget is between 0 and 2. We don't *strictly* need the upper
+	// Check c.LoadAverageFractionTarget is between 0 and 2. We don't *strictly* need the upper
 	// bound, but it's a good safety check.
 	if c.LoadAverageFractionTarget != nil {
 		erc.Whenf(ec, *c.LoadAverageFractionTarget < 0.0, "%s must be set to value >= 0", ".loadAverageFractionTarget")

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/samber/lo"
 	"github.com/tychoish/fun/erc"
 	"go.uber.org/zap"
 
@@ -363,10 +364,10 @@ func (defaults ScalingConfig) WithOverrides(overrides *ScalingConfig) ScalingCon
 	}
 
 	if overrides.LoadAverageFractionTarget != nil {
-		defaults.LoadAverageFractionTarget = &[]float64{*overrides.LoadAverageFractionTarget}[0] // slice trick to shallow copy
+		defaults.LoadAverageFractionTarget = lo.ToPtr(*overrides.LoadAverageFractionTarget)
 	}
 	if overrides.MemoryUsageFractionTarget != nil {
-		defaults.MemoryUsageFractionTarget = &[]float64{*overrides.MemoryUsageFractionTarget}[0]
+		defaults.MemoryUsageFractionTarget = lo.ToPtr(*overrides.MemoryUsageFractionTarget)
 	}
 
 	return defaults


### PR DESCRIPTION
In short: When ScalingConfig is used to define global defaults, all required fields should be required. But when it's used to define the configuration for a VM, the "required" fields should actually be optional!

This change should allow the control plane to granularly specify only some scaling settings, while using the defaults for all others. That will make it easier to add fields to ScalingConfig (and have them actually used, at least), and reduce "spooky action at a distance" in the system.

---

Extracted from #895, thought it might be simpler/easier to handle separately.