### PR TITLE
neonvm-controller: bring back RecordSuccess for conflicting

### DIFF
--- a/neonvm/controllers/metrics.go
+++ b/neonvm/controllers/metrics.go
@@ -235,6 +235,7 @@ func (d *wrappedReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			"duration", duration.String(), "outcome", outcome)
 	} else {
 		d.failing.RecordSuccess(req.NamespacedName)
+		d.conflicting.RecordSuccess(req.NamespacedName)
 		log.Info("Successful reconciliation", "duration", duration.String())
 	}
 	d.Metrics.ObserveReconcileDuration(outcome, duration)


### PR DESCRIPTION
The commit below has changed how the failing VMs are tracked:

    commit 3ac5841c59423f1f25838ca8f9fc93a98d49d14b
    Author: Oleg Vasilev <oleg@neon.tech>
    Date:   Fri Jun 7 22:19:47 2024 +0400

    neonvm-controller: replace failing reconciliation with per-VM failure interval  (#949)

The commit accidentaly lost a line which was meant to reset conflicting status, which resulted in an ever-increasing number of conflicting VMs.

Fix this.