### PR TITLE
neonvm: Tweak README's kernel upgrade steps

### DIFF
--- a/neonvm/README.md
+++ b/neonvm/README.md
@@ -114,7 +114,8 @@ make kernel
 To adjust the kernel config:
 
 ```
-docker build --build-arg KERNEL_VERSION=6.1.63 --platform linux/x86_64 --target build-deps -t kernel-build-deps -f Dockerfile.kernel-builder   .
+cd hack/kernel
+docker build --build-arg KERNEL_VERSION=6.1.63 --platform linux/x86_64 --target build-deps -t kernel-build-deps -f Dockerfile.kernel-builder .
 docker run --rm -v $PWD:/host --name kernel-build -it kernel-build-deps bash
 # inside that bash shell, do the menuconfig, then copy-out the config to /host
 ```


### PR DESCRIPTION
When first reading it, it took me a moment to realize that it's easier if you start from neonvm/hack/kernel rather than the repo root. Also, remove some extra spaces.