### PR TITLE
vm-builder: Use fresh base for 'builder' stage

### DIFF
--- a/neonvm/tools/vm-builder/files/Dockerfile.img
+++ b/neonvm/tools/vm-builder/files/Dockerfile.img
@@ -97,7 +97,7 @@ RUN set -e \
     && /neonvm/bin/id -g sshd > /dev/null 2>&1 || /neonvm/bin/addgroup sshd \
     && /neonvm/bin/id -u sshd > /dev/null 2>&1 || /neonvm/bin/adduser -D -H -G sshd -g 'sshd privsep' -s /neonvm/bin/nologin sshd
 
-FROM vm-runtime AS builder
+FROM alpine:3.19 AS builder
 ARG DISK_SIZE
 COPY --from=rootdisk-mod / /rootdisk
 


### PR DESCRIPTION
The builder stage doesn't need anything from runtime, and previously only depended on 'vm-runtime' because of the installed disk-related binaries, but installing those has already been moved into 'builder' with #1077.