### PR TITLE
Fix warnings in dockerfiles

### DIFF
--- a/neonvm/Dockerfile
+++ b/neonvm/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.21 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG BUILDTAGS

--- a/neonvm/hack/kernel/Dockerfile.kernel-builder
+++ b/neonvm/hack/kernel/Dockerfile.kernel-builder
@@ -8,7 +8,7 @@ RUN set -e \
     && test -n "${KERNEL_VERSION}" \
     && echo "force this as a requirement for build-deps" > /build/arg-check-succeeded
 
-FROM ubuntu:23.10 as build-deps
+FROM ubuntu:23.10 AS build-deps
 WORKDIR /build
 
 RUN apt-get update && apt-get -y install \

--- a/neonvm/runner/Dockerfile
+++ b/neonvm/runner/Dockerfile
@@ -1,5 +1,5 @@
 # Build the Go binary
-FROM golang:1.21 as builder
+FROM golang:1.21 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -27,7 +27,7 @@ COPY pkg/util pkg/util
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /runner neonvm/runner/main.go
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /container-mgr neonvm/runner/container-mgr/*.go
 
-FROM alpine:3.18 as crictl
+FROM alpine:3.18 AS crictl
 
 RUN apk add --no-cache \
     curl

--- a/neonvm/samples/vm-example/Dockerfile
+++ b/neonvm/samples/vm-example/Dockerfile
@@ -25,7 +25,7 @@ RUN set -e \
 		su-exec \
 		postgresql14
 # init postgres
-ENV PGDATA /var/lib/postgresql
+ENV PGDATA=/var/lib/postgresql
 RUN set -e \
     && mkdir -p ${PGDATA} /run/postgresql \
     && chown -R postgres:postgres ${PGDATA} /run/postgresql \

--- a/neonvm/tools/vxlan/Dockerfile
+++ b/neonvm/tools/vxlan/Dockerfile
@@ -1,5 +1,5 @@
 # Build the Go binary
-FROM golang:1.21 as builder
+FROM golang:1.21 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -51,7 +51,7 @@ files:
 
 build: |
   # Build vm-monitor
-  FROM rust:1.79-alpine as monitor-builder
+  FROM rust:1.79-alpine AS monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev
@@ -75,7 +75,7 @@ build: |
   # At time of writing (2023-03-14), debian bullseye has a version of cgroup-tools (technically
   # libcgroup) that doesn't support cgroup v2 (version 0.41-11). Unfortunately, the vm-monitor
   # requires cgroup v2, so we'll build cgroup-tools ourselves.
-  FROM debian:bullseye-slim as libcgroup-builder
+  FROM debian:bullseye-slim AS libcgroup-builder
   ENV LIBCGROUP_VERSION v2.0.3
 
   RUN set -exu \

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -36,7 +36,7 @@ files:
     hostPath: cgconfig.conf
 build: |
   # Build vm-monitor
-  FROM rust:1.79-alpine as monitor-builder
+  FROM rust:1.79-alpine AS monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev
@@ -85,7 +85,7 @@ merge: |
                 postgresql16
 
   # Initialize postgres
-  ENV PGDATA /var/lib/postgresql
+  ENV PGDATA=/var/lib/postgresql
   RUN set -e \
       && mkdir -p ${PGDATA} /run/postgresql \
       && chown -R postgres:postgres ${PGDATA} /run/postgresql \


### PR DESCRIPTION
Relatively recently, docker has introduced a "linter" for dockerfiles: https://docs.docker.com/reference/build-checks/
I went through all the files (using `for f in $(find . -name Dockerfile); do docker build --check -f $f . ; done`) and fixed found warnings. 
A newer version of ` docker/build-push-action` will report such warnings as build annotations (see https://github.com/neondatabase/autoscaling/pull/1041/files, scroll down to "Unchanged files with check annotations")
