### PR TITLE
neonvm-controller: Fix error in panic catching middleware

### DIFF
--- a/neonvm/controllers/catch_panic.go
+++ b/neonvm/controllers/catch_panic.go
@@ -23,7 +23,7 @@ func (r *catchPanicReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	defer func() {
 		if v := recover(); v != nil {
-			err = fmt.Errorf("payload: %v", v)
+			err = fmt.Errorf("panicked with: %v", v)
 			log.Error(err, "Reconcile panicked", "stack", string(debug.Stack()))
 		}
 	}()

--- a/neonvm/controllers/catch_panic.go
+++ b/neonvm/controllers/catch_panic.go
@@ -23,8 +23,8 @@ func (r *catchPanicReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	defer func() {
 		if v := recover(); v != nil {
-			err = fmt.Errorf("Reconcile panicked: %v", v)
-			log.Error(err, "stack", string(debug.Stack()))
+			err = fmt.Errorf("payload: %v", v)
+			log.Error(err, "Reconcile panicked", "stack", string(debug.Stack()))
 		}
 	}()
 


### PR DESCRIPTION
While working on #963, I spotted this in the logs:

```
{"level":"dpanic","ts":"2024-06-15T18:50:47.809Z","msg":"odd number of arguments passed as key-value pairs for logging",...,"ignored key":"goroutine 501 [running]:\nruntime/debug.Stack()\n\t/usr/local/go/src/runtime/debug/stack.go:24 ..."}
```