### PR TITLE
neonvm-controller: Fix immutable `.spec.guest.memoryProvider`

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_webhook.go
@@ -134,7 +134,6 @@ func (r *VirtualMachine) ValidateUpdate(old runtime.Object) (admission.Warnings,
 		// nb: we don't check memoryProvider here, so that it's allowed to be mutable as a way of
 		// getting flexibility to solidify the memory provider or change it across restarts.
 		// ref https://github.com/neondatabase/autoscaling/pull/970#discussion_r1644225986
-		{".spec.guest.memoryProvider", func(v *VirtualMachine) any { return v.Spec.Guest.MemoryProvider }},
 		{".spec.guest.ports", func(v *VirtualMachine) any { return v.Spec.Guest.Ports }},
 		{".spec.guest.rootDisk", func(v *VirtualMachine) any { return v.Spec.Guest.RootDisk }},
 		{".spec.guest.command", func(v *VirtualMachine) any { return v.Spec.Guest.Command }},


### PR DESCRIPTION
In the original PR (#970), I'd intended to make this field mutable and added a comment about it, but forgot to actually remove it from the list of immutable fields.

*Probably* doesn't matter much, but IMO it's worth cleaning up.