### PR TITLE
vm-builder: don't use ANSI terminal formatting in vector logs

### DIFF
--- a/neonvm/tools/vm-builder/files/inittab
+++ b/neonvm/tools/vm-builder/files/inittab
@@ -4,7 +4,7 @@
 ::respawn:/neonvm/bin/udevd
 ::wait:/neonvm/bin/udev-init.sh
 ::respawn:/neonvm/bin/acpid -f -c /neonvm/acpi
-::respawn:/neonvm/bin/vector -c /neonvm/config/vector.yaml --config-dir /etc/vector
+::respawn:/neonvm/bin/vector -c /neonvm/config/vector.yaml --config-dir /etc/vector --color never
 ::respawn:/neonvm/bin/chronyd -n -f /neonvm/config/chrony.conf -l /var/log/chrony/chrony.log
 ::respawn:/neonvm/bin/sshd -E /var/log/ssh.log -f /neonvm/config/sshd_config
 ::respawn:/neonvm/bin/vmstart


### PR DESCRIPTION
It is not possible for all of the log collectors to correctly strip them out.

```
vector --help | grep '\-\-color' -A 5
      --color <COLOR>
          Control when ANSI terminal formatting is used.

          By default `vector` will try and detect if `stdout` is a terminal, if it is ANSI will be enabled. Otherwise it will be disabled. By providing this flag with the `--color always` option will always enable
          ANSI terminal formatting. `--color never` will disable all ANSI terminal formatting. `--color auto` will attempt to detect it automatically.

          [env: VECTOR_COLOR=]
          [default: auto]
          [possible values: auto, always, never]
```