### PR TITLE
agent: add metric and log warning for denied scaling

### DIFF
--- a/pkg/agent/prommetrics.go
+++ b/pkg/agent/prommetrics.go
@@ -16,6 +16,9 @@ type GlobalMetrics struct {
 	schedulerRequestedChange resourceChangePair
 	schedulerApprovedChange  resourceChangePair
 
+	scalingFullDeniesTotal       *prometheus.CounterVec
+	scalingPartialApprovalsTotal *prometheus.CounterVec
+
 	monitorRequestsOutbound *prometheus.CounterVec
 	monitorRequestsInbound  *prometheus.CounterVec
 	monitorRequestedChange  resourceChangePair
@@ -130,7 +133,21 @@ func makeGlobalMetrics() (GlobalMetrics, *prometheus.Registry) {
 				[]string{directionLabel},
 			)),
 		},
-
+		// ---- scaling denies related metrics ----
+		scalingFullDeniesTotal: util.RegisterMetric(reg, prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "autoscaling_agent_scaling_full_denials_total",
+				Help: "Number of the scheduler or vmmon full denials responses",
+			},
+			[]string{directionLabel},
+		)),
+		scalingPartialApprovalsTotal: util.RegisterMetric(reg, prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "autoscaling_agent_scaling_partial_approvals_total",
+				Help: "Number of the scheduler partially approved responses",
+			},
+			[]string{directionLabel},
+		)),
 		// ---- MONITOR ----
 		monitorRequestsOutbound: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -834,8 +834,11 @@ func (r *Runner) DoSchedulerRequest(
 		// Fatal because invalid JSON might also be semantically invalid
 		return nil, fmt.Errorf("Bad JSON response: %w", err)
 	}
-
-	logger.Debug("Received response from scheduler", zap.Any("response", respData))
+	level := zap.DebugLevel
+	if respData.Permit.HasFieldLessThan(resources) {
+		level = zap.WarnLevel
+	}
+	logger.Log(level, "Received response from scheduler", zap.Any("response", respData), zap.Any("requested", resources))
 
 	return &respData, nil
 }


### PR DESCRIPTION
Add new VM metrics called autoscaling_agent_scaling_full_denials_total and autoscaling_agent_scaling_partial_approvals_total.


Closes #940