### PR TITLE
Use cargo-chef for vm-monitor builds

### DIFF
--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -51,24 +51,40 @@ files:
 
 build: |
   # Build vm-monitor
-  FROM rust:1.79-alpine as monitor-builder
+  # We use cargo-chef to help with caching here, so that minor changes to neondatabase/neon don't
+  # require rebuilding heavy dependencies at least.
+  FROM lukemathwalker/cargo-chef:latest-rust-1.79.0-alpine AS chef
+  RUN apk add musl-dev git openssl-dev
   WORKDIR /workspace
 
-  RUN apk add musl-dev git openssl-dev
-
+  FROM chef AS neon-src
   # Which branch to pull from
   ENV BRANCH main
-
   # Ensures we reclone upon new commits
   # https://stackoverflow.com/questions/35134713
   ADD "https://api.github.com/repos/neondatabase/neon/commits/$BRANCH" latest_commit
+  # Clone, but remove rust-toolchain.toml so that we don't redo work if the versions are out of sync
+  RUN git clone --depth 1 --branch $BRANCH https://github.com/neondatabase/neon.git \
+    && rm -f rust-toolchain.toml
+  WORKDIR /workspace/neon
 
-  RUN git clone --depth 1 --branch $BRANCH https://github.com/neondatabase/neon.git
-  RUN cargo build --release --manifest-path neon/libs/vm_monitor/Cargo.toml
-  # Move binary so we can cargo clean
-  RUN mkdir -p /workspace/bin && cp /workspace/neon/target/release/vm-monitor /workspace/bin
-  # Cargo clean dramatically reduces the size of the image
-  RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+  FROM neon-src AS monitor-planner
+  RUN cargo chef prepare --bin vm-monitor --recipe-path ../recipe.json
+
+  FROM chef AS monitor-builder
+  COPY --from=monitor-planner /workspace/recipe.json /workspace/recipe.json
+  WORKDIR /workspace/neon
+  # THIS WILL BE CACHED: Build deps.
+  RUN cargo chef cook --release -p vm_monitor --recipe-path ../recipe.json && \
+    mv target ../target
+  # ... and *now* copy over the current source.
+  COPY --from=neon-src /workspace/neon .
+  # Build vm-monitor and 'cargo clean' so we don't explode the size of cached layers.
+  RUN mv ../target target \
+    && cargo build --release -p vm_monitor \
+    && mkdir -p /workspace/bin \
+    && cp /workspace/neon/target/release/vm-monitor /workspace/bin \
+    && cargo clean
 
   # Build cgroup-tools
   #

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -36,24 +36,49 @@ files:
     hostPath: cgconfig.conf
 build: |
   # Build vm-monitor
-  FROM rust:1.79-alpine as monitor-builder
+  # We use cargo-chef to help with caching here, so that minor changes to neondatabase/neon don't
+  # require rebuilding heavy dependencies at least.
+  FROM lukemathwalker/cargo-chef:latest-rust-1.79.0-alpine AS chef
+  RUN apk add musl-dev git openssl-dev
   WORKDIR /workspace
 
-  RUN apk add musl-dev git openssl-dev
-
+  FROM chef AS neon-src
   # Which branch to pull from
   ENV BRANCH main
-
   # Ensures we reclone upon new commits
   # https://stackoverflow.com/questions/35134713
   ADD "https://api.github.com/repos/neondatabase/neon/commits/$BRANCH" latest_commit
+  # Clone, but remove rust-toolchain.toml so that we don't redo work if the versions are out of sync
+  RUN git clone --depth 1 --branch $BRANCH https://github.com/neondatabase/neon.git \
+    && rm -f rust-toolchain.toml
+  WORKDIR /workspace/neon
 
-  RUN git clone --depth 1 --branch $BRANCH https://github.com/neondatabase/neon.git
-  RUN cargo build --release --manifest-path neon/libs/vm_monitor/Cargo.toml
-  # Move binary so we can cargo clean
-  RUN mkdir -p /workspace/bin && cp /workspace/neon/target/release/vm-monitor /workspace/bin
-  # Cargo clean dramatically reduces the size of the image
-  RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+  FROM neon-src AS monitor-planner
+  RUN cargo chef prepare --bin vm-monitor --recipe-path ../recipe.json
+
+  FROM chef AS monitor-builder
+  COPY --from=monitor-planner /workspace/recipe.json /workspace/recipe.json
+  WORKDIR /workspace/neon
+  # THIS WILL BE CACHED: Build deps.
+  # Note that we must use '-p vm_monitor' rather than '--bin vm-monitor' because for some reason
+  # using --bin requires more dependencies. In our case, it also includes the giant aws crates, so
+  # it's particularly worthwhile to make sure they aren't being compiled...
+  #
+  # This appears to be an issue with cargo itself, rather than cargo-chef, but I (@sharnoff)
+  # couldn't tell whether there was already a related issue open, and didn't feel like trying to
+  # reproduce it.
+  # Written 2024-06-23, rust 1.79.0.
+  RUN cargo chef cook --release -p vm_monitor --recipe-path ../recipe.json && \
+    mv target ../target
+  # ... and *now* copy over the current source. We need to do it after building deps, otherwise
+  # we'll be invalidating the cache for building dependencies.
+  COPY --from=neon-src /workspace/neon .
+  # Build vm-monitor and 'cargo clean' so we don't explode the size of cached layers.
+  RUN mv ../target target \
+    && cargo build --release -p vm_monitor \
+    && mkdir -p /workspace/bin \
+    && cp /workspace/neon/target/release/vm-monitor /workspace/bin \
+    && cargo clean
 
   # Build the allocation tester:
   FROM alpine:3.16 AS allocate-loop-builder


### PR DESCRIPTION
Before this PR, pg16-disk-test:
Clean build took 266s. Rebuilding from main+1 took 201s.

With this PR, pg16-disk-test:
Clean build took 303s. Rebuilding from main+1 took 101s.

(main+1 was jcsp/shard-split-logging; 75747cdbf -> 7f7f33f7e)

This is still quite a bit more time to rebuild than I'd like. The final step of building vm-monitor actually takes a surprisingly long time.

Also, there's this strange thing where the cargo chef image spends time installing clippy et al during prepare & cook (so, we actually end up doing it twice!). It doesn't take *too* long, but it's worth fixing that before merging, because there's no sense being wasteful.