### PR TITLE
neonvm: Add controller flag to disable runner cgroup

### DIFF
--- a/neonvm/controllers/config.go
+++ b/neonvm/controllers/config.go
@@ -23,6 +23,14 @@ type ReconcilerConfig struct {
 	// This is defined as a config option so we can do a gradual rollout of this change.
 	UseContainerMgr bool
 
+	// DisableRunnerCgroup, if true, disables running QEMU in a cgroup in new VM runner pods.
+	// Fractional CPU scaling will continue to *pretend* to work, but it will not do anything in
+	// practice.
+	//
+	// Under the hood, this results in passing -skip-cgroup-management and -enable-dummy-cpu-server
+	// to neonvm-runner.
+	DisableRunnerCgroup bool
+
 	MaxConcurrentReconciles int
 
 	// SkipUpdateValidationFor is the set of object names that we should ignore when doing webhook

--- a/neonvm/controllers/functests/vm_controller_test.go
+++ b/neonvm/controllers/functests/vm_controller_test.go
@@ -109,6 +109,7 @@ var _ = Describe("VirtualMachine controller", func() {
 				Config: &controllers.ReconcilerConfig{
 					IsK3s:                   false,
 					UseContainerMgr:         true,
+					DisableRunnerCgroup:     false,
 					MaxConcurrentReconciles: 1,
 					SkipUpdateValidationFor: nil,
 					QEMUDiskCacheSettings:   "cache=none",

--- a/neonvm/controllers/vm_controller_unit_test.go
+++ b/neonvm/controllers/vm_controller_unit_test.go
@@ -117,6 +117,7 @@ func newTestParams(t *testing.T) *testParams {
 		Config: &ReconcilerConfig{
 			IsK3s:                   false,
 			UseContainerMgr:         false,
+			DisableRunnerCgroup:     false,
 			MaxConcurrentReconciles: 10,
 			SkipUpdateValidationFor: nil,
 			QEMUDiskCacheSettings:   "",

--- a/neonvm/main.go
+++ b/neonvm/main.go
@@ -101,6 +101,7 @@ func main() {
 	var concurrencyLimit int
 	var skipUpdateValidationFor map[types.NamespacedName]struct{}
 	var enableContainerMgr bool
+	var disableRunnerCgroup bool
 	var qemuDiskCacheSettings string
 	var defaultMemoryProvider vmv1.MemoryProvider
 	var memhpAutoMovableRatio string
@@ -138,7 +139,9 @@ func main() {
 			return nil
 		},
 	)
+	// note: cannot have both -enable-container-mgr and -disable-runner-cgroup.
 	flag.BoolVar(&enableContainerMgr, "enable-container-mgr", false, "Enable crictl-based container-mgr alongside each VM")
+	flag.BoolVar(&disableRunnerCgroup, "disable-runner-cgroup", false, "Disable creation of a cgroup in neonvm-runner for fractional CPU limiting")
 	flag.StringVar(&qemuDiskCacheSettings, "qemu-disk-cache-settings", "cache=none", "Set neonvm-runner's QEMU disk cache settings")
 	flag.Func("default-memory-provider", "Set default memory provider to use for new VMs", defaultMemoryProvider.FlagFunc)
 	flag.StringVar(&memhpAutoMovableRatio, "memhp-auto-movable-ratio", "301", "For virtio-mem, set VM kernel's memory_hotplug.auto_movable_ratio")
@@ -150,6 +153,10 @@ func main() {
 
 	if defaultMemoryProvider == "" {
 		fmt.Fprintln(os.Stderr, "missing required flag '-default-memory-provider'")
+		os.Exit(1)
+	}
+	if disableRunnerCgroup && enableContainerMgr {
+		fmt.Fprintln(os.Stderr, "Cannot have both '-enable-container-mgr' and '-disable-runner-cgroup'")
 		os.Exit(1)
 	}
 
@@ -205,6 +212,7 @@ func main() {
 	rc := &controllers.ReconcilerConfig{
 		IsK3s:                   isK3s,
 		UseContainerMgr:         enableContainerMgr,
+		DisableRunnerCgroup:     disableRunnerCgroup,
 		MaxConcurrentReconciles: concurrencyLimit,
 		SkipUpdateValidationFor: skipUpdateValidationFor,
 		QEMUDiskCacheSettings:   qemuDiskCacheSettings,


### PR DESCRIPTION
This commit adds new flags to neonvm-controller and neonvm-runner:

* controller: `-disable-runner-cgroup`
* runner: `-enable-dummy-cpu-server`

If the controller is passed `-disable-runner-cgroup`, then it will pass both `-skip-cgroup-management` and `-enable-dummy-cpu-server` to new runner pods.

If neonvm-runner is passed `-enable-dummy-cpu-server` (requires the `-skip-cgroup-management` flag), it will *not* run QEMU in a cgroup, but still provide an HTTP server with endpoints that pretend as if the CPU limit was updated successfully.

Internally, the runner's "dummy" implementation still needs to store the most recently set value to provide it back to the controller, so that it doesn't infinitely loop trying to set the CPU.

ref https://neondb.slack.com/archives/C06SJG60FRB/p1723485730034399