### PR TITLE
neonvm: Move runner image env var into YAML

### DIFF
--- a/neonvm/Dockerfile
+++ b/neonvm/Dockerfile
@@ -33,9 +33,6 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -tags
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 
-ARG VM_RUNNER_IMAGE=runner:dev
-ENV VM_RUNNER_IMAGE=${VM_RUNNER_IMAGE}
-
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/neonvm/config/controller/deployment.yaml
+++ b/neonvm/config/controller/deployment.yaml
@@ -64,6 +64,8 @@ spec:
         - "--failure-pending-period=1m"
         - "--failing-refresh-interval=15s"
         env:
+        - name: VM_RUNNER_IMAGE
+          value: $(VM_RUNNER_IMAGE) # will be replaced by kustomize
         - name: NAD_IPAM_NAME
           value: $(NAD_IPAM_NAME)
         - name: NAD_IPAM_NAMESPACE

--- a/neonvm/config/controller/deployment.yaml
+++ b/neonvm/config/controller/deployment.yaml
@@ -65,7 +65,7 @@ spec:
         - "--failing-refresh-interval=15s"
         env:
         - name: VM_RUNNER_IMAGE
-          value: $(VM_RUNNER_IMAGE) # will be replaced by kustomize
+          value: $(VM_RUNNER_IMAGE) # will be replaced by kustomize based on neonvm-runner-image-loader image
         - name: NAD_IPAM_NAME
           value: $(NAD_IPAM_NAME)
         - name: NAD_IPAM_NAMESPACE

--- a/neonvm/config/kustomization.yaml
+++ b/neonvm/config/kustomization.yaml
@@ -13,7 +13,6 @@ namePrefix: neonvm-
 #  someName: someValue
 
 bases:
-- namespace
 - crd
 - rbac
 - controller
@@ -24,12 +23,21 @@ bases:
 - vxlan-controller
 - network
 - device-plugin
+- ../runner-image-loader
 
 patchesStrategicMerge:
 - webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
+- name: VM_RUNNER_IMAGE # full name of the neonvm-runner image
+  objref:
+    kind: DaemonSet
+    name: runner-image-loader
+    group: apps
+    version: v1
+  fieldref:
+    fieldpath: spec.template.spec.containers.[name=neonvm-runner-loader].image
 - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
   objref:
     kind: Certificate

--- a/neonvm/runner-image-loader/daemonset.yaml
+++ b/neonvm/runner-image-loader/daemonset.yaml
@@ -16,6 +16,10 @@ spec:
         name: neonvm-runner-image-loader
     spec:
       containers:
+        # NOTE: this image is referenced by kustomize in order to set the value of the
+        # neonvm-controller's VM_RUNNER_IMAGE env var. We do it that way so that we can use
+        # 'kustomize edit image' to set the runner image, even if it does require some
+        # spooky action at a distance.
       - image: runner:dev
         name: neonvm-runner-loader
         command: ["sh", "-c", "echo 'image loaded and container started' && sleep 100d"]


### PR DESCRIPTION
For neondatabase/cloud#10177, we want to be able to override the neonvm-runner image that the controller uses *after* it's built and the YAML is generated.

To do this, we need to actually define the runner image in the YAML somwhere.

This PR:

1. Moves VM_RUNNER_IMAGE env var from the neonvm-controller dockerfile into its Pod spec.
2. Adds neonvm-runner-image-loader to neonvm.yaml (required for 1)

---

Tested compared to previous main the difference in the YAMLs when using v0.32.0 as the tag, and the diff to neonvm.yaml (aside from adding the image loader) was just the env var in the expected place.