### PR TITLE
agent: Set log level to info

### DIFF
--- a/cmd/autoscaler-agent/main.go
+++ b/cmd/autoscaler-agent/main.go
@@ -21,8 +21,8 @@ import (
 
 func main() {
 	logConfig := zap.NewProductionConfig()
-	logConfig.Sampling = nil                 // Disable sampling, which the production config enables by default.
-	logConfig.Level.SetLevel(zap.DebugLevel) // Allow debug logs
+	logConfig.Sampling = nil                // Disable sampling, which the production config enables by default.
+	logConfig.Level.SetLevel(zap.InfoLevel) // Only "info" level and above (i.e. not debug logs)
 	logger := zap.Must(logConfig.Build()).Named("autoscaler-agent")
 	defer logger.Sync() //nolint:errcheck // what are we gonna do, log something about it?
 


### PR DESCRIPTION
Our current debug logs are largely not useful in production, and the volume is very high.
So, let's disable debug logs for now - can individually re-enable log lines by setting them to info later, when needed.

Ref https://neondb.slack.com/archives/C03TN5G758R/p1718652664673599?thread_ts=1718210683.556539