### PR TITLE
Release pipeline fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: vm-builder
-          path: .
+          path: vm-builder
 
       - name: download manifests
         uses: actions/download-artifact@v4
@@ -84,7 +84,7 @@ jobs:
         with:
           fail_on_unmatched_files: true
           files: |
-            vm-builder
+            vm-builder/vm-builder
             rendered_manifests/autoscale-scheduler.yaml
             rendered_manifests/autoscaler-agent.yaml
             rendered_manifests/neonvm.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,4 +95,4 @@ jobs:
             rendered_manifests/multus-aks.yaml
             rendered_manifests/multus-eks.yaml
             rendered_manifests/whereabouts.yaml
-            deploy/vmscrape.yaml
+            vmscrape.yaml


### PR DESCRIPTION
commit 5e48a1bb0c31953e077335e85419474f3067949c (HEAD -> oleg/fix-release, origin/oleg/fix-release)
Author: Oleg Vasilev <oleg@neon.tech>
Date:   Fri Oct 18 17:06:20 2024 +0200

    ci/release: reflect moving of vmscrape.yaml from deploy/ (#1117)

    This was done in the following commit:
    a2f53e32 Flatten & unify component structure (#961)

    Signed-off-by: Oleg Vasilev <oleg@neon.tech>

commit b319c0b8d2d59031b3407f53b69d65af3f562101
Author: Oleg Vasilev <oleg@neon.tech>
Date:   Fri Oct 18 16:09:08 2024 +0200

    ci/release: don't put vm-builder binary into root dir (#1117)

    Since last release, vm-builder directory was moved into root
    of the repo. Because of this, we can't download vm-builder during
    release pipeline, this name is already occupied by a dir.

    This was caused by the following commit:
    a2f53e32 Flatten & unify component structure (#961)

    Signed-off-by: Oleg Vasilev <oleg@neon.tech>