### PR TITLE
Update alpine base images: 3.16 → 3.17

### DIFF
--- a/neonvm/runner/Dockerfile
+++ b/neonvm/runner/Dockerfile
@@ -27,7 +27,7 @@ COPY pkg/util pkg/util
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /runner neonvm/runner/main.go
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /container-mgr neonvm/runner/container-mgr/*.go
 
-FROM alpine:3.16 as crictl
+FROM alpine:3.17 as crictl
 
 RUN apk add --no-cache \
     curl
@@ -38,7 +38,7 @@ ENV VERSION="v1.27.1"
 RUN curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz" -o crictl.tar.gz \
 	&& tar zxvf crictl.tar.gz -C /
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 RUN apk add --no-cache \
     tini \

--- a/neonvm/samples/vm-example/Dockerfile
+++ b/neonvm/samples/vm-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16 AS rootdisk
+FROM alpine:3.17 AS rootdisk
 
 RUN set -e \
 	&& apk add --no-cache \
@@ -35,7 +35,7 @@ ADD postgresql.conf /etc/postgresql/
 ADD pg_hba.conf     /etc/postgresql/
 
 
-FROM alpine:3.16 AS image
+FROM alpine:3.17 AS image
 
 ARG DISK_SIZE=2G
 
@@ -47,6 +47,6 @@ RUN set -e \
     && rm -f /disk.raw \
     && qemu-img info /disk.qcow2
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 COPY --from=image /disk.qcow2 /

--- a/neonvm/tools/vm-builder/files/Dockerfile.img
+++ b/neonvm/tools/vm-builder/files/Dockerfile.img
@@ -7,7 +7,7 @@ FROM {{.RootDiskImage}} AS rootdisk
 USER root
 {{.SpecMerge}}
 
-FROM alpine:3.16 AS vm-runtime
+FROM alpine:3.17 AS vm-runtime
 # add busybox
 ENV BUSYBOX_VERSION 1.35.0
 RUN set -e \
@@ -107,6 +107,6 @@ RUN set -e \
     && mkfs.ext4 -L vmroot -d /rootdisk /disk.raw ${DISK_SIZE} \
     && qemu-img convert -f raw -O qcow2 -o cluster_size=2M,lazy_refcounts=on /disk.raw /disk.qcow2
 
-FROM alpine:3.16
+FROM alpine:3.17
 RUN apk add --no-cache --no-progress --quiet qemu-img
 COPY --from=builder /disk.qcow2 /

--- a/neonvm/tools/vm-builder/files/Dockerfile.img
+++ b/neonvm/tools/vm-builder/files/Dockerfile.img
@@ -16,6 +16,8 @@ RUN set -e \
 	&& chmod +x /neonvm/bin/busybox \
 	&& /neonvm/bin/busybox --install -s /neonvm/bin
 
+COPY helper.move-bins.sh /helper.move-bins.sh
+
 # add udevd and agetty (with shared libs)
 RUN set -e \
 	&& apk add --no-cache --no-progress --quiet \
@@ -26,27 +28,16 @@ RUN set -e \
 		e2fsprogs-extra \
 		blkid \
 		flock \
-	&& mv /sbin/acpid         /neonvm/bin/ \
-	&& mv /sbin/udevd         /neonvm/bin/ \
-	&& mv /bin/udevadm        /neonvm/bin/ \
-	&& mv /sbin/agetty        /neonvm/bin/ \
-	&& mv /sbin/su-exec       /neonvm/bin/ \
-	&& mv /usr/sbin/resize2fs /neonvm/bin/resize2fs \
-	&& mv /sbin/blkid         /neonvm/bin/blkid \
-	&& mv /usr/bin/flock	  /neonvm/bin/flock \
 	&& mkdir -p /neonvm/lib \
-	&& cp -f /lib/ld-musl-x86_64.so.1  /neonvm/lib/ \
-	&& cp -f /lib/libblkid.so.1.1.0    /neonvm/lib/libblkid.so.1 \
-	&& cp -f /lib/libcrypto.so.1.1     /neonvm/lib/ \
-	&& cp -f /lib/libkmod.so.2.3.7     /neonvm/lib/libkmod.so.2 \
-	&& cp -f /lib/libudev.so.1.6.3     /neonvm/lib/libudev.so.1 \
-	&& cp -f /lib/libz.so.1.2.12       /neonvm/lib/libz.so.1 \
-	&& cp -f /usr/lib/liblzma.so.5.2.5 /neonvm/lib/liblzma.so.5 \
-	&& cp -f /usr/lib/libzstd.so.1.5.2 /neonvm/lib/libzstd.so.1 \
-	&& cp -f /lib/libe2p.so.2          /neonvm/lib/libe2p.so.2 \
-	&& cp -f /lib/libext2fs.so.2       /neonvm/lib/libext2fs.so.2 \
-	&& cp -f /lib/libcom_err.so.2      /neonvm/lib/libcom_err.so.2 \
-	&& cp -f /lib/libblkid.so.1        /neonvm/lib/libblkid.so.1 \
+	&& /helper.move-bins.sh \
+		acpid \
+		udevd \
+		udevadm \
+		agetty \
+		su-exec \
+		resize2fs \
+		blkid \
+		flock \
 	&& mv /usr/share/udhcpc/default.script /neonvm/bin/udhcpc.script \
 	&& sed -i 's/#!\/bin\/sh/#!\/neonvm\/bin\/sh/' /neonvm/bin/udhcpc.script \
 	&& sed -i 's/export PATH=.*/export PATH=\/neonvm\/bin/' /neonvm/bin/udhcpc.script
@@ -66,26 +57,13 @@ RUN set -e \
 RUN set -e \
        && apk add --no-cache --no-progress --quiet \
                chrony \
-       && mv /usr/sbin/chronyd /neonvm/bin/ \
-       && mv /usr/bin/chronyc  /neonvm/bin/ \
-       && cp -f /lib/libc.musl-x86_64.so.1 /neonvm/lib/ \
-       && cp -f /lib/libz.so.1 /neonvm/lib/ \
-       && cp -f /usr/lib/libcap.so.2 /neonvm/lib/ \
-       && cp -f /usr/lib/libffi.so.8 /neonvm/lib/ \
-       && cp -f /usr/lib/libgmp.so.10 /neonvm/lib/ \
-       && cp -f /usr/lib/libgnutls.so.30 /neonvm/lib/ \
-       && cp -f /usr/lib/libhogweed.so.6 /neonvm/lib/ \
-       && cp -f /usr/lib/libnettle.so.8 /neonvm/lib/ \
-       && cp -f /usr/lib/libp11-kit.so.0 /neonvm/lib/ \
-       && cp -f /usr/lib/libtasn1.so.6 /neonvm/lib/ \
-       && cp -f /usr/lib/libunistring.so.2 /neonvm/lib/
+       && /helper.move-bins.sh chronyd chronyc
 
 # ssh server
 RUN set -e \
 	&& apk add --no-cache --no-progress --quiet \
 		openssh-server \
-	&& mv /usr/bin/ssh-keygen /neonvm/bin/ \
-	&& mv /usr/sbin/sshd      /neonvm/bin/
+	&& /helper.move-bins.sh sshd ssh-keygen
 
 # init scripts & configs
 COPY inittab     /neonvm/bin/inittab

--- a/neonvm/tools/vm-builder/files/helper.move-bins.sh
+++ b/neonvm/tools/vm-builder/files/helper.move-bins.sh
@@ -1,0 +1,12 @@
+#!/neonvm/bin/sh
+#
+# Helper script to move binaries into /neonvm/bin and copy the dynamically loaded libraries they
+# depend upon into /neonvm/lib.
+
+set -eux -o pipefail
+
+for name in "$@"; do
+    path="$(which "$name")"
+    cp "$path" /neonvm/bin/
+    cp -f $(ldd "$path" | grep '=>' | grep -oE '[^ ]*/lib[^ ]+') /neonvm/lib/
+done

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// vm-builder --src alpine:3.16 --dst vm-alpine:dev --file vm-alpine.qcow2
+// vm-builder --src alpine:3.17 --dst vm-alpine:dev --file vm-alpine.qcow2
 
 var (
 	//go:embed files/Dockerfile.img
@@ -56,8 +56,8 @@ var (
 var (
 	Version string
 
-	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.16`)
-	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.16`)
+	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.17`)
+	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.17`)
 	size      = flag.String("size", "1G", `Size for disk image: --size=1G`)
 	outFile   = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
 	specFile  = flag.String("spec", "", `File containing additional customization: --spec=spec.yaml`)

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -29,6 +29,8 @@ import (
 var (
 	//go:embed files/Dockerfile.img
 	dockerfileVmBuilder string
+	//go:embed files/helper.move-bins.sh
+	scriptMoveBinsHelper string
 	//go:embed files/vmstart
 	scriptVmStart string
 	//go:embed files/inittab
@@ -272,6 +274,7 @@ func main() {
 		tmpl     string
 	}{
 		{"Dockerfile", dockerfileVmBuilder},
+		{"helper.move-bins.sh", scriptMoveBinsHelper},
 		{"vmstart", scriptVmStart},
 		{"vmshutdown", scriptVmShutdown},
 		{"inittab", scriptInitTab},

--- a/neonvm/tools/vxlan/Dockerfile
+++ b/neonvm/tools/vxlan/Dockerfile
@@ -21,7 +21,7 @@ COPY neonvm/tools/vxlan/controller/ neonvm/tools/vxlan/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /vxlan-controller neonvm/tools/vxlan/controller/main.go
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 RUN apk add --no-cache \
     tini \

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -56,7 +56,7 @@ build: |
   RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
 
   # Build the allocation tester:
-  FROM alpine:3.16 AS allocate-loop-builder
+  FROM alpine:3.17 AS allocate-loop-builder
   RUN set -e \
       && apk add gcc musl-dev
   COPY allocate-loop.c allocate-loop.c


### PR DESCRIPTION
Part of #900; extracted from #1008.

This PR:

1. Replaces the shared library copying in vm-builder with a script to handle that for us, using the output from `ldd`
2. Bumps the alpine versions everywhere to 3.17

The two parts are in two separate commits. It probably makes sense to merge them via rebase-and-merge.

Notably, the bump to 3.17 includes bumping QEMU from 7.0.0 to 7.1.0.