### PR TITLE
Replace util.{Min,Max} with stdlib {min,max}

### DIFF
--- a/pkg/agent/billing/billing.go
+++ b/pkg/agent/billing/billing.go
@@ -246,7 +246,7 @@ func (s *metricsState) collect(logger *zap.Logger, store VMStoreForNode, metrics
 			timeSlice := metricsTimeSlice{
 				metrics: vmMetricsInstant{
 					// strategically under-bill by assigning the minimum to the entire time slice.
-					cpu: util.Min(oldMetrics.cpu, presentMetrics.cpu),
+					cpu: min(oldMetrics.cpu, presentMetrics.cpu),
 				},
 				// note: we know s.lastTime != nil because otherwise old would be empty.
 				startTime: *s.lastCollectTime,

--- a/pkg/agent/billing/queue.go
+++ b/pkg/agent/billing/queue.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/slices"
-
-	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
 // this is generic just so there's less typing - "billing.IncrementalEvent" is long!
@@ -63,7 +61,7 @@ func (q eventQueuePuller[E]) get(limit int) []E {
 	q.internals.mu.Lock()
 	defer q.internals.mu.Unlock()
 
-	count := util.Min(limit, len(q.internals.items))
+	count := min(limit, len(q.internals.items))
 	// NOTE: this kind of access escaping the mutex is only sound because this access is only
 	// granted to the puller, and there's only one puller, and it isn't sound to use the output of a
 	// previous get() after calling drop().

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -343,16 +343,16 @@ func (r Resources) HasFieldLessThan(cmp Resources) bool {
 // Min returns a new Resources value with each field F as the minimum of r.F and cmp.F
 func (r Resources) Min(cmp Resources) Resources {
 	return Resources{
-		VCPU: util.Min(r.VCPU, cmp.VCPU),
-		Mem:  util.Min(r.Mem, cmp.Mem),
+		VCPU: min(r.VCPU, cmp.VCPU),
+		Mem:  min(r.Mem, cmp.Mem),
 	}
 }
 
 // Max returns a new Resources value with each field F as the maximum of r.F and cmp.F
 func (r Resources) Max(cmp Resources) Resources {
 	return Resources{
-		VCPU: util.Max(r.VCPU, cmp.VCPU),
-		Mem:  util.Max(r.Mem, cmp.Mem),
+		VCPU: max(r.VCPU, cmp.VCPU),
+		Mem:  max(r.Mem, cmp.Mem),
 	}
 }
 

--- a/pkg/api/versionutils.go
+++ b/pkg/api/versionutils.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 
 	"golang.org/x/exp/constraints"
-
-	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
 // VersionRange is a helper type to represent a range of versions.
@@ -34,8 +32,8 @@ func (r VersionRange[V]) String() string {
 // If either range is invalid, or no such version exists (i.e. the ranges are disjoint), then the
 // returned values will be (0, false).
 func (r VersionRange[V]) LatestSharedVersion(cmp VersionRange[V]) (_ V, ok bool) {
-	maxVersion := util.Min(r.Max, cmp.Max)
-	minVersion := util.Max(r.Min, cmp.Min)
+	maxVersion := min(r.Max, cmp.Max)
+	minVersion := max(r.Min, cmp.Min)
 	if maxVersion >= minVersion {
 		return maxVersion, true
 	} else {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -701,7 +701,7 @@ func (e *AutoscaleEnforcer) Score(
 	cpuFScore, cpuIScore := calculateScore(cpuFraction, cpuScale)
 	memFScore, memIScore := calculateScore(memFraction, memScale)
 
-	score := util.Min(cpuIScore, memIScore)
+	score := min(cpuIScore, memIScore)
 	logger.Info(
 		"Scored pod placement for node",
 		zap.Int64("score", score),

--- a/pkg/plugin/trans.go
+++ b/pkg/plugin/trans.go
@@ -314,7 +314,7 @@ func (r resourceTransitioner[T]) handleRequestedGeneric(
 		maxIncrease := (remainingReservable / opts.factor) * opts.factor
 		// ... but we must allow at least opts.forceApprovalMinimum
 		increaseFromForceApproval := util.SaturatingSub(opts.forceApprovalMinimum, r.pod.Reserved)
-		maxIncrease = util.Max(maxIncrease, increaseFromForceApproval)
+		maxIncrease = max(maxIncrease, increaseFromForceApproval)
 
 		if increase > maxIncrease /* increases are bound by what's left in the node */ {
 			r.pod.CapacityPressure = increase - maxIncrease
@@ -516,7 +516,7 @@ func handleUpdatedLimits[T constraints.Unsigned](
 		// Note that we don't want to reserve *below* what we think the VM is using if the bounds
 		// decrease; it may be that the autoscaler-agent has not yet reacted to that.
 		using := pod.Reserved - pod.Buffer
-		pod.Reserved = util.Max(newMax, using)
+		pod.Reserved = max(newMax, using)
 		pod.Buffer = pod.Reserved - using
 
 		node.Reserved = node.Reserved + pod.Reserved - oldPodReserved

--- a/pkg/util/arith.go
+++ b/pkg/util/arith.go
@@ -16,24 +16,6 @@ func SaturatingSub[T constraints.Unsigned](x, y T) T {
 	}
 }
 
-// Max returns the maximum of the two values
-func Max[T constraints.Ordered](x, y T) T {
-	if x > y {
-		return x
-	} else {
-		return y
-	}
-}
-
-// Min returns the minimum of the two values
-func Min[T constraints.Ordered](x, y T) T {
-	if x < y {
-		return x
-	} else {
-		return y
-	}
-}
-
 // AbsDiff returns the absolute value of the difference between x and y
 func AbsDiff[T constraints.Unsigned](x, y T) T {
 	if x > y {


### PR DESCRIPTION
Go 1.22 added the standard min & max functions. Now that #1035 has been merged, we should switch to these instead of replicating the same functionality in pkg/util.

ref https://github.com/neondatabase/autoscaling/pull/1067#discussion_r1749364205

---

**Note:** This PR builds on #1067 and shouldn't be merged before it.