### PR TITLE
neonvm-controller: disable cgroup management

### DIFF
--- a/neonvm/config/controller/deployment.yaml
+++ b/neonvm/config/controller/deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - "--leader-elect"
         - "--concurrency-limit=128"
         - "--skip-update-validation-for="
-        - "--enable-container-mgr"
+        - "--disable-runner-cgroup"
         # See #775 and its links.
         # * cache.writeback=on - don't set O_DSYNC (don't flush every write)
         # * cache.direct=on    - use O_DIRECT (don't abuse host's page cache!)


### PR DESCRIPTION
neonvm-controller: change args in the deployment, add disable-runner-cgroup, drop enable-container-mgr as mutually exclusive