### PR TITLE
plugin: Fix Score reserving when over-budget

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -655,7 +655,7 @@ func (e *AutoscaleEnforcer) Score(
 	}
 
 	// Special case: return minimum score if we don't have room
-	overbudget, verdict := e.speculativeReserve(node, vmInfo, pod, false, func(_ verdictSet, overBudget bool) bool {
+	overbudget, verdict := e.speculativeReserve(node, vmInfo, pod, false, func(_ verdictSet, _ bool) bool {
 		return false // never actually accept the pod; we're just doing this to ask if it's over-budget.
 	})
 	if overbudget {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -656,7 +656,7 @@ func (e *AutoscaleEnforcer) Score(
 
 	// Special case: return minimum score if we don't have room
 	overbudget, verdict := e.speculativeReserve(node, vmInfo, pod, false, func(_ verdictSet, overBudget bool) bool {
-		return overBudget
+		return false // never actually accept the pod; we're just doing this to ask if it's over-budget.
 	})
 	if overbudget {
 		score := framework.MinNodeScore


### PR DESCRIPTION
For calls to `(*AutoscaleEnforcer).speculativeReserve()`, the callback given to it returns a boolean which should indicate whether to actually reserve the Pod.

When handling Score, we were returning true (which we should never do in Score) exactly when the placement would have been over-budget. This meant that pods would be recorded on an over-full node early in the scheduling flow, disagreeing with the core scheduler, which causes even more calls to Score that we'd think are over-budget, exacerbating the problem.

ref https://neondb.slack.com/archives/C0798QG4D0T/p1719016313787749?thread_ts=1719014348.041469