### PR TITLE
ci: temporary trigger test run on all main merges

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,8 +2,6 @@ name: test
 on:
   pull_request:
   push:
-    paths:
-      - "**.go"
     branches:
       - main
 jobs:


### PR DESCRIPTION
I need this PR to be merged to trigger test run on main branch to get the artifacts uploaded. After the https://github.com/neondatabase/cloud/issues/16669 is closed, those artifacts will be used as baseline for coverage reports.