### PR TITLE
infra/build: explicitly specify linux OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	# `go vet` requires gcc
 	# ref https://github.com/golang/go/issues/56755
-	CGO_ENABLED=0 go vet ./...
+	GOOS=linux CGO_ENABLED=0 go vet ./...
 
 
 TESTARGS ?= ./...
@@ -115,13 +115,13 @@ test: fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: fmt vet bin/vm-builder ## Build all neonvm binaries.
-	go build -o bin/controller       neonvm/main.go
-	go build -o bin/vxlan-controller neonvm/tools/vxlan/controller/main.go
-	go build -o bin/runner           neonvm/runner/*.go
+	GOOS=linux go build -o bin/controller       neonvm/main.go
+	GOOS=linux go build -o bin/vxlan-controller neonvm/tools/vxlan/controller/main.go
+	GOOS=linux go build -o bin/runner           neonvm/runner/*.go
 
 .PHONY: bin/vm-builder
 bin/vm-builder: ## Build vm-builder binary.
-	CGO_ENABLED=0 go build -o bin/vm-builder -ldflags "-X main.Version=${GIT_INFO}" neonvm/tools/vm-builder/main.go
+	GOOS=linux CGO_ENABLED=0 go build -o bin/vm-builder -ldflags "-X main.Version=${GIT_INFO}" neonvm/tools/vm-builder/main.go
 
 .PHONY: run
 run: fmt vet ## Run a controller from your host.
@@ -129,7 +129,7 @@ run: fmt vet ## Run a controller from your host.
 
 .PHONY: lint
 lint: ## Run golangci-lint against code.
-	golangci-lint run
+	GOOS=linux golangci-lint run
 
 # If you wish built the controller image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.

--- a/neonvm/tools/vxlan/controller/main.go
+++ b/neonvm/tools/vxlan/controller/main.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package main
 
 import (


### PR DESCRIPTION
in reponse to https://github.com/neondatabase/autoscaling/pull/994#discussion_r1654771673 this explicitly specifies `GOOS=linux` and `//go:build linux` in places where I had IDE/golang complain on unsupported architecture.

https://github.com/neondatabase/cloud/issues/14786
