### PR TITLE
neonvm-controller: improve node failure reaction speed

### DIFF
--- a/neonvm-controller/cmd/main.go
+++ b/neonvm-controller/cmd/main.go
@@ -100,6 +100,7 @@ func main() {
 	var memhpAutoMovableRatio string
 	var failurePendingPeriod time.Duration
 	var failingRefreshInterval time.Duration
+	var atMostOnePod bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -140,6 +141,9 @@ func main() {
 		"the period for the propagation of reconciliation failures to the observability instruments")
 	flag.DurationVar(&failingRefreshInterval, "failing-refresh-interval", 1*time.Minute,
 		"the interval between consecutive updates of metrics and logs, related to failing reconciliations")
+	flag.BoolVar(&atMostOnePod, "at-most-one-pod", false,
+		"If true, the controller will ensure that at most one pod is running at a time. "+
+			"Otherwise, the outdated pod might be left to terminate, while the new one is already running.")
 	flag.Parse()
 
 	if defaultMemoryProvider == "" {
@@ -195,6 +199,7 @@ func main() {
 		MemhpAutoMovableRatio:   memhpAutoMovableRatio,
 		FailurePendingPeriod:    failurePendingPeriod,
 		FailingRefreshInterval:  failingRefreshInterval,
+		AtMostOnePod:            atMostOnePod,
 	}
 
 	vmReconciler := &controllers.VMReconciler{

--- a/pkg/neonvm/controllers/config.go
+++ b/pkg/neonvm/controllers/config.go
@@ -50,4 +50,7 @@ type ReconcilerConfig struct {
 	// FailingRefreshInterval is the interval between consecutive
 	// updates of metrics and logs, related to failing reconciliations
 	FailingRefreshInterval time.Duration
+
+	// AtMostOnePod is the flag that indicates whether we should only have one pod per VM.
+	AtMostOnePod bool
 }

--- a/pkg/neonvm/controllers/functests/vm_controller_test.go
+++ b/pkg/neonvm/controllers/functests/vm_controller_test.go
@@ -115,6 +115,7 @@ var _ = Describe("VirtualMachine controller", func() {
 					MemhpAutoMovableRatio:   "301",
 					FailurePendingPeriod:    1 * time.Minute,
 					FailingRefreshInterval:  1 * time.Minute,
+					AtMostOnePod:            false,
 				},
 			}
 

--- a/pkg/neonvm/controllers/vm_controller_unit_test.go
+++ b/pkg/neonvm/controllers/vm_controller_unit_test.go
@@ -123,6 +123,7 @@ func newTestParams(t *testing.T) *testParams {
 			MemhpAutoMovableRatio:   "301",
 			FailurePendingPeriod:    time.Minute,
 			FailingRefreshInterval:  time.Minute,
+			AtMostOnePod:            false,
 		},
 		Metrics: reconcilerMetrics,
 	}


### PR DESCRIPTION
Multiple commits, their descriptions:

 - neonvm: recreate the pod for VM even if the older pod still exists

    We have previously assumed running multiple pods for one VM is
    dangerous.

    We now believe it should be fine, even if the old pod still tries to
    continue operating. What would happen is that the new pod would take
    over the safekeepers quorum, leaving the old one to disconnect and
    shutdown.

 - neonvm: check if deletion timestamp is in the past

    If we are passed the mark of the deletion timestamp, it means
    the deletion is stuck, and we should consider the pod failed anyway.

    Possible reasons for this are:
    1. Node is down.
    2. Pod is stuck pulling the image from the container registry.

 - neonvm: add explicit "node not ready" tolerations with 30s grace period

    By default they are 300s (5m), which is way too long.

Part of the https://github.com/neondatabase/cloud/issues/14114