### PR TITLE
neonvm: Replace deprecated generate-groups.sh with kube_codegen.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,6 @@ generate: ## Generate boilerplate DeepCopy methods, manifests, and Go client
 	set -x ; \
 	docker run --rm \
 		"$${volumes[@]}" \
-		--volume "$$volumes" \
 		--workdir /go/src/github.com/neondatabase/autoscaling \
 		--user $(shell id -u $(USER)):$(shell id -g $(USER)) \
 		$$(cat $$iidfile) \

--- a/Makefile
+++ b/Makefile
@@ -70,22 +70,31 @@ help: ## Display this help.
 .PHONY: generate
 generate: ## Generate boilerplate DeepCopy methods, manifests, and Go client
 	# Use uid and gid of current user to avoid mismatched permissions
-	iidfile=$$(mktemp /tmp/iid-XXXXXX) && \
+	set -e ; \
+	iidfile=$$(mktemp /tmp/iid-XXXXXX) ; \
 	docker build \
 		--build-arg USER_ID=$(shell id -u $(USER)) \
 		--build-arg GROUP_ID=$(shell id -g $(USER)) \
 		--build-arg CONTROLLER_TOOLS_VERSION=$(CONTROLLER_TOOLS_VERSION) \
 		--build-arg CODE_GENERATOR_VERSION=$(CODE_GENERATOR_VERSION) \
 		--file neonvm/hack/Dockerfile.generate \
-		--iidfile $$iidfile . && \
+		--iidfile $$iidfile . ; \
+	volumes=('--volume' "$$PWD:/go/src/github.com/neondatabase/autoscaling") ; \
+	if [ -f .git ]; then \
+		gitdir="$$(git rev-parse --git-common-dir)" ; \
+		volumes+=('--volume') ; \
+		volumes+=("$$gitdir:$$gitdir") ; \
+	fi ; \
+	set -x ; \
 	docker run --rm \
-		--volume $$PWD:/go/src/github.com/neondatabase/autoscaling \
+		"$${volumes[@]}" \
+		--volume "$$volumes" \
 		--workdir /go/src/github.com/neondatabase/autoscaling \
 		--user $(shell id -u $(USER)):$(shell id -g $(USER)) \
 		$$(cat $$iidfile) \
-		./neonvm/hack/generate.sh && \
-	docker rmi $$(cat $$iidfile)
-	rm -rf $$iidfile
+		./neonvm/hack/generate.sh ; \
+	docker rmi $$(cat $$iidfile) ; \
+	rm -rf $$iidfile ; \
 	go fmt ./...
 
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ generate: ## Generate boilerplate DeepCopy methods, manifests, and Go client
 	volumes=('--volume' "$$PWD:/go/src/github.com/neondatabase/autoscaling") ; \
 	if [ -f .git ]; then \
 		gitdir="$$(git rev-parse --git-common-dir)" ; \
-		volumes+=('--volume') ; \
-		volumes+=("$$gitdir:$$gitdir") ; \
+		gitdir="$$(cd -P -- $$gitdir && pwd)" ; \
+		volumes+=('--volume' "$$gitdir:$$gitdir") ; \
 	fi ; \
 	set -x ; \
 	docker run --rm \

--- a/neonvm/hack/Dockerfile.generate
+++ b/neonvm/hack/Dockerfile.generate
@@ -1,5 +1,7 @@
 FROM golang:1.21
 
+RUN apt-get update && apt-get install -y patch
+
 ARG CONTROLLER_TOOLS_VERSION
 ARG CODE_GENERATOR_VERSION
 

--- a/neonvm/hack/generate.sh
+++ b/neonvm/hack/generate.sh
@@ -4,11 +4,34 @@
 
 set -eu -o pipefail
 
-bash $GOPATH/src/k8s.io/code-generator/generate-groups.sh "deepcopy,client,informer,lister" \
-    github.com/neondatabase/autoscaling/neonvm/client \
-    github.com/neondatabase/autoscaling/neonvm/apis \
-    neonvm:v1 \
-    --go-header-file neonvm/hack/boilerplate.go.txt
+CODEGEN_PATH="$GOPATH/src/k8s.io/code-generator/kube_codegen.sh"
+
+# apply a small patch to allow kube_codegen.sh to work with our file structure.
+patch "$CODEGEN_PATH" neonvm/hack/kube_codegen.patch
+
+source "$CODEGEN_PATH"
+
+# Required to allow git worktrees with non-root ownership on the host to work.
+git config --global --add safe.directory "$GOPATH/src/github.com/neondatabase/autoscaling"
+
+# note: generation requires that "${output_base}/${input_pkg_root}" is valid, and *generally* the
+# way to do that is that it's the same directory.
+# The only way for that to be true is if $output_base is equal to "$GOPATH/src", which we make
+# possible by the way we mount the repo from the host.
+
+echo "Running gen_helpers ..."
+kube::codegen::gen_helpers \
+    --output-base "/go/src" \
+    --input-pkg-root  github.com/neondatabase/autoscaling/neonvm/apis \
+    --boilerplate neonvm/hack/boilerplate.go.txt
+
+echo "Running gen_client ..."
+kube::codegen::gen_client \
+    --output-base "/go/src" \
+    --input-pkg-root  github.com/neondatabase/autoscaling/neonvm/apis \
+    --output-pkg-root github.com/neondatabase/autoscaling/neonvm/client \
+    --with-watch \
+    --boilerplate neonvm/hack/boilerplate.go.txt
 
 controller-gen object:headerFile="neonvm/hack/boilerplate.go.txt" paths="./neonvm/apis/..."
 

--- a/neonvm/hack/kube_codegen.patch
+++ b/neonvm/hack/kube_codegen.patch
@@ -1,0 +1,13 @@
+527,528c527
+<     while read -r file; do
+<         dir="$(dirname "${file}")"
+---
+>     while read -r dir; do
+541c540
+<             ":(glob)${in_root}"/'**/types.go' \
+---
+>             ":(glob)${in_root}"/'**/*.go' \
+543c542
+<         ) | LC_ALL=C sort -u
+---
+>         ) | LC_ALL=C sort -u | sed 's:/[^/]*$::' | uniq


### PR DESCRIPTION
The new script is a completely different format :(
See e.g. kubernetes/kubernetes#117262 for examples.

Changes required here:

1. Passing through the git directory, even when using worktrees, because kube_codegen.sh directly uses git for things (git grep, git ls-files)
2. Patching kube_codegen.sh because it expects that our types files are exactly `types.go`, but we have `virtualmachine_types.go` and `virtualmachinemigration_types.go`.

There are further breaking changes in later kubernetes versions, but we don't need to deal with those quite yet.

Extracted from #1048.

---

**Notes for review:** Please check it runs locally.
**Do not approve this PR unless you have checked that `make generate` works for you.**