### PR TITLE
neonvm-controller: patch status if reconcile fails (#889)

### DIFF
--- a/neonvm/controllers/vm_controller.go
+++ b/neonvm/controllers/vm_controller.go
@@ -171,19 +171,40 @@ func (r *VMReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	if err := r.doReconcile(ctx, &vm); err != nil {
 		r.Recorder.Eventf(&vm, corev1.EventTypeWarning, "Failed",
 			"Failed to reconcile (%s): %s", vm.Name, err)
+		if !DeepEqual(statusBefore, vm.Status) {
+			if err := r.patchStatus(ctx, req.NamespacedName, vm.Status); err != nil {
+				log.Error(err, "Unable to update status for VirtualMachine", "virtualmachine", vm.Name)
+			}
+		}
 		return ctrl.Result{}, err
 	}
 
-	// If the status changed, try to update the object
+	// If the status changed, try to patch the object
 	if !DeepEqual(statusBefore, vm.Status) {
-		if err := r.Status().Update(ctx, &vm); err != nil {
-			log.Error(err, "Failed to update VirtualMachine status after reconcile loop",
-				"virtualmachine", vm.Name)
+		if err := r.patchStatus(ctx, req.NamespacedName, vm.Status); err != nil {
+			log.Error(err, "Unable to update status for VirtualMachine", "virtualmachine", vm.Name)
 			return ctrl.Result{}, err
 		}
 	}
 
 	return ctrl.Result{RequeueAfter: time.Second}, nil
+}
+
+// patchStatus create a patch for VirtualMachine and send a Patch request with a new status
+func (r *VMReconciler) patchStatus(ctx context.Context, name types.NamespacedName, newStatus vmv1.VirtualMachineStatus) error {
+	log := log.FromContext(ctx)
+
+	var vm vmv1.VirtualMachine
+	if err := r.Get(ctx, name, &vm); err != nil {
+		log.Error(err, "Unable to fetch VirtualMachine")
+		return err
+	}
+
+	patch := client.MergeFrom(vm.DeepCopy())
+	vm.Status = newStatus
+
+	return r.Status().Patch(ctx, &vm, patch)
+
 }
 
 // doFinalizerOperationsForVirtualMachine will perform the required operations before delete the CR.


### PR DESCRIPTION
Added status update on fail. There is a way to just run it in a defer, but it's only 2 places so I guess it's more straightforward solution.

Also changed Update to Patch, added request of virtualmachine before to avoid conflicts.

And a last one - removed requeue after succesful reconcile, it's not required to reconcile if nothing happens, reconcile will be queued if there will be a change in a VirtualMachine or Pod with VirtualMachine owner. If there is another reason to keep it in a constant loop - please tell, will update it. Otherwise it'll save some CPU cycles and make logs more readable.

Tested it manually on a virtualmachine inside GCP, if there is a way to run autoscaling on Silicon Apple, I'd be happy to know (x86-64 emulation in QEMU is too slow, took hours to build everything).