### PR TITLE
agent: Reduce logging

### DIFF
--- a/deploy/agent/config_map.yaml
+++ b/deploy/agent/config_map.yaml
@@ -53,7 +53,7 @@ data:
       "scheduler": {
         "schedulerName": "autoscale-scheduler",
         "requestTimeoutSeconds": 2,
-        "requestAtLeastEverySeconds": 5,
+        "requestAtLeastEverySeconds": 15,
         "retryFailedRequestSeconds": 3,
         "retryDeniedUpscaleSeconds": 2,
         "requestPort": 10299,

--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -4,7 +4,6 @@ package agent
 // connection through a simple RPC-style protocol.
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -323,12 +322,7 @@ func (disp *Dispatcher) send(ctx context.Context, logger *zap.Logger, id uint64,
 	// by base64 encoding it, so use RawMessage to avoid serializing to []byte
 	// (done by SerializeMonitorMessage), and then base64 encoding again
 	raw := json.RawMessage(data)
-	if bytes.HasPrefix(data, []byte("{\"content\":{},\"type\":\"HealthCheck\",\"id\":")) {
-		// don't log health checks, they're too frequent
-		logger.Debug("sending message to monitor", zap.ByteString("message", raw))
-	} else {
-		logger.Info("sending message to monitor", zap.ByteString("message", raw))
-	}
+	logger.Debug("sending message to monitor", zap.ByteString("message", raw))
 	return wsjson.Write(ctx, disp.conn, &raw)
 }
 
@@ -440,12 +434,7 @@ func (disp *Dispatcher) HandleMessage(
 		return fmt.Errorf("Error receiving message: %w", err)
 	}
 
-	if bytes.HasPrefix(message, []byte("{\"type\":\"HealthCheck\",\"id\":")) {
-		// don't log health checks, they're too frequent
-		logger.Debug("(pre-decoding): received a message", zap.ByteString("message", message))
-	} else {
-		logger.Info("(pre-decoding): received a message", zap.ByteString("message", message))
-	}
+	logger.Debug("(pre-decoding): received a message", zap.ByteString("message", message))
 
 	var unstructured map[string]interface{}
 	if err := json.Unmarshal(message, &unstructured); err != nil {

--- a/pkg/agent/executor/exec_plugin.go
+++ b/pkg/agent/executor/exec_plugin.go
@@ -39,7 +39,7 @@ func (c *ExecutorCoreWithClients) DoPluginRequests(ctx context.Context, logger *
 		action := *last.actions.PluginRequest
 
 		if updated := c.updateIfActionsUnchanged(last, func(state *core.State) {
-			logger.Debug("Starting plugin request", zap.Object("action", action))
+			logger.Info("Starting plugin request", zap.Object("action", action))
 			startTime = time.Now()
 			state.Plugin().StartingRequest(startTime, action.Target)
 		}); !updated {

--- a/pkg/agent/executor/exec_plugin.go
+++ b/pkg/agent/executor/exec_plugin.go
@@ -39,7 +39,7 @@ func (c *ExecutorCoreWithClients) DoPluginRequests(ctx context.Context, logger *
 		action := *last.actions.PluginRequest
 
 		if updated := c.updateIfActionsUnchanged(last, func(state *core.State) {
-			logger.Info("Starting plugin request", zap.Object("action", action))
+			logger.Debug("Starting plugin request", zap.Object("action", action))
 			startTime = time.Now()
 			state.Plugin().StartingRequest(startTime, action.Target)
 		}); !updated {

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -812,7 +812,6 @@ func (r *Runner) DoSchedulerRequest(
 		return nil, fmt.Errorf("Bad JSON response: %w", err)
 	}
 
-	// there will be "Plugin request successful" INFO log right after
 	logger.Debug("Received response from scheduler", zap.Any("response", respData))
 
 	return &respData, nil

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -778,12 +778,7 @@ func (r *Runner) DoSchedulerRequest(
 	}
 	request.Header.Set("content-type", "application/json")
 
-	if reqData.LastPermit != nil && *reqData.LastPermit == reqData.Resources {
-		// If the last permit is the same as the current request, we can skip request logging.
-		logger.Debug("Sending request to scheduler", zap.Any("request", reqData))
-	} else {
-		logger.Info("Sending request to scheduler", zap.Any("request", reqData))
-	}
+	logger.Debug("Sending request to scheduler", zap.Any("request", reqData))
 
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -604,7 +604,7 @@ func doMetricsRequest(
 		panic(fmt.Errorf("Error constructing metrics request to %q: %w", url, err))
 	}
 
-	logger.Info("Making metrics request to VM", zap.String("url", url))
+	logger.Debug("Making metrics request to VM", zap.String("url", url))
 
 	resp, err := http.DefaultClient.Do(req)
 	if ctx.Err() != nil {

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -778,7 +778,12 @@ func (r *Runner) DoSchedulerRequest(
 	}
 	request.Header.Set("content-type", "application/json")
 
-	logger.Info("Sending request to scheduler", zap.Any("request", reqData))
+	if reqData.LastPermit != nil && *reqData.LastPermit == reqData.Resources {
+		// If the last permit is the same as the current request, we can skip request logging.
+		logger.Debug("Sending request to scheduler", zap.Any("request", reqData))
+	} else {
+		logger.Info("Sending request to scheduler", zap.Any("request", reqData))
+	}
 
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
@@ -807,7 +812,8 @@ func (r *Runner) DoSchedulerRequest(
 		return nil, fmt.Errorf("Bad JSON response: %w", err)
 	}
 
-	logger.Info("Received response from scheduler", zap.Any("response", respData))
+	// there will be "Plugin request successful" INFO log right after
+	logger.Debug("Received response from scheduler", zap.Any("response", respData))
 
 	return &respData, nil
 }


### PR DESCRIPTION
Try to reduce some very common logs:
- Change interval for recurring scheduler requests (5s -> 15s)
- Log 1-2 log entries instead of 4 for each scheduler request
- Log successful healthchecks only once per 10 requests
- Do not log "Making metrics request to VM", same info as in "Updated metrics"

ref https://github.com/neondatabase/cloud/issues/15591
ref https://github.com/neondatabase/cloud/issues/15605