### PR TITLE
vm-builder: change sshd config to use internal-sftp subsystem

### DIFF
--- a/neonvm/tools/vm-builder/files/sshd_config
+++ b/neonvm/tools/vm-builder/files/sshd_config
@@ -84,8 +84,10 @@ X11Forwarding no
 # no default banner path
 #Banner none
 
-# override default of no subsystems
-Subsystem	sftp	/usr/lib/ssh/sftp-server
+# Override default of no subsystems
+# Use internal-sftp for SFTP connections. This is the modern method and doesn't require additional binaries,
+# as the logic is implemented directly within the sshd binary.
+Subsystem	sftp	internal-sftp
 
 # Example of overriding settings on a per-user basis
 #Match User anoncvs

--- a/tests/e2e/vm-ssh/00-assert.yaml
+++ b/tests/e2e/vm-ssh/00-assert.yaml
@@ -7,6 +7,16 @@ commands:
       pod="$(kubectl get neonvm -n "$NAMESPACE" example -o jsonpath='{.status.podName}')"
       kubectl exec -n "$NAMESPACE" $pod -- ssh guest-vm true
 ---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+commands:
+  - script: |
+      set -eux
+      pod="$(kubectl get neonvm -n "$NAMESPACE" example -o jsonpath='{.status.podName}')"
+      kubectl exec -n "$NAMESPACE" $pod -- touch /tmp/testfile
+      kubectl exec -n "$NAMESPACE" $pod -- scp /tmp/testfile guest-vm:/tmp/testfile
+---
 apiVersion: vm.neon.tech/v1
 kind: VirtualMachine
 metadata:


### PR DESCRIPTION
Change sshd_config to let scp command work outside of the box.
Add e2e test for scp command.

The root cause for non-working scp was config directive ```Subsystem	sftp	/usr/lib/ssh/sftp-server```

We don't have that binary in the guest vm. There are 2 ways to fix it - either add binary during the image build or change the configuration to use embedded realization of the sftp subsystem. I chose the second option since it is a bit easier.

More context: https://man.openbsd.org/sshd_config#Subsystem

Closes #930 