### PR TITLE
ci: save cover.out profile as run artifact

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,6 @@ on:
       - "**.go"
     branches:
       - main
-
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -29,3 +28,8 @@ jobs:
         if: env.GIT_DIFF
         run: |
           make test
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: cover.out


### PR DESCRIPTION
ci: save cover.out profile-file as run artifact to enable using it as input for the reporter


Related to https://github.com/neondatabase/cloud/issues/16669