### PR TITLE
ci/vm-example: fix the workflow

### DIFF
--- a/.github/workflows/vm-example.yaml
+++ b/.github/workflows/vm-example.yaml
@@ -3,6 +3,9 @@ name: vm-example
 on:
   schedule:
     - cron:  '42 4 * * 2'  # run once a week
+  pull_request:
+    paths:
+      - ".github/workflows/vm-example.yaml"
   workflow_dispatch: # adds ability to run this manually
 
 jobs:
@@ -18,6 +21,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
         timeout-minutes: 10
+
+      - name: build daemon
+        run:  make docker-build-daemon
 
       - name: build vm-builder
         run:  make bin/vm-builder


### PR DESCRIPTION
[`vm-example`](https://github.com/neondatabase/autoscaling/actions/workflows/vm-example.yaml) workflow is broken for some time due to the lack of `daemon:dev` image:
```
Step 3/39 : FROM daemon:dev AS neonvm-daemon-loader
2024/11/05 04:44:24 pull access denied for daemon, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

This PR fixes it by running `make docker-build-daemon` command in the job.