### PR TITLE
agent: Don't include VM name in neonvm request metric labels

### DIFF
--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -675,7 +676,11 @@ func (r *Runner) doNeonVMRequest(
 		Patch(requestCtx, r.vmName.Name, ktypes.JSONPatchType, patchPayload, metav1.PatchOptions{})
 
 	if err != nil {
-		r.global.metrics.neonvmRequestsOutbound.WithLabelValues(fmt.Sprintf("[error: %s]", util.RootError(err))).Inc()
+		errMsg := util.RootError(err).Error()
+		// Some error messages contain the object name. We could try to filter them all out, but
+		// it's probably more maintainable to just keep them as-is and remove the name.
+		errMsg = strings.ReplaceAll(errMsg, r.vmName.Name, "<name>")
+		r.global.metrics.neonvmRequestsOutbound.WithLabelValues(fmt.Sprintf("[error: %s]", errMsg)).Inc()
 		return err
 	}
 


### PR DESCRIPTION
Currently, we sometimes get neonvm request failure metric labels like

    [error: virtualmachines.vm.neon.tech "compute-rapid-wave-a45g5t85" not found]

Thankfully *in practice* the rates are very low, so it's not a big issue, but in theory we could accidentally blow up our metrics storage if some issue was causing our requests to fail for every object in a way that included the object name.

So this PR makes sure we filter out the name.