### PR TITLE
Support ScaleRequest message, to allow vm-monitor to control autoscaling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,6 +148,8 @@ on each node, the scheduler can reject a scale up request to avoid having undesi
    memory slots. The permit will exactly equal the resources in the `AgentRequest`.
 4. The `autoscaler-agent` repeatedly fetches metrics from the VM. For each:
     1. Calculate the new desired resource allocation, as a multiple of compute units.
+       With the new ScaleRequest protocol message, the vm-monitor can specify it directly.
+       With older vm-monitor versions, the agent calculates it based on the VM metrics.
     2. If reaching the desired resource allocation requires scaling any resources _down_, submit a VM patch
        request that scales those resources down, but keeps the rest the same.
        * Note: this requires submitting a Kubernetes patch request. This goes through the NeonVM

--- a/pkg/agent/core/state.go
+++ b/pkg/agent/core/state.go
@@ -137,6 +137,9 @@ type pluginRequested struct {
 type monitorState struct {
 	OngoingRequest *ongoingMonitorRequest
 
+	// Last received desired VM size received from the vm-monitor.
+	RequestedScale *requestedScale
+
 	// RequestedUpscale, if not nil, stores the most recent *unresolved* upscaling requested by the
 	// vm-monitor, along with the time at which it occurred.
 	RequestedUpscale *requestedUpscale
@@ -172,6 +175,11 @@ const (
 	monitorRequestKindDownscale monitorRequestKind = "downscale"
 	monitorRequestKindUpscale   monitorRequestKind = "upscale"
 )
+
+type requestedScale struct {
+	At     time.Time
+	Target api.Allocation
+}
 
 type requestedUpscale struct {
 	At        time.Time
@@ -210,6 +218,7 @@ func NewState(vm api.VmInfo, config Config) *State {
 			},
 			Monitor: monitorState{
 				OngoingRequest:     nil,
+				RequestedScale:     nil,
 				RequestedUpscale:   nil,
 				DeniedDownscale:    nil,
 				Approved:           nil,
@@ -251,10 +260,25 @@ func (s *State) NextActions(now time.Time) ActionSet {
 func (s *state) nextActions(now time.Time) ActionSet {
 	var actions ActionSet
 
-	desiredResources, calcDesiredResourcesWait := s.desiredResourcesFromMetricsOrRequestedUpscaling(now)
-	if calcDesiredResourcesWait == nil {
-		// our handling later on is easier if we can assume it's non-nil
+	var desiredResources api.Resources
+	var calcDesiredResourcesWait func(ActionSet) *time.Duration
+
+	// If the VM directly requested a specific size, try to satisfy it. Otherwise, calculate
+	// the desired size from the metrics we collect from the VM.
+	//
+	// New vm-monitor versions specify the size directly, the calculation based on metrics
+	// is for old computes running with older vm-monitor versions. If we ever receive a direct
+	// size request from the VM, we assume that it's running a new version and "stick" to
+	// that mode for that VM thereafter.
+	if s.Monitor.RequestedScale != nil {
+		desiredResources = s.desiredResourcesFromRequestedScale(now, s.Monitor.RequestedScale)
 		calcDesiredResourcesWait = func(ActionSet) *time.Duration { return nil }
+	} else {
+		desiredResources, calcDesiredResourcesWait = s.desiredResourcesFromMetricsOrRequestedUpscaling(now)
+		if calcDesiredResourcesWait == nil {
+			// our handling later on is easier if we can assume it's non-nil
+			calcDesiredResourcesWait = func(ActionSet) *time.Duration { return nil }
+		}
 	}
 
 	// ----
@@ -642,6 +666,38 @@ func (s *State) DesiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (
 	return s.internal.desiredResourcesFromMetricsOrRequestedUpscaling(now)
 }
 
+func (s *state) desiredResourcesFromRequestedScale(now time.Time, request: Allocation) api.Resources {
+	// There's some annoying edge cases that this function has to be able to handle properly. For
+	// the sake of completeness, they are:
+	//
+	// 1. s.vm.Using() is not a multiple of s.computeUnit
+	// 2. s.vm.Max() is less than s.computeUnit (or: has at least one resource that is)
+	// 3. s.vm.Using() is a fractional multiple of s.computeUnit, but !allowDecrease and rounding up
+	//    is greater than s.vm.Max()
+	// 4. s.vm.Using() is much larger than s.vm.Min() and not a multiple of s.computeUnit, but load
+	//    is low so we should just decrease *anyways*.
+	//
+	// ---
+	//
+
+	// resources for the desired "goal" compute units
+	var goalResources api.Resources
+
+	cpuGoalCU := uint32(math.Round(request.Cpu / s.Config.ComputeUnit.VCPU.AsFloat64()))
+
+	memGoalBytes := api.Bytes(request.Mem)
+	memGoalCU := uint32(memGoalBytes / s.Config.ComputeUnit.Mem)
+
+	goalCU := util.Max(cpuGoalCU, memGoalCU)
+
+	// bound goalResources by the minimum and maximum resource amounts for the VM
+	result := goalResources.Min(s.VM.Max()).Max(s.VM.Min())
+
+	s.info("Using desired resources from VM", zap.Object("current", s.VM.Using()), zap.Object("target", result))
+
+	return result
+}
+
 func (s *state) desiredResourcesFromMetricsOrRequestedUpscaling(now time.Time) (api.Resources, func(ActionSet) *time.Duration) {
 	// There's some annoying edge cases that this function has to be able to handle properly. For
 	// the sake of completeness, they are:
@@ -1010,6 +1066,7 @@ func (s *State) Monitor() MonitorHandle {
 func (h MonitorHandle) Reset() {
 	h.s.Monitor = monitorState{
 		OngoingRequest:     nil,
+		RequestedScale:     nil,
 		RequestedUpscale:   nil,
 		DeniedDownscale:    nil,
 		Approved:           nil,
@@ -1024,6 +1081,13 @@ func (h MonitorHandle) Active(active bool) {
 		h.s.Monitor.Approved = &approved // TODO: this is racy
 	} else {
 		h.s.Monitor.Approved = nil
+	}
+}
+
+func (h MonitorHandle) ScaleRequested(now time.Time, resources api.Allocation) {
+	h.s.Monitor.RequestedScale = &requestedScale{
+		At:     now,
+		Target: resources,
 	}
 }
 

--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -84,6 +84,7 @@ func NewDispatcher(
 	logger *zap.Logger,
 	addr string,
 	runner *Runner,
+	sendScaleRequested func(request api.Allocation, withLock func()),
 	sendUpscaleRequested func(request api.MoreResources, withLock func()),
 ) (_finalDispatcher *Dispatcher, _ error) {
 	// Create a new root-level context for this Dispatcher so that we can cancel if need be
@@ -153,7 +154,7 @@ func NewDispatcher(
 
 	msgHandlerLogger := logger.Named("message-handler")
 	runner.spawnBackgroundWorker(ctx, msgHandlerLogger, "vm-monitor message handler", func(c context.Context, l *zap.Logger) {
-		disp.run(c, l, sendUpscaleRequested)
+		disp.run(c, l, sendScaleRequested, sendUpscaleRequested)
 	})
 	runner.spawnBackgroundWorker(ctx, logger.Named("health-checks"), "vm-monitor health checks", func(ctx context.Context, logger *zap.Logger) {
 		timeout := time.Second * time.Duration(runner.global.config.Monitor.ResponseTimeoutSeconds)
@@ -386,11 +387,14 @@ func extractField[T any](data map[string]interface{}, key string) (*T, error) {
 }
 
 type messageHandlerFuncs struct {
+	handleScaleRequest func(api.ScaleRequest)
+
 	handleUpscaleRequest      func(api.UpscaleRequest)
 	handleUpscaleConfirmation func(api.UpscaleConfirmation, uint64) error
 	handleDownscaleResult     func(api.DownscaleResult, uint64) error
-	handleMonitorError        func(api.InternalError, uint64) error
-	handleHealthCheck         func(api.HealthCheck, uint64) error
+
+	handleMonitorError func(api.InternalError, uint64) error
+	handleHealthCheck  func(api.HealthCheck, uint64) error
 }
 
 // Handle messages from the monitor. Make sure that all message types the monitor
@@ -488,6 +492,14 @@ func (disp *Dispatcher) HandleMessage(
 	}
 
 	switch *typeStr {
+	case "ScaleRequest":
+		var req api.ScaleRequest
+		if err := unmarshal(&req); err != nil {
+			return err
+		}
+		handlers.handleScaleRequest(req)
+		return nil
+
 	case "UpscaleRequest":
 		var req api.UpscaleRequest
 		if err := unmarshal(&req); err != nil {
@@ -507,6 +519,7 @@ func (disp *Dispatcher) HandleMessage(
 			return err
 		}
 		return handlers.handleDownscaleResult(res, id)
+
 	case "InternalError":
 		var monitorErr api.InternalError
 		if err := unmarshal(&monitorErr); err != nil {
@@ -538,7 +551,10 @@ func (disp *Dispatcher) HandleMessage(
 }
 
 // Long running function that orchestrates all requests/responses.
-func (disp *Dispatcher) run(ctx context.Context, logger *zap.Logger, upscaleRequester func(_ api.MoreResources, withLock func())) {
+func (disp *Dispatcher) run(ctx context.Context, logger *zap.Logger,
+	scaleRequester func(_ api.Allocation, withLock func()),
+	upscaleRequester func(_ api.MoreResources, withLock func()),
+) {
 	logger.Info("Starting message handler")
 
 	// Utility for logging + returning an error when we get a message with an
@@ -553,6 +569,17 @@ func (disp *Dispatcher) run(ctx context.Context, logger *zap.Logger, upscaleRequ
 	// Does not take a message id because we don't know when the agent will
 	// upscale. The monitor will get the result back as a NotifyUpscale message
 	// from us, with a new id.
+	handleScaleRequest := func(req api.ScaleRequest) {
+		// TODO: it shouldn't be this function's responsibility to update metrics.
+		defer func() {
+			disp.runner.global.metrics.monitorRequestsInbound.WithLabelValues("ScaleRequest", "ok").Inc()
+		}()
+
+		scaleRequester(req.Target, func() {
+			logger.Info("Updating requested scale", zap.Any("target", req))
+		})
+	}
+
 	handleUpscaleRequest := func(req api.UpscaleRequest) {
 		// TODO: it shouldn't be this function's responsibility to update metrics.
 		defer func() {
@@ -660,6 +687,7 @@ func (disp *Dispatcher) run(ctx context.Context, logger *zap.Logger, upscaleRequ
 	}
 
 	handlers := messageHandlerFuncs{
+		handleScaleRequest:        handleScaleRequest,
 		handleUpscaleRequest:      handleUpscaleRequest,
 		handleUpscaleConfirmation: handleUpscaleConfirmation,
 		handleDownscaleResult:     handleDownscaleResult,

--- a/pkg/agent/executor/core.go
+++ b/pkg/agent/executor/core.go
@@ -196,6 +196,15 @@ func (c ExecutorCoreUpdater) ResetMonitor(withLock func()) {
 	})
 }
 
+// ScaleRequested calls (*core.State).Monitor().ScaleRequested(...) on the inner core.State and
+// runs withLock while holding the lock.
+func (c ExecutorCoreUpdater) ScaleRequested(resources api.Allocation, withLock func()) {
+	c.core.update(func(state *core.State) {
+		state.Monitor().ScaleRequested(time.Now(), resources)
+		withLock()
+	})
+}
+
 // UpscaleRequested calls (*core.State).Monitor().UpscaleRequested(...) on the inner core.State and
 // runs withLock while holding the lock.
 func (c ExecutorCoreUpdater) UpscaleRequested(resources api.MoreResources, withLock func()) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -495,6 +495,19 @@ type Allocation struct {
 
 // ** Types sent by monitor **
 
+// This type is sent to the agent as a way to request downscale/upscale to
+// the given size. Since the agent cannot control if the agent will choose
+// to upscale the VM, it does not return anything. If the scale request
+// results in upscaling, the agent will send an UpscaleNotification when
+// the upscaling happens. If it results in downscaling, the agent will
+// request the downscaling with the DownscaleRequest message. (XXX: The extra
+// DownscaleRequest + DownscaleResult dance is a bit silly when the VM initiates
+// the scaling with a ScaleRequest message. It would make sense for the VM
+// to perform any downscale actions before sending the ScaleRequest.)
+type ScaleRequest struct {
+	Target Allocation `json:"target"`
+}
+
 // This type is sent to the agent as a way to request immediate upscale.
 // Since the agent cannot control if the agent will choose to upscale the VM,
 // it does not return anything. If an upscale is granted, the agent will notify

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -42,7 +42,7 @@ build: |
   RUN apk add musl-dev git openssl-dev
 
   # Which branch to pull from
-  ENV BRANCH main
+  ENV BRANCH heikki/wip-autoscale-api
 
   # Ensures we reclone upon new commits
   # https://stackoverflow.com/questions/35134713


### PR DESCRIPTION
The new protocol message allows the vm-monitor to directly specify the desired size of the VM. With that, the agent doesn't need the metrics anymore, it will just try to make the vm-monitor's wish true.

This is the autoscaler agent implementation of the RFC I proposed here: https://github.com/neondatabase/neon/pull/8111. In order to use the new API, see the corresponding VM monitor changes at: https://github.com/neondatabase/neon/tree/heikki/wip-autoscale-api