### PR TITLE
agent/revsource: fix out-of-bounds error

### DIFF
--- a/pkg/agent/core/revsource/revsource.go
+++ b/pkg/agent/core/revsource/revsource.go
@@ -64,7 +64,7 @@ func (c *RevisionSource) Observe(moment time.Time, rev vmv1.Revision) error {
 	}
 
 	idx := rev.Value - c.offset
-	if idx > int64(len(c.measurements)) {
+	if idx >= int64(len(c.measurements)) {
 		return errors.New("revision is in the future")
 	}
 


### PR DESCRIPTION
Index equal to length should also result in an early return.