### PR TITLE
Update paths to vm_monitor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,7 +32,7 @@ This isn't the only architecture document. You may also want to look at:
 * [`neondatabase/neon/.../vm_monitor`] (a different repo) — where the vm-monitor, an autoscaling
   component running _inside_ each VM lives.
 
-[`neondatabase/neon/.../vm_monitor`]: https://github.com/neondatabase/neon/tree/main/libs/vm_monitor
+[`neondatabase/neon/.../vm_monitor`]: https://github.com/neondatabase/neon/tree/main/compute_tools/vm_monitor
 
 ## High-level overview
 

--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -64,11 +64,11 @@ build: |
   ADD "https://api.github.com/repos/neondatabase/neon/commits/$BRANCH" latest_commit
 
   RUN git clone --depth 1 --branch $BRANCH https://github.com/neondatabase/neon.git
-  RUN cargo build --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+  RUN cargo build --release --manifest-path neon/compute_tools/vm_monitor/Cargo.toml
   # Move binary so we can cargo clean
   RUN mkdir -p /workspace/bin && cp /workspace/neon/target/release/vm-monitor /workspace/bin
   # Cargo clean dramatically reduces the size of the image
-  RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+  RUN cargo clean --release --manifest-path neon/compute_tools/vm_monitor/Cargo.toml
 
   # Build cgroup-tools
   #

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -49,11 +49,11 @@ build: |
   ADD "https://api.github.com/repos/neondatabase/neon/commits/$BRANCH" latest_commit
 
   RUN git clone --depth 1 --branch $BRANCH https://github.com/neondatabase/neon.git
-  RUN cargo build --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+  RUN cargo build --release --manifest-path neon/compute_tools/vm_monitor/Cargo.toml
   # Move binary so we can cargo clean
   RUN mkdir -p /workspace/bin && cp /workspace/neon/target/release/vm-monitor /workspace/bin
   # Cargo clean dramatically reduces the size of the image
-  RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
+  RUN cargo clean --release --manifest-path neon/compute_tools/vm_monitor/Cargo.toml
 
   # Build the allocation tester:
   FROM alpine:3.19 AS allocate-loop-builder


### PR DESCRIPTION
https://github.com/neondatabase/neon/pull/9252 moves vm_monitor from libs/ to compute_tools/.