### PR TITLE
CI(lint): golangci-lint 1.60.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and
           # should be specified with patch version.
-          version: v1.59.1
+          version: v1.60.3
           args: --timeout 5m
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,11 +30,11 @@ linters:
     - asciicheck       # all identifiers are ASCII
     - bidichk          # no Unicode bidi sequences as per CVE-2021-42574
     - bodyclose        # HTTP response bodies are closed
+    - copyloopvar      # detects places where loop variables are copied
     - dupword          # things like 'the the' in comments/strings
     - durationcheck    # bad time.Duration arithmetic
     - errorlint        # common errors with Go 1.13+ error wrapping
     - exhaustruct      # all struct fields are initialized
-    - exportloopref    # escaping pointers to loop variables
     - gci              # deterministic import ordering
     - gocritic         # lots of small checks, see <https://go-critic.com/overview>
     - noctx            # HTTP requests are passed a Context

--- a/neonvm/controllers/vm_controller.go
+++ b/neonvm/controllers/vm_controller.go
@@ -317,7 +317,7 @@ func (r *VMReconciler) doReconcile(ctx context.Context, vm *vmv1.VirtualMachine)
 	log := log.FromContext(ctx)
 
 	// Let's check and just set the condition status as Unknown when no status are available
-	if vm.Status.Conditions == nil || len(vm.Status.Conditions) == 0 {
+	if len(vm.Status.Conditions) == 0 {
 		// set Unknown condition status for AvailableVirtualMachine
 		meta.SetStatusCondition(&vm.Status.Conditions, metav1.Condition{Type: typeAvailableVirtualMachine, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 	}

--- a/neonvm/controllers/vmmigration_controller.go
+++ b/neonvm/controllers/vmmigration_controller.go
@@ -183,7 +183,7 @@ func (r *VirtualMachineMigrationReconciler) Reconcile(ctx context.Context, req c
 	// MAIN RECONCILE LOOP START
 
 	// Let's check and just set the condition status as Unknown when no status are available
-	if migration.Status.Conditions == nil || len(migration.Status.Conditions) == 0 {
+	if len(migration.Status.Conditions) == 0 {
 		log.Info("Set initial Unknown condition status")
 		meta.SetStatusCondition(&migration.Status.Conditions, metav1.Condition{Type: typeAvailableVirtualMachineMigration, Status: metav1.ConditionUnknown, Reason: "Reconciling", Message: "Starting reconciliation"})
 		return r.updateMigrationStatus(ctx, migration)

--- a/pkg/agent/dumpstate.go
+++ b/pkg/agent/dumpstate.go
@@ -97,7 +97,6 @@ func (s *agentState) DumpState(ctx context.Context, stopped bool) (*StateDump, e
 
 	for i, pod := range podList {
 		sema <- struct{}{} // enforce only 'concurrencyLimit' threads running at a time
-		i, pod := i, pod
 		go func() {
 			defer func() {
 				<-sema

--- a/pkg/api/versionutils.go
+++ b/pkg/api/versionutils.go
@@ -34,10 +34,10 @@ func (r VersionRange[V]) String() string {
 // If either range is invalid, or no such version exists (i.e. the ranges are disjoint), then the
 // returned values will be (0, false).
 func (r VersionRange[V]) LatestSharedVersion(cmp VersionRange[V]) (_ V, ok bool) {
-	max := util.Min(r.Max, cmp.Max)
-	min := util.Max(r.Min, cmp.Min)
-	if max >= min {
-		return max, true
+	maxVersion := util.Min(r.Max, cmp.Max)
+	minVersion := util.Max(r.Min, cmp.Min)
+	if maxVersion >= minVersion {
+		return maxVersion, true
 	} else {
 		var v V
 		return v, false

--- a/pkg/api/vminfo.go
+++ b/pkg/api/vminfo.go
@@ -225,35 +225,35 @@ func extractVmInfoGeneric(
 		info.Config.ScalingConfig = &config
 	}
 
-	min := info.Min()
+	minResources := info.Min()
 	using := info.Using()
-	max := info.Max()
+	maxResources := info.Max()
 
 	// we can't do validation for resource.Quantity with kubebuilder
 	// so do it here
-	if err := min.CheckValuesAreReasonablySized(); err != nil {
+	if err := minResources.CheckValuesAreReasonablySized(); err != nil {
 		return nil, fmt.Errorf("min resources are invalid: %w", err)
 	}
 
-	if err := max.CheckValuesAreReasonablySized(); err != nil {
+	if err := maxResources.CheckValuesAreReasonablySized(); err != nil {
 		return nil, fmt.Errorf("max resources are invalid: %w", err)
 	}
 
 	// check: min <= max
-	if min.HasFieldGreaterThan(max) {
-		return nil, fmt.Errorf("min resources %+v has field greater than maximum %+v", min, max)
+	if minResources.HasFieldGreaterThan(maxResources) {
+		return nil, fmt.Errorf("min resources %+v has field greater than maximum %+v", minResources, maxResources)
 	}
 
 	// check: min <= using <= max
-	if using.HasFieldLessThan(min) {
+	if using.HasFieldLessThan(minResources) {
 		logger.Warn(
 			"Current usage has field less than minimum",
-			zap.Object("using", using), zap.Object("min", min),
+			zap.Object("using", using), zap.Object("min", minResources),
 		)
-	} else if using.HasFieldGreaterThan(max) {
+	} else if using.HasFieldGreaterThan(maxResources) {
 		logger.Warn(
 			"Current usage has field greater than maximum",
-			zap.Object("using", using), zap.Object("max", max),
+			zap.Object("using", using), zap.Object("max", maxResources),
 		)
 	}
 

--- a/pkg/util/time.go
+++ b/pkg/util/time.go
@@ -12,16 +12,16 @@ type TimeRange struct {
 	units time.Duration
 }
 
-func NewTimeRange(units time.Duration, min, max int) *TimeRange {
-	if min < 0 {
+func NewTimeRange(units time.Duration, minTime, maxTime int) *TimeRange {
+	if minTime < 0 {
 		panic(errors.New("bad time range: min < 0"))
-	} else if min == 0 && max == 0 {
+	} else if minTime == 0 && maxTime == 0 {
 		panic(errors.New("bad time range: min and max = 0"))
-	} else if max < min {
+	} else if maxTime < minTime {
 		panic(errors.New("bad time range: max < min"))
 	}
 
-	return &TimeRange{min: min, max: max, units: units}
+	return &TimeRange{min: minTime, max: maxTime, units: units}
 }
 
 // Random returns a random time.Duration within the range


### PR DESCRIPTION
Update `golangci-lint` to 1.60.3 and fix new warnings

A prerequisite for go 1.23[0]

- [0] https://github.com/neondatabase/autoscaling/pull/1065 