### PR TITLE
go.mod: Remove unused cilium replace directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,6 @@ module github.com/neondatabase/autoscaling
 
 go 1.21
 
-// Replace directives from github.com/cilium/cilium. Keep in sync when updating Cilium!
-replace (
-	github.com/miekg/dns => github.com/cilium/dns v1.1.51-0.20220729113855-5b94b11b46fc
-	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b
-	go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7
-	sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.10.0
-)
-
 replace (
 	k8s.io/api => k8s.io/api v0.26.15
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.15


### PR DESCRIPTION
These were previously required because of versioning controller-tools in go.mod, but we removed that in #985, so these replaces aren't needed.

Came across this while rebasing #929