### PR TITLE
Silence "Unknown parameter 'mode'" messages at neonvm startup

### DIFF
--- a/neonvm/runner/main.go
+++ b/neonvm/runner/main.go
@@ -258,7 +258,7 @@ func createISO9660runtime(
 	}
 	if enableSSH {
 		mounts = append(mounts, "/neonvm/bin/mkdir -p /mnt/ssh")
-		mounts = append(mounts, "/neonvm/bin/mount -o ro,mode=0644 $(/neonvm/bin/blkid -L ssh-authorized-keys) /mnt/ssh")
+		mounts = append(mounts, "/neonvm/bin/mount  -t iso9660 -o ro,mode=0644 $(/neonvm/bin/blkid -L ssh-authorized-keys) /mnt/ssh")
 	}
 
 	if swapInfo != nil && (swapInfo.SkipSwapon == nil || !*swapInfo.SkipSwapon) {
@@ -281,7 +281,7 @@ func createISO9660runtime(
 				// Note: chmod must be after mount, otherwise it gets overwritten by mount.
 				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/chmod 0777 %s`, disk.MountPath))
 			case disk.ConfigMap != nil || disk.Secret != nil:
-				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/mount -o ro,mode=0644 $(/neonvm/bin/blkid -L %s) %s`, disk.Name, disk.MountPath))
+				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/mount -t iso9660 -o ro,mode=0644 $(/neonvm/bin/blkid -L %s) %s`, disk.Name, disk.MountPath))
 			case disk.Tmpfs != nil:
 				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/chmod 0777 %s`, disk.MountPath))
 				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/mount -t tmpfs -o size=%d %s %s`, disk.Tmpfs.Size.Value(), disk.Name, disk.MountPath))

--- a/neonvm/tools/vm-builder/files/vminit
+++ b/neonvm/tools/vm-builder/files/vminit
@@ -40,7 +40,7 @@ mount -t devpts -o noexec,nosuid       devpts    /dev/pts
 mount -t tmpfs  -o noexec,nosuid,nodev shm-tmpfs /dev/shm
 
 # neonvm runtime params mounted as iso9660 disk
-mount -o ro,mode=0644 /dev/vdb /neonvm/runtime
+mount -t iso9660 -o ro,mode=0644 /dev/vdb /neonvm/runtime
 
 # mount virtual machine .spec.disks
 test -f /neonvm/runtime/mounts.sh && /neonvm/bin/sh /neonvm/runtime/mounts.sh


### PR DESCRIPTION
The kernel prints a few lines like these to the kernel log at startup:

    [    0.886717] ext3: Unknown parameter 'mode'
    [    0.887279] ext2: Unknown parameter 'mode'
    [    0.887595] ext4: Unknown parameter 'mode'
    [    0.887906] squashfs: Unknown parameter 'mode'

It's because the runtime, ssh-authorized-keys image and any ConfigMaps or Secrets are iso9660 images, mounted with commands like this:

    /neonvm/bin/mount -o ro,mode=0644 $(/neonvm/bin/blkid -L ssh-authorized-keys) /mnt/ssh

Because we don't specify the filesystem type, the command tries different filesystems until it finds one that recognizes it. You get the errors, because "mode" option is not supported by those other filesystems that the command tries first.

The messages are harmless, but add noise to the logs. To silence them, specify the "iso9660" filesystem explicitly in the mount command.