### PR TITLE
neonvm/hack/generate.sh: Replace tabs with 4 spaces

### DIFF
--- a/neonvm/hack/generate.sh
+++ b/neonvm/hack/generate.sh
@@ -13,6 +13,6 @@ bash $GOPATH/src/k8s.io/code-generator/generate-groups.sh "deepcopy,client,infor
 controller-gen object:headerFile="neonvm/hack/boilerplate.go.txt" paths="./neonvm/apis/..."
 
 controller-gen rbac:roleName=manager-role crd webhook paths="./neonvm/..." \
-	output:crd:artifacts:config=neonvm/config/crd/bases \
-	output:rbac:artifacts:config=neonvm/config/rbac \
-	output:webhook:artifacts:config=neonvm/config/webhook
+    output:crd:artifacts:config=neonvm/config/crd/bases \
+    output:rbac:artifacts:config=neonvm/config/rbac \
+    output:webhook:artifacts:config=neonvm/config/webhook


### PR DESCRIPTION
The rest of the file uses spaces - didn't notice the change in #919.

Extracted out from #905.