### PR TITLE
Update alpine base images: 3.17 → 3.18

### DIFF
--- a/neonvm/runner/Dockerfile
+++ b/neonvm/runner/Dockerfile
@@ -27,7 +27,7 @@ COPY pkg/util pkg/util
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /runner neonvm/runner/main.go
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /container-mgr neonvm/runner/container-mgr/*.go
 
-FROM alpine:3.17 as crictl
+FROM alpine:3.18 as crictl
 
 RUN apk add --no-cache \
     curl
@@ -38,7 +38,7 @@ ENV VERSION="v1.27.1"
 RUN curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz" -o crictl.tar.gz \
 	&& tar zxvf crictl.tar.gz -C /
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 RUN apk add --no-cache \
     tini \

--- a/neonvm/samples/vm-example/Dockerfile
+++ b/neonvm/samples/vm-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17 AS rootdisk
+FROM alpine:3.18 AS rootdisk
 
 RUN set -e \
 	&& apk add --no-cache \
@@ -35,7 +35,7 @@ ADD postgresql.conf /etc/postgresql/
 ADD pg_hba.conf     /etc/postgresql/
 
 
-FROM alpine:3.17 AS image
+FROM alpine:3.18 AS image
 
 ARG DISK_SIZE=2G
 
@@ -47,6 +47,6 @@ RUN set -e \
     && rm -f /disk.raw \
     && qemu-img info /disk.qcow2
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 COPY --from=image /disk.qcow2 /

--- a/neonvm/tools/vm-builder/files/Dockerfile.img
+++ b/neonvm/tools/vm-builder/files/Dockerfile.img
@@ -7,7 +7,7 @@ FROM {{.RootDiskImage}} AS rootdisk
 USER root
 {{.SpecMerge}}
 
-FROM alpine:3.17 AS vm-runtime
+FROM alpine:3.18 AS vm-runtime
 # add busybox
 ENV BUSYBOX_VERSION 1.35.0
 RUN set -e \
@@ -107,6 +107,6 @@ RUN set -e \
     && mkfs.ext4 -L vmroot -d /rootdisk /disk.raw ${DISK_SIZE} \
     && qemu-img convert -f raw -O qcow2 -o cluster_size=2M,lazy_refcounts=on /disk.raw /disk.qcow2
 
-FROM alpine:3.17
+FROM alpine:3.18
 RUN apk add --no-cache --no-progress --quiet qemu-img
 COPY --from=builder /disk.qcow2 /

--- a/neonvm/tools/vm-builder/main.go
+++ b/neonvm/tools/vm-builder/main.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// vm-builder --src alpine:3.17 --dst vm-alpine:dev --file vm-alpine.qcow2
+// vm-builder --src alpine:3.18 --dst vm-alpine:dev --file vm-alpine.qcow2
 
 var (
 	//go:embed files/Dockerfile.img
@@ -56,8 +56,8 @@ var (
 var (
 	Version string
 
-	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.17`)
-	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.17`)
+	srcImage  = flag.String("src", "", `Docker image used as source for virtual machine disk image: --src=alpine:3.18`)
+	dstImage  = flag.String("dst", "", `Docker image with resulting disk image: --dst=vm-alpine:3.18`)
 	size      = flag.String("size", "1G", `Size for disk image: --size=1G`)
 	outFile   = flag.String("file", "", `Save disk image as file: --file=vm-alpine.qcow2`)
 	specFile  = flag.String("spec", "", `File containing additional customization: --spec=spec.yaml`)

--- a/neonvm/tools/vxlan/Dockerfile
+++ b/neonvm/tools/vxlan/Dockerfile
@@ -21,7 +21,7 @@ COPY neonvm/tools/vxlan/controller/ neonvm/tools/vxlan/controller/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /vxlan-controller neonvm/tools/vxlan/controller/main.go
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 RUN apk add --no-cache \
     tini \

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -56,7 +56,7 @@ build: |
   RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
 
   # Build the allocation tester:
-  FROM alpine:3.17 AS allocate-loop-builder
+  FROM alpine:3.18 AS allocate-loop-builder
   RUN set -e \
       && apk add gcc musl-dev
   COPY allocate-loop.c allocate-loop.c


### PR DESCRIPTION
Part of #900; extracted from #1008.

Notably, this PR also bumps QEMU in neonvm-runner: 7.1.0 -> 8.0.5

The QEMU 8.0 changelog is here: https://wiki.qemu.org/ChangeLog/8.0