### PR TITLE
agent/core: Use cached LFC for memory scaling signal

### DIFF
--- a/deploy/agent/config_map.yaml
+++ b/deploy/agent/config_map.yaml
@@ -12,6 +12,7 @@ data:
         "defaultConfig": {
           "loadAverageFractionTarget": 0.9,
           "memoryUsageFractionTarget": 0.75,
+          "memoryTotalFractionTarget": 0.9,
           "enableLFCMetrics": false,
           "lfcToMemoryRatio": 0.75,
           "lfcWindowSizeMinutes": 5,

--- a/pkg/agent/core/goalcu.go
+++ b/pkg/agent/core/goalcu.go
@@ -1,0 +1,125 @@
+package core
+
+// extracted components of how "goal CU" is determined
+
+import (
+	"math"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/neondatabase/autoscaling/pkg/api"
+	"github.com/neondatabase/autoscaling/pkg/util"
+)
+
+type scalingGoal struct {
+	hasAllMetrics bool
+	goalCU        uint32
+}
+
+func calculateGoalCU(
+	warn func(string),
+	cfg api.ScalingConfig,
+	computeUnit api.Resources,
+	systemMetrics *SystemMetrics,
+	lfcMetrics *LFCMetrics,
+) (scalingGoal, []zap.Field) {
+	hasAllMetrics := systemMetrics != nil && (!*cfg.EnableLFCMetrics || lfcMetrics != nil)
+	if !hasAllMetrics {
+		warn("Making scaling decision without all required metrics available")
+	}
+
+	var goalCU uint32
+	var logFields []zap.Field
+
+	if systemMetrics != nil {
+		cpuGoalCU := calculateCPUGoalCU(cfg, computeUnit, *systemMetrics)
+		goalCU = max(goalCU, cpuGoalCU)
+
+		memGoalCU := calculateMemGoalCU(cfg, computeUnit, *systemMetrics)
+
+		goalCU = max(goalCU, memGoalCU)
+	}
+
+	if lfcMetrics != nil {
+		lfcGoalCU, lfcLogFunc := calculateLFCGoalCU(warn, cfg, computeUnit, *lfcMetrics)
+		goalCU = max(goalCU, lfcGoalCU)
+		if lfcLogFunc != nil {
+			logFields = append(logFields, zap.Object("lfc", zapcore.ObjectMarshalerFunc(lfcLogFunc)))
+		}
+	}
+
+	return scalingGoal{hasAllMetrics: hasAllMetrics, goalCU: goalCU}, logFields
+}
+
+// For CPU:
+// Goal compute unit is at the point where (CPUs) × (LoadAverageFractionTarget) == (load average),
+// which we can get by dividing LA by LAFT, and then dividing by the number of CPUs per CU
+func calculateCPUGoalCU(
+	cfg api.ScalingConfig,
+	computeUnit api.Resources,
+	systemMetrics SystemMetrics,
+) uint32 {
+	goalCPUs := systemMetrics.LoadAverage1Min / *cfg.LoadAverageFractionTarget
+	cpuGoalCU := uint32(math.Round(goalCPUs / computeUnit.VCPU.AsFloat64()))
+	return cpuGoalCU
+}
+
+// For Mem:
+// Goal compute unit is at the point where (Mem) * (MemoryUsageFractionTarget) == (Mem Usage)
+// We can get the desired memory allocation in bytes by dividing MU by MUFT, and then convert
+// that to CUs.
+func calculateMemGoalCU(
+	cfg api.ScalingConfig,
+	computeUnit api.Resources,
+	systemMetrics SystemMetrics,
+) uint32 {
+	memGoalBytes := api.Bytes(math.Round(systemMetrics.MemoryUsageBytes / *cfg.MemoryUsageFractionTarget))
+	memGoalCU := uint32(memGoalBytes / computeUnit.Mem)
+	return memGoalCU
+}
+
+func calculateLFCGoalCU(
+	warn func(string),
+	cfg api.ScalingConfig,
+	computeUnit api.Resources,
+	lfcMetrics LFCMetrics,
+) (uint32, func(zapcore.ObjectEncoder) error) {
+	wssValues := lfcMetrics.ApproximateworkingSetSizeBuckets
+	// At this point, we can assume that the values are equally spaced at 1 minute apart,
+	// starting at 1 minute.
+	offsetIndex := *cfg.LFCMinWaitBeforeDownscaleMinutes - 1 // -1 because values start at 1m
+	windowSize := *cfg.LFCWindowSizeMinutes
+	// Handle invalid metrics:
+	if len(wssValues) < offsetIndex+windowSize {
+		warn("not enough working set size values to make scaling determination")
+		return 0, nil
+	} else {
+		estimateWss := EstimateTrueWorkingSetSize(wssValues, WssEstimatorConfig{
+			MaxAllowedIncreaseFactor: 3.0, // hard-code this for now.
+			InitialOffset:            offsetIndex,
+			WindowSize:               windowSize,
+		})
+		projectSliceEnd := offsetIndex // start at offsetIndex to avoid panics if not monotonically non-decreasing
+		for ; projectSliceEnd < len(wssValues) && wssValues[projectSliceEnd] <= estimateWss; projectSliceEnd++ {
+		}
+		projectLen := 0.5 // hard-code this for now.
+		predictedHighestNextMinute := ProjectNextHighest(wssValues[:projectSliceEnd], projectLen)
+
+		// predictedHighestNextMinute is still in units of 8KiB pages. Let's convert that
+		// into GiB, then convert that into CU, and then invert the discount from only some
+		// of the memory going towards LFC to get the actual CU required to fit the
+		// predicted working set size.
+		requiredCU := predictedHighestNextMinute * 8192 / computeUnit.Mem.AsFloat64() / *cfg.LFCToMemoryRatio
+		lfcGoalCU := uint32(math.Ceil(requiredCU))
+
+		lfcLogFields := func(obj zapcore.ObjectEncoder) error {
+			obj.AddFloat64("estimateWssPages", estimateWss)
+			obj.AddFloat64("predictedNextWssPages", predictedHighestNextMinute)
+			obj.AddFloat64("requiredCU", requiredCU)
+			return nil
+		}
+
+		return lfcGoalCU, lfcLogFields
+	}
+}

--- a/pkg/agent/core/metrics.go
+++ b/pkg/agent/core/metrics.go
@@ -18,8 +18,10 @@ import (
 )
 
 type SystemMetrics struct {
-	LoadAverage1Min  float64
-	MemoryUsageBytes float64
+	LoadAverage1Min float64
+
+	MemoryUsageBytes  float64
+	MemoryCachedBytes float64
 }
 
 func (m SystemMetrics) ToAPI() api.Metrics {
@@ -94,11 +96,13 @@ func (m *SystemMetrics) fromPrometheus(mfs map[string]*promtypes.MetricFamily) e
 	load1 := getFloat("host_load1")
 	memTotal := getFloat("host_memory_total_bytes")
 	memAvailable := getFloat("host_memory_available_bytes")
+	memCached := getFloat("host_memory_cached_bytes")
 
 	tmp := SystemMetrics{
 		LoadAverage1Min: load1,
 		// Add an extra 100 MiB to account for kernel memory usage
-		MemoryUsageBytes: memTotal - memAvailable + 100*(1<<20),
+		MemoryUsageBytes:  memTotal - memAvailable + 100*(1<<20),
+		MemoryCachedBytes: memCached,
 	}
 
 	if err := ec.Resolve(); err != nil {

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -328,13 +328,23 @@ type ScalingConfig struct {
 	// this field is left out the settings will fall back on the global default.
 	LoadAverageFractionTarget *float64 `json:"loadAverageFractionTarget,omitempty"`
 
-	// MemoryUsageFractionTarget sets the desired fraction of current memory that
-	// we would like to be using. For example, with a value of 0.7, on a 4GB VM
-	// we'd like to be using 2.8GB of memory.
+	// MemoryUsageFractionTarget sets the maximum fraction of total memory that postgres allocations
+	// (MemoryUsage) must fit into. This doesn't count the LFC memory.
+	// This memory may also be viewed as "unreclaimable" (contrary to e.g. page cache).
+	//
+	// For example, with a value of 0.75 on a 4GiB VM, we will try to upscale if the unreclaimable
+	// memory usage exceeds 3GiB.
 	//
 	// When specifying the autoscaler-agent config, this field is required. For an individual VM, if
 	// this field is left out the settings will fall back on the global default.
 	MemoryUsageFractionTarget *float64 `json:"memoryUsageFractionTarget,omitempty"`
+
+	// MemoryTotalFractionTarget sets the maximum fraction of total memory that postgres allocations
+	// PLUS LFC memory (MemoryUsage + MemoryCached) must fit into.
+	//
+	// Compared with MemoryUsageFractionTarget, this value can be set higher (e.g. 0.9 vs 0.75),
+	// because we can tolerate higher fraction of consumption for both in-VM memory consumers.
+	MemoryTotalFractionTarget *float64 `json:"memoryTotalFractionTarget,omitempty"`
 
 	// EnableLFCMetrics, if true, enables fetching additional metrics about the Local File Cache
 	// (LFC) to provide as input to the scaling algorithm.
@@ -375,6 +385,9 @@ func (defaults ScalingConfig) WithOverrides(overrides *ScalingConfig) ScalingCon
 	}
 	if overrides.MemoryUsageFractionTarget != nil {
 		defaults.MemoryUsageFractionTarget = lo.ToPtr(*overrides.MemoryUsageFractionTarget)
+	}
+	if overrides.MemoryTotalFractionTarget != nil {
+		defaults.MemoryTotalFractionTarget = lo.ToPtr(*overrides.MemoryTotalFractionTarget)
 	}
 	if overrides.EnableLFCMetrics != nil {
 		defaults.EnableLFCMetrics = lo.ToPtr(*overrides.EnableLFCMetrics)
@@ -427,6 +440,13 @@ func (c *ScalingConfig) validate(requireAll bool) error {
 		erc.Whenf(ec, *c.MemoryUsageFractionTarget >= 1.0, "%s must be set to value < 1 ", ".memoryUsageFractionTarget")
 	} else if requireAll {
 		ec.Add(fmt.Errorf("%s is a required field", ".memoryUsageFractionTarget"))
+	}
+	// Make sure c.MemoryTotalFractionTarget is between 0 and 1
+	if c.MemoryTotalFractionTarget != nil {
+		erc.Whenf(ec, *c.MemoryTotalFractionTarget < 0.0, "%s must be set to value >= 0", ".memoryTotalFractionTarget")
+		erc.Whenf(ec, *c.MemoryTotalFractionTarget >= 1.0, "%s must be set to value < 1 ", ".memoryTotalFractionTarget")
+	} else if requireAll {
+		ec.Add(fmt.Errorf("%s is a required field", ".memoryTotalFractionTarget"))
 	}
 
 	if requireAll {


### PR DESCRIPTION
In short: In addition to scaling when there's a lot of memory used by postgres, we should also scale up to make sure that enough of the LFC is able to fit into the page cache alongside it.

To answer "how much is enough of the LFC", this PR takes the minimum of the estimated LFC working set size (from window size) and the cached memory (from the `Cached` field of `/proc/meminfo`, via vector's host metrics).

This PR also adds the `memoryTotalFractionTarget` field to the scaling config, serving a similar purpose to `memoryUsageFractionTarget`, but applying to the total of memory usage and cached data.

This PR is part of #1030 and must be deployed before the vm-monitor changes in order to make sure we don't regress performance for workloads that are both memory-heavy and rely on LFC being in the VM's page cache.

For more info, see: https://www.notion.so/neondatabase/0f75b15d47ad479094861302a99114af.

---

**Notes for review:**

1. This PR is broken into two commits -- the first is a refactor to make the second one easier to read.
1. Planning to test on staging with neondatabase/neon#8668 using some familiar workloads (in particular: LFC-aware scaling tests and pgvector index build)