### PR TITLE
plugin/trans: Fix over-allowing from forceApprovalMinimum

### DIFF
--- a/pkg/plugin/trans.go
+++ b/pkg/plugin/trans.go
@@ -313,8 +313,7 @@ func (r resourceTransitioner[T]) handleRequestedGeneric(
 		// the factor.
 		maxIncrease := (remainingReservable / opts.factor) * opts.factor
 		// ... but we must allow at least opts.forceApprovalMinimum
-		remainingBelowForcedApproval := util.SaturatingSub(opts.forceApprovalMinimum, r.pod.Reserved)
-		increaseFromForceApproval := (remainingBelowForcedApproval / opts.factor) * opts.factor
+		increaseFromForceApproval := util.SaturatingSub(opts.forceApprovalMinimum, r.pod.Reserved)
 		maxIncrease = util.Max(maxIncrease, increaseFromForceApproval)
 
 		if increase > maxIncrease /* increases are bound by what's left in the node */ {

--- a/pkg/plugin/trans.go
+++ b/pkg/plugin/trans.go
@@ -313,7 +313,9 @@ func (r resourceTransitioner[T]) handleRequestedGeneric(
 		// the factor.
 		maxIncrease := (remainingReservable / opts.factor) * opts.factor
 		// ... but we must allow at least opts.forceApprovalMinimum
-		maxIncrease = util.Max(maxIncrease, opts.forceApprovalMinimum)
+		remainingBelowForcedApproval := util.SaturatingSub(opts.forceApprovalMinimum, r.pod.Reserved)
+		increaseFromForceApproval := (remainingBelowForcedApproval / opts.factor) * opts.factor
+		maxIncrease = util.Max(maxIncrease, increaseFromForceApproval)
 
 		if increase > maxIncrease /* increases are bound by what's left in the node */ {
 			r.pod.CapacityPressure = increase - maxIncrease

--- a/pkg/plugin/trans_test.go
+++ b/pkg/plugin/trans_test.go
@@ -369,18 +369,16 @@ func Test_handleRequested_nomigration(t *testing.T) {
 			lastPermit: lo.ToPtr[uint](4),
 			factor:     2,
 
-			// FIXME: This is actually incorrect / not working. The request should be rejected with
-			// only 6 reserved, because otherwise we end up over the total (as seen below).
-			verdict: "",
+			verdict: "Register 4 -> 6 (wanted 8) (pressure 0 -> 2); node reserved 7 -> 9 (of 10), node capacityPressure 0 -> 2 (0 -> 0 spoken for)",
 			podAfter: pod{
-				reserved: 8,
+				reserved: 6,
 				buffer:   0,
-				pressure: 0,
+				pressure: 2,
 			},
 			nodeAfter: node{
-				reserved: 11,
+				reserved: 9,
 				buffer:   0,
-				pressure: 0,
+				pressure: 2,
 			},
 		},
 		{
@@ -403,18 +401,16 @@ func Test_handleRequested_nomigration(t *testing.T) {
 			lastPermit: lo.ToPtr[uint](2),
 			factor:     1,
 
-			// FIXME: This is actually incorrect / not working. The request should be rejected with
-			// only 2 reserved, because otherwise we end up over the total (as seen below).
-			verdict: "",
+			verdict: "Register 2 -> 2 (wanted 3) (pressure 0 -> 1); node reserved 12 -> 12 (of 10), node capacityPressure 0 -> 1 (0 -> 0 spoken for)",
 			podAfter: pod{
-				reserved: 3,
+				reserved: 2,
 				buffer:   0,
-				pressure: 0,
+				pressure: 1,
 			},
 			nodeAfter: node{
-				reserved: 13,
+				reserved: 12,
 				buffer:   0,
-				pressure: 0,
+				pressure: 1,
 			},
 		},
 		{


### PR DESCRIPTION
Noticed as part of #1023.

The current (incorrect) behavior is that `forceApprovalMinimum` is relative to the current resources when it's actually intended (and documented as such) to be absolute. So in practice, we're approving autoscaler-agent requests that we shouldn't -- allowing resource increases above the node maximum when we don't need to.

`forceApprovalMinimum` was added as part of #936, and presumably we didn't catch this because of the lack of unit tests.