### PR TITLE
neonvm: Add support for virtio-mem

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/samber/lo"
 
@@ -172,6 +173,8 @@ type Guest struct {
 	// +optional
 	MemorySlots MemorySlots `json:"memorySlots"`
 	// +optional
+	MemoryProvider *MemoryProvider `json:"memoryProvider,omitempty"`
+	// +optional
 	RootDisk RootDisk `json:"rootDisk"`
 	// Docker image Entrypoint array replacement.
 	// +optional
@@ -192,6 +195,24 @@ type Guest struct {
 	// Cannot be updated.
 	// +optional
 	Settings *GuestSettings `json:"settings,omitempty"`
+}
+
+const virtioMemBlockSizeBytes = 8 * 1024 * 1024 // 8 MiB
+
+// ValidateForMemoryProvider returns an error iff the guest memory settings are invalid for the
+// MemoryProvider.
+//
+// This is used in two places. First, to validate VirtualMachine object creation. Second, to handle
+// the defaulting behavior for VirtualMachines that would be switching from DIMMSlots to VirtioMem
+// on restart. We place more restrictions on VirtioMem because we use 8MiB block sizes, so changing
+// to a new default can only happen if the memory slot size is a multiple of 8MiB.
+func (g Guest) ValidateForMemoryProvider(p MemoryProvider) error {
+	if p == MemoryProviderVirtioMem {
+		if g.MemorySlotSize.Value()%virtioMemBlockSizeBytes != 0 {
+			return fmt.Errorf("memorySlotSize invalid for memoryProvider VirtioMem: must be a multiple of 8Mi")
+		}
+	}
+	return nil
 }
 
 type GuestSettings struct {
@@ -353,6 +374,29 @@ type MemorySlots struct {
 	Use int32 `json:"use"`
 }
 
+// +kubebuilder:validation:Enum=DIMMSlots;VirtioMem
+type MemoryProvider string
+
+const (
+	MemoryProviderDIMMSlots MemoryProvider = "DIMMSlots"
+	MemoryProviderVirtioMem MemoryProvider = "VirtioMem"
+)
+
+// FlagFunc is a parsing function to be used with flag.Func
+func (p *MemoryProvider) FlagFunc(value string) error {
+	possibleValues := []string{
+		string(MemoryProviderDIMMSlots),
+		string(MemoryProviderVirtioMem),
+	}
+
+	if !slices.Contains(possibleValues, value) {
+		return fmt.Errorf("Unknown MemoryProvider %q, must be one of %v", value, possibleValues)
+	}
+
+	*p = MemoryProvider(value)
+	return nil
+}
+
 type RootDisk struct {
 	Image string `json:"image"`
 	// +optional
@@ -485,6 +529,8 @@ type VirtualMachineStatus struct {
 	// +optional
 	MemorySize *resource.Quantity `json:"memorySize,omitempty"`
 	// +optional
+	MemoryProvider *MemoryProvider `json:"memoryProvider,omitempty"`
+	// +optional
 	SSHSecretName string `json:"sshSecretName,omitempty"`
 }
 
@@ -550,6 +596,7 @@ func (vm *VirtualMachine) Cleanup() {
 	vm.Status.Node = ""
 	vm.Status.CPUs = nil
 	vm.Status.MemorySize = nil
+	vm.Status.MemoryProvider = nil
 }
 
 func (vm *VirtualMachine) HasRestarted() bool {

--- a/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
@@ -61,6 +61,13 @@ func (r *VirtualMachine) ValidateCreate() error {
 			r.Spec.Guest.CPUs.Max)
 	}
 
+	// validate .spec.guest.memorySlotSize w.r.t. .spec.guest.memoryProvider
+	if r.Spec.Guest.MemoryProvider != nil {
+		if err := r.Spec.Guest.ValidateForMemoryProvider(*r.Spec.Guest.MemoryProvider); err != nil {
+			return fmt.Errorf(".spec.guest: %w", err)
+		}
+	}
+
 	// validate .spec.guest.memorySlots.use and .spec.guest.memorySlots.max
 	if r.Spec.Guest.MemorySlots.Use < r.Spec.Guest.MemorySlots.Min {
 		return fmt.Errorf(".spec.guest.memorySlots.use (%d) should be greater than or equal to the .spec.guest.memorySlots.min (%d)",
@@ -124,6 +131,10 @@ func (r *VirtualMachine) ValidateUpdate(old runtime.Object) error {
 		{".spec.guest.cpus.max", func(v *VirtualMachine) any { return v.Spec.Guest.CPUs.Max }},
 		{".spec.guest.memorySlots.min", func(v *VirtualMachine) any { return v.Spec.Guest.MemorySlots.Min }},
 		{".spec.guest.memorySlots.max", func(v *VirtualMachine) any { return v.Spec.Guest.MemorySlots.Max }},
+		// nb: we don't check memoryProvider here, so that it's allowed to be mutable as a way of
+		// getting flexibility to solidify the memory provider or change it across restarts.
+		// ref https://github.com/neondatabase/autoscaling/pull/970#discussion_r1644225986
+		{".spec.guest.memoryProvider", func(v *VirtualMachine) any { return v.Spec.Guest.MemoryProvider }},
 		{".spec.guest.ports", func(v *VirtualMachine) any { return v.Spec.Guest.Ports }},
 		{".spec.guest.rootDisk", func(v *VirtualMachine) any { return v.Spec.Guest.RootDisk }},
 		{".spec.guest.command", func(v *VirtualMachine) any { return v.Spec.Guest.Command }},

--- a/neonvm/apis/neonvm/v1/zz_generated.deepcopy.go
+++ b/neonvm/apis/neonvm/v1/zz_generated.deepcopy.go
@@ -160,6 +160,11 @@ func (in *Guest) DeepCopyInto(out *Guest) {
 	out.CPUs = in.CPUs
 	out.MemorySlotSize = in.MemorySlotSize.DeepCopy()
 	out.MemorySlots = in.MemorySlots
+	if in.MemoryProvider != nil {
+		in, out := &in.MemoryProvider, &out.MemoryProvider
+		*out = new(MemoryProvider)
+		**out = **in
+	}
 	in.RootDisk.DeepCopyInto(&out.RootDisk)
 	if in.Command != nil {
 		in, out := &in.Command, &out.Command
@@ -749,6 +754,11 @@ func (in *VirtualMachineStatus) DeepCopyInto(out *VirtualMachineStatus) {
 		in, out := &in.MemorySize, &out.MemorySize
 		x := (*in).DeepCopy()
 		*out = &x
+	}
+	if in.MemoryProvider != nil {
+		in, out := &in.MemoryProvider, &out.MemoryProvider
+		*out = new(MemoryProvider)
+		**out = **in
 	}
 }
 

--- a/neonvm/config/controller/deployment.yaml
+++ b/neonvm/config/controller/deployment.yaml
@@ -59,6 +59,7 @@ spec:
         # * cache.direct=on    - use O_DIRECT (don't abuse host's page cache!)
         # * cache.no-flush=on  - ignores disk flush operations (not needed; our disks are ephemeral)
         - "--qemu-disk-cache-settings=cache.writeback=on,cache.direct=on,cache.no-flush=on"
+        - "--default-memory-provider=DIMMSlots"
         - "--failure-pending-period=1m"
         - "--failing-refresh-interval=15s"
         env:

--- a/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -2415,6 +2415,11 @@ spec:
                     type: array
                   kernelImage:
                     type: string
+                  memoryProvider:
+                    enum:
+                    - DIMMSlots
+                    - VirtioMem
+                    type: string
                   memorySlotSize:
                     anyOf:
                     - type: integer
@@ -2769,6 +2774,11 @@ spec:
               extraNetIP:
                 type: string
               extraNetMask:
+                type: string
+              memoryProvider:
+                enum:
+                - DIMMSlots
+                - VirtioMem
                 type: string
               memorySize:
                 anyOf:

--- a/neonvm/controllers/config.go
+++ b/neonvm/controllers/config.go
@@ -1,6 +1,10 @@
 package controllers
 
-import "time"
+import (
+	"time"
+
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+)
 
 // ReconcilerConfig stores shared configuration for VirtualMachineReconciler and
 // VirtualMachineMigrationReconciler.
@@ -24,6 +28,10 @@ type ReconcilerConfig struct {
 	// This field is passed to neonvm-runner as the `-qemu-disk-cache-settings` arg, and is directly
 	// used in setting up the VM disks via QEMU's `-drive` flag.
 	QEMUDiskCacheSettings string
+
+	// DefaultMemoryProvider is the memory provider (dimm slots or virtio-mem) that will be used for
+	// new VMs (or, when old ones restart) if nothing is explicitly set.
+	DefaultMemoryProvider vmv1.MemoryProvider
 
 	// FailurePendingPeriod is the period for the propagation of
 	// reconciliation failures to the observability instruments

--- a/neonvm/controllers/functests/vm_controller_test.go
+++ b/neonvm/controllers/functests/vm_controller_test.go
@@ -111,6 +111,7 @@ var _ = Describe("VirtualMachine controller", func() {
 					UseContainerMgr:         true,
 					MaxConcurrentReconciles: 1,
 					QEMUDiskCacheSettings:   "cache=none",
+					DefaultMemoryProvider:   vmv1.MemoryProviderDIMMSlots,
 					FailurePendingPeriod:    1 * time.Minute,
 					FailingRefreshInterval:  1 * time.Minute,
 				},

--- a/neonvm/controllers/vm_controller_unit_test.go
+++ b/neonvm/controllers/vm_controller_unit_test.go
@@ -116,6 +116,7 @@ func newTestParams(t *testing.T) *testParams {
 			UseContainerMgr:         false,
 			MaxConcurrentReconciles: 10,
 			QEMUDiskCacheSettings:   "",
+			DefaultMemoryProvider:   vmv1.MemoryProviderDIMMSlots,
 			FailurePendingPeriod:    time.Minute,
 			FailingRefreshInterval:  time.Minute,
 		},

--- a/neonvm/controllers/vm_qmp_queries.go
+++ b/neonvm/controllers/vm_qmp_queries.go
@@ -333,6 +333,65 @@ type QMPRunner interface {
 	Run([]byte) ([]byte, error)
 }
 
+// QmpSetVirtioMem updates virtio-mem to the new target size, returning the previous target.
+//
+// If the new target size is equal to the previous one, this function does nothing but query the
+// target.
+func QmpSetVirtioMem(vm *vmv1.VirtualMachine, targetVirtioMemSize int64) (previous int64, _ error) {
+	// Note: The virtio-mem device only exists when max mem != min mem.
+	// So if min == max, we should just short-cut, skip the queries, and say it's all good.
+	// Refer to the instantiation in neonvm-runner for more.
+	if vm.Spec.Guest.MemorySlots.Min == vm.Spec.Guest.MemorySlots.Max {
+		// if target size is non-zero even though min == max, something went very wrong
+		if targetVirtioMemSize != 0 {
+			panic(fmt.Sprintf(
+				"VM min mem slots == max mem slots, but target virtio-mem size %d != 0",
+				targetVirtioMemSize,
+			))
+		}
+		// Otherwise, we're all good, just pretend like we talked to the VM.
+		return 0, nil
+	}
+
+	mon, err := QmpConnect(QmpAddr(vm))
+	if err != nil {
+		return 0, err
+	}
+	defer mon.Disconnect() //nolint:errcheck // nothing to do with error when deferred. TODO: log it?
+
+	// First, fetch current desired virtio-mem size. If it's the same as targetVirtioMemSize, then
+	// we can report that it was already the same.
+	cmd := []byte(`{"execute": "qom-get", "arguments": {"path": "vm0", "property": "requested-size"}}`)
+	raw, err := mon.Run(cmd)
+	if err != nil {
+		return 0, err
+	}
+	result := struct {
+		Return int64 `json:"return"`
+	}{Return: 0}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return 0, fmt.Errorf("error unmarshaling json: %w", err)
+	}
+
+	previous = result.Return
+
+	if previous == targetVirtioMemSize {
+		return previous, nil
+	}
+
+	// The current requested size is not equal to the new desired size. Let's change that.
+	cmd = []byte(fmt.Sprintf(
+		`{"execute": "qom-set", "arguments": {"path": "vm0", "property": "requested-size", "value": %d}}`,
+		targetVirtioMemSize,
+	))
+	_, err = mon.Run(cmd)
+	if err != nil {
+		return 0, err
+	}
+
+	return previous, nil
+}
+
 // QmpAddMemoryBackend adds a single memory slot to the VM with the given size.
 //
 // The memory slot does nothing until a corresponding "device" is added to the VM for the same memory slot.

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -98,6 +98,7 @@ func main() {
 	var concurrencyLimit int
 	var enableContainerMgr bool
 	var qemuDiskCacheSettings string
+	var defaultMemoryProvider vmv1.MemoryProvider
 	var failurePendingPeriod time.Duration
 	var failingRefreshInterval time.Duration
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -108,11 +109,17 @@ func main() {
 	flag.IntVar(&concurrencyLimit, "concurrency-limit", 1, "Maximum number of concurrent reconcile operations")
 	flag.BoolVar(&enableContainerMgr, "enable-container-mgr", false, "Enable crictl-based container-mgr alongside each VM")
 	flag.StringVar(&qemuDiskCacheSettings, "qemu-disk-cache-settings", "cache=none", "Set neonvm-runner's QEMU disk cache settings")
+	flag.Func("default-memory-provider", "Set default memory provider to use for new VMs", defaultMemoryProvider.FlagFunc)
 	flag.DurationVar(&failurePendingPeriod, "failure-pending-period", 1*time.Minute,
 		"the period for the propagation of reconciliation failures to the observability instruments")
 	flag.DurationVar(&failingRefreshInterval, "failing-refresh-interval", 1*time.Minute,
 		"the interval between consecutive updates of metrics and logs, related to failing reconciliations")
 	flag.Parse()
+
+	if defaultMemoryProvider == "" {
+		fmt.Fprintln(os.Stderr, "missing required flag '-default-memory-provider'")
+		os.Exit(1)
+	}
 
 	logConfig := zap.NewProductionConfig()
 	logConfig.Sampling = nil // Disabling sampling; it's enabled by default for zap's production configs.
@@ -167,6 +174,7 @@ func main() {
 		UseContainerMgr:         enableContainerMgr,
 		MaxConcurrentReconciles: concurrencyLimit,
 		QEMUDiskCacheSettings:   qemuDiskCacheSettings,
+		DefaultMemoryProvider:   defaultMemoryProvider,
 		FailurePendingPeriod:    failurePendingPeriod,
 		FailingRefreshInterval:  failingRefreshInterval,
 	}

--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -596,9 +596,10 @@ type Config struct {
 	appendKernelCmdline  string
 	skipCgroupManagement bool
 	diskCacheSettings    string
+	memoryProvider       vmv1.MemoryProvider
 }
 
-func newConfig() *Config {
+func newConfig(logger *zap.Logger) *Config {
 	cfg := &Config{
 		vmSpecDump:           "",
 		vmStatusDump:         "",
@@ -606,6 +607,7 @@ func newConfig() *Config {
 		appendKernelCmdline:  "",
 		skipCgroupManagement: false,
 		diskCacheSettings:    "cache=none",
+		memoryProvider:       "", // Require that this is explicitly set. We'll check later.
 	}
 	flag.StringVar(&cfg.vmSpecDump, "vmspec", cfg.vmSpecDump,
 		"Base64 encoded VirtualMachine json specification")
@@ -620,7 +622,12 @@ func newConfig() *Config {
 		"Don't try to manage CPU (use if running alongside container-mgr)")
 	flag.StringVar(&cfg.diskCacheSettings, "qemu-disk-cache-settings",
 		cfg.diskCacheSettings, "Cache settings to add to -drive args for VM disks")
+	flag.Func("memory-provider", "Set provider for memory hotplug", cfg.memoryProvider.FlagFunc)
 	flag.Parse()
+
+	if cfg.memoryProvider == "" {
+		logger.Fatal("missing required flag '-memory-provider'")
+	}
 
 	return cfg
 }
@@ -634,7 +641,7 @@ func main() {
 }
 
 func run(logger *zap.Logger) error {
-	cfg := newConfig()
+	cfg := newConfig(logger)
 
 	vmSpecJson, err := base64.StdEncoding.DecodeString(cfg.vmSpecDump)
 	if err != nil {
@@ -849,12 +856,27 @@ func buildQEMUCmd(
 	))
 
 	// memory details
+	logger.Info(fmt.Sprintf("Using memory provider %s", cfg.memoryProvider))
 	qemuCmd = append(qemuCmd, "-m", fmt.Sprintf(
 		"size=%db,slots=%d,maxmem=%db",
 		vmSpec.Guest.MemorySlotSize.Value()*int64(vmSpec.Guest.MemorySlots.Min),
 		vmSpec.Guest.MemorySlots.Max-vmSpec.Guest.MemorySlots.Min,
 		vmSpec.Guest.MemorySlotSize.Value()*int64(vmSpec.Guest.MemorySlots.Max),
 	))
+	if cfg.memoryProvider == vmv1.MemoryProviderVirtioMem {
+		// we don't actually have any slots because it's virtio-mem, but we're still using the API
+		// designed around DIMM slots, so we need to use them to calculate how much memory we expect
+		// to be able to plug in.
+		numSlots := vmSpec.Guest.MemorySlots.Max - vmSpec.Guest.MemorySlots.Min
+		virtioMemSize := int64(numSlots) * vmSpec.Guest.MemorySlotSize.Value()
+		// We can add virtio-mem if it actually needs to be a non-zero size.
+		// Otherwise, QEMU fails with:
+		//   property 'size' of memory-backend-ram doesn't take value '0'
+		if virtioMemSize != 0 {
+			qemuCmd = append(qemuCmd, "-object", fmt.Sprintf("memory-backend-ram,id=vmem0,size=%db", virtioMemSize))
+			qemuCmd = append(qemuCmd, "-device", "virtio-mem-pci,id=vm0,memdev=vmem0,block-size=8M,requested-size=0")
+		}
+	}
 
 	// default (pod) net details
 	macDefault, err := defaultNetwork(logger, defaultNetworkCIDR, vmSpec.Guest.Ports)

--- a/neonvm/samples/vm-example.virtio-mem.yaml
+++ b/neonvm/samples/vm-example.virtio-mem.yaml
@@ -39,6 +39,7 @@ spec:
       min: 1
       max: 2
       use: 2
+    memoryProvider: VirtioMem
     rootDisk:
       image: vm-postgres:15-bullseye
       size: 8Gi

--- a/tests/e2e/autoscaling.virtio-mem/00-assert.yaml
+++ b/tests/e2e/autoscaling.virtio-mem/00-assert.yaml
@@ -14,4 +14,4 @@ status:
       status: "True"
   cpus: 250m
   memorySize: 1Gi
-  memoryProvider: DIMMSlots
+  memoryProvider: VirtioMem

--- a/tests/e2e/autoscaling.virtio-mem/00-create-vm.yaml
+++ b/tests/e2e/autoscaling.virtio-mem/00-create-vm.yaml
@@ -1,3 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+unitTest: false
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,37 +12,31 @@ spec:
     port: 5432
     protocol: TCP
     targetPort: postgres
-  - name: pooler
-    port: 6432
-    protocol: TCP
-    targetPort: postgres
-  - name: host-metrics
-    port: 9100
-    protocol: TCP
-    targetPort: host-metrics
-  - name: metrics
-    port: 9187
-    protocol: TCP
-    targetPort: metrics
+  type: NodePort
   selector:
     vm.neon.tech/name: example
-
 ---
 apiVersion: vm.neon.tech/v1
 kind: VirtualMachine
 metadata:
   name: example
+  labels:
+    autoscaling.neon.tech/enabled: "true"
+  annotations:
+    autoscaling.neon.tech/bounds: '{ "min": { "cpu": "250m", "mem": "1Gi" }, "max": {"cpu": 1, "mem": "4Gi" } }'
 spec:
+  schedulerName: autoscale-scheduler
   guest:
     cpus:
-      min: 1
-      max: 4
-      use: 2
+      min: 0.25
+      max: 1.25 # set value greater than bounds so our tests check we don't exceed the bounds.
+      use: 0.5
     memorySlotSize: 1Gi
     memorySlots:
       min: 1
-      max: 2
-      use: 2
+      max: 5
+      use: 1
+    memoryProvider: VirtioMem
     rootDisk:
       image: vm-postgres:15-bullseye
       size: 8Gi
@@ -52,12 +50,10 @@ spec:
     ports:
       - name: postgres
         port: 5432
-      - name: pooler
-        port: 5432
       - name: host-metrics
         port: 9100
-      - name: metrics
-        port: 9187
+      - name: monitor
+        port: 10301
   extraNetwork:
       enable: true
   disks:
@@ -72,13 +68,6 @@ spec:
         items:
           - key: postgresql.conf
             path: postgresql.conf
-    - name: vector-config
-      mountPath: /etc/vector
-      configMap:
-        name: example-config
-        items:
-          - key: vector.yaml
-            path: vector.yaml
     - name: cache
       mountPath: /neonvm/cache
       tmpfs:
@@ -95,7 +84,7 @@ data:
     shared_preload_libraries = 'pg_stat_statements'
 
     max_connections = 64
-    shared_buffers = 512MB
+    shared_buffers = 256MB
     effective_cache_size = 1536MB
     maintenance_work_mem = 128MB
     checkpoint_completion_target = 0.9
@@ -110,18 +99,3 @@ data:
     max_parallel_workers_per_gather = 2
     max_parallel_workers = 4
     max_parallel_maintenance_workers = 2
-
-  vector.yaml: |
-    sources:
-      postgresql_metrics:
-        type: postgresql_metrics
-        endpoints:
-          - "postgres://postgres@localhost:5432"
-        exclude_databases:
-          - "^template.*"
-    sinks:
-      postgres_exporter:
-        type: prometheus_exporter
-        inputs:
-          - postgresql_metrics
-        address: "0.0.0.0:9187"

--- a/tests/e2e/autoscaling.virtio-mem/01-assert.yaml
+++ b/tests/e2e/autoscaling.virtio-mem/01-assert.yaml
@@ -12,6 +12,13 @@ status:
   conditions:
     - type: Available
       status: "True"
-  cpus: 250m
-  memorySize: 1Gi
-  memoryProvider: DIMMSlots
+  cpus: 1
+  memorySize: 4Gi
+  memoryProvider: VirtioMem
+---
+apiVersion: v1
+kind: pod
+metadata:
+  name: workload
+status:
+  phase: Running

--- a/tests/e2e/autoscaling.virtio-mem/01-upscale.yaml
+++ b/tests/e2e/autoscaling.virtio-mem/01-upscale.yaml
@@ -1,0 +1,49 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+unitTest: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: workload
+spec:
+  terminationGracePeriodSeconds: 1
+  initContainers:
+  - name: wait-for-pg
+    image: postgres:15-bullseye
+    command:
+    - sh
+    - "-c"
+    - |
+      set -e
+      until pg_isready --username=postgres --dbname=postgres --host=example --port=5432; do
+        sleep 1
+      done
+  containers:
+  - name: pgbench
+    image: postgres:15-bullseye
+    volumeMounts:
+    - name: my-volume
+      mountPath: /etc/misc
+    command:
+    - pgbench
+    args:
+    - postgres://postgres@example:5432/postgres
+    - --client=20
+    - --progress=1
+    - --progress-timestamp
+    - --time=600
+    - --file=/etc/misc/query.sql
+  volumes:
+  - name: my-volume
+    configMap:
+      name: query
+  restartPolicy: Never
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: query
+data:
+  query.sql: |
+    select length(factorial(length(factorial(1223)::text)/2)::text);

--- a/tests/e2e/autoscaling.virtio-mem/02-assert.yaml
+++ b/tests/e2e/autoscaling.virtio-mem/02-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 90
+timeout: 300
 ---
 apiVersion: vm.neon.tech/v1
 kind: VirtualMachine
@@ -14,4 +14,3 @@ status:
       status: "True"
   cpus: 250m
   memorySize: 1Gi
-  memoryProvider: DIMMSlots

--- a/tests/e2e/autoscaling.virtio-mem/02-downscale.yaml
+++ b/tests/e2e/autoscaling.virtio-mem/02-downscale.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Pod
+  name: workload
+unitTest: false

--- a/tests/e2e/vm-migration.virtio-mem/00-assert.yaml
+++ b/tests/e2e/vm-migration.virtio-mem/00-assert.yaml
@@ -12,6 +12,11 @@ status:
   conditions:
     - type: Available
       status: "True"
-  cpus: 250m
-  memorySize: 1Gi
-  memoryProvider: DIMMSlots
+  memoryProvider: VirtioMem
+---
+apiVersion: v1
+kind: pod
+metadata:
+  name: workload
+status:
+  phase: Running

--- a/tests/e2e/vm-migration.virtio-mem/00-prepare.yaml
+++ b/tests/e2e/vm-migration.virtio-mem/00-prepare.yaml
@@ -1,0 +1,43 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- ../../../neonvm/samples/vm-example.virtio-mem.yaml
+unitTest: false
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: workload
+spec:
+  terminationGracePeriodSeconds: 1
+  initContainers:
+  - name: wait-for-pg
+    image: postgres:15-bullseye
+    command:
+    - sh
+    - "-c"
+    - |
+      set -e
+      until pg_isready --username=postgres --dbname=postgres --host=example --port=5432; do
+        sleep 1
+      done
+  - name: pgbench-initialize
+    image: postgres:15-bullseye
+    command:
+    - pgbench
+    args:
+    - postgres://postgres@example:5432/postgres
+    - --initialize
+    - --scale=10
+  containers:
+  - name: pgbench
+    image: postgres:15-bullseye
+    command:
+    - pgbench
+    args:
+    - postgres://postgres@example:5432/postgres
+    - --client=2
+    - --progress=1
+    - --progress-timestamp
+    - --time=600
+  restartPolicy: Never

--- a/tests/e2e/vm-migration.virtio-mem/01-assert.yaml
+++ b/tests/e2e/vm-migration.virtio-mem/01-assert.yaml
@@ -3,6 +3,13 @@ kind: TestAssert
 timeout: 90
 ---
 apiVersion: vm.neon.tech/v1
+kind: VirtualMachineMigration
+metadata:
+  name: example
+status:
+  phase: Succeeded
+---
+apiVersion: vm.neon.tech/v1
 kind: VirtualMachine
 metadata:
   name: example
@@ -12,6 +19,10 @@ status:
   conditions:
     - type: Available
       status: "True"
-  cpus: 250m
-  memorySize: 1Gi
-  memoryProvider: DIMMSlots
+---
+apiVersion: v1
+kind: pod
+metadata:
+  name: workload
+status:
+  phase: Running

--- a/tests/e2e/vm-migration.virtio-mem/01-migrate.yaml
+++ b/tests/e2e/vm-migration.virtio-mem/01-migrate.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+apply:
+- ../../../neonvm/samples/vm-example-migration.yaml
+unitTest: false

--- a/tests/e2e/vm-migration/00-assert.yaml
+++ b/tests/e2e/vm-migration/00-assert.yaml
@@ -12,6 +12,7 @@ status:
   conditions:
     - type: Available
       status: "True"
+  memoryProvider: DIMMSlots
 ---
 apiVersion: v1
 kind: pod


### PR DESCRIPTION
Adapted from #705.

This implementation is focused on making virtio-mem a drop-in replacement for our existing DIMM hotplug -based memory scaling.

As such, the externally visible differences are:

1. VirtualMachines have a new optional field: `.spec.guest.memoryProvider`
2. VirtualMachines have a new optional field: `.status.memoryProvider`
3. VirtualMachine `.status.memorySize` changes in smaller increments if using virtio-mem.

This change introduces the concept of a "memory provider", which is either "DIMMSlots" or "VirtioMem".

If a VM is created without setting the memory provider in the spec, the controller will use the default one, which is specified by its `--default-memory-provider` flag.
This will only persist for the lifetime of the runner pod. If the VM is restarted, then it may change to a new default.

Additionally, because our usage of virtio-mem has 8MiB block sizes, we actually *don't* default to virtio-mem if the VM was created with some odd memory slot size that isn't divisible by 8MiB.

The memory provider of the current runner pod is stored in the new status field. For old VMs created before this change, the status field is set to DIMMSlots iff the pod name is set without the status field.

Also, we allow mutating `.spec.guest.memoryProvider` IFF it is being set equal to the current `.status.memoryProvider`, in case we we want old VMs to keep their dimm slots after switching to virtio-mem by default.

---

Changes to split out from this PR:

1. #971
2. #973
3. #974

On top of those, there's a couple places where code was indented that should probably be split into its own commit so it can be properly added to .git-blame-ignore-revs :)

---

Remaining testing for this PR before merging:

- [x] Test that backwards compatibility works as expected
   - [x] Old VMs are updated while running as described above
   - [x] Old VMs switch to the new default on restart
- [x] Test rollback safety: that it's ok to go between the last release and this PR (with `--default-memory-provider=DIMMSlots`).
   - Note: If `--default-memory-provider=VirtioMem` when this is released, we cannot make it rollback-safe.
- [ ] ~~Test that updating `.spec.guest.memoryProvider` works as expected~~

---

Future/follow-up work:

1. #981
2. Switch to virtio-mem by default
3. Remove support for DIMM hotplug
4. Move from representing memory as "memory slots" towards the implementation
5. Fix the raciness issue with migration target pod creation.