### PR TITLE
agent,plugin: Remove metrics from AgentRequests

### DIFF
--- a/pkg/agent/core/action.go
+++ b/pkg/agent/core/action.go
@@ -24,7 +24,6 @@ type ActionWait struct {
 type ActionPluginRequest struct {
 	LastPermit     *api.Resources        `json:"current"`
 	Target         api.Resources         `json:"target"`
-	Metrics        *api.Metrics          `json:"metrics"`
 	TargetRevision vmv1.RevisionWithTime `json:"targetRevision"`
 }
 
@@ -74,7 +73,6 @@ func (a ActionWait) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 func (a ActionPluginRequest) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	_ = addObjectPtr(enc, "lastPermit", a.LastPermit)
 	_ = enc.AddObject("target", a.Target)
-	_ = enc.AddReflected("metrics", a.Metrics)
 	return nil
 }
 

--- a/pkg/agent/core/metrics.go
+++ b/pkg/agent/core/metrics.go
@@ -13,8 +13,6 @@ import (
 	promtypes "github.com/prometheus/client_model/go"
 	promfmt "github.com/prometheus/common/expfmt"
 	"github.com/tychoish/fun/erc"
-
-	"github.com/neondatabase/autoscaling/pkg/api"
 )
 
 type SystemMetrics struct {
@@ -22,14 +20,6 @@ type SystemMetrics struct {
 
 	MemoryUsageBytes  float64
 	MemoryCachedBytes float64
-}
-
-func (m SystemMetrics) ToAPI() api.Metrics {
-	return api.Metrics{
-		LoadAverage1Min:  float32(m.LoadAverage1Min),
-		LoadAverage5Min:  nil,
-		MemoryUsageBytes: nil,
-	}
 }
 
 type LFCMetrics struct {

--- a/pkg/agent/core/state.go
+++ b/pkg/agent/core/state.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
@@ -443,16 +442,8 @@ func (s *state) calculatePluginAction(
 	// The rest of the complication is just around accurate logging.
 	if timeForRequest || shouldRequestNewResources {
 		return &ActionPluginRequest{
-			LastPermit: s.Plugin.Permit,
-			Target:     permittedRequestResources,
-			// convert maybe-nil '*Metrics' to maybe-nil '*core.Metrics'
-			Metrics: func() *api.Metrics {
-				if s.Metrics != nil {
-					return lo.ToPtr(s.Metrics.ToAPI())
-				} else {
-					return nil
-				}
-			}(),
+			LastPermit:     s.Plugin.Permit,
+			Target:         permittedRequestResources,
 			TargetRevision: s.TargetRevision.WithTime(now),
 		}, nil
 	} else {

--- a/pkg/agent/execbridge.go
+++ b/pkg/agent/execbridge.go
@@ -50,13 +50,12 @@ func (iface *execPluginInterface) Request(
 	logger *zap.Logger,
 	lastPermit *api.Resources,
 	target api.Resources,
-	metrics *api.Metrics,
 ) (*api.PluginResponse, error) {
 	if lastPermit != nil {
 		iface.runner.recordResourceChange(*lastPermit, target, iface.runner.global.metrics.schedulerRequestedChange)
 	}
 
-	resp, err := iface.runner.DoSchedulerRequest(ctx, logger, target, lastPermit, metrics)
+	resp, err := iface.runner.DoSchedulerRequest(ctx, logger, target, lastPermit)
 
 	if err == nil && lastPermit != nil {
 		iface.runner.recordResourceChange(*lastPermit, resp.Permit, iface.runner.global.metrics.schedulerApprovedChange)

--- a/pkg/agent/executor/exec_plugin.go
+++ b/pkg/agent/executor/exec_plugin.go
@@ -12,7 +12,7 @@ import (
 )
 
 type PluginInterface interface {
-	Request(_ context.Context, _ *zap.Logger, lastPermit *api.Resources, target api.Resources, _ *api.Metrics) (*api.PluginResponse, error)
+	Request(_ context.Context, _ *zap.Logger, lastPermit *api.Resources, target api.Resources) (*api.PluginResponse, error)
 }
 
 func (c *ExecutorCoreWithClients) DoPluginRequests(ctx context.Context, logger *zap.Logger) {
@@ -46,7 +46,7 @@ func (c *ExecutorCoreWithClients) DoPluginRequests(ctx context.Context, logger *
 			continue // state has changed, retry.
 		}
 
-		resp, err := c.clients.Plugin.Request(ctx, ifaceLogger, action.LastPermit, action.Target, action.Metrics)
+		resp, err := c.clients.Plugin.Request(ctx, ifaceLogger, action.LastPermit, action.Target)
 		endTime := time.Now()
 
 		c.update(func(state *core.State) {

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -47,7 +47,7 @@ import (
 //
 // Currently, each autoscaler-agent supports only one version at a time. In the future, this may
 // change.
-const PluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV5_0
+const PluginProtocolVersion api.PluginProtoVersion = api.PluginProtoV6_0
 
 // Runner is per-VM Pod god object responsible for handling everything
 //
@@ -754,7 +754,6 @@ func (r *Runner) DoSchedulerRequest(
 	logger *zap.Logger,
 	resources api.Resources,
 	lastPermit *api.Resources,
-	metrics *api.Metrics,
 ) (_ *api.PluginResponse, err error) {
 	reqData := &api.AgentRequest{
 		ProtoVersion: PluginProtocolVersion,
@@ -762,7 +761,6 @@ func (r *Runner) DoSchedulerRequest(
 		ComputeUnit:  r.global.config.Scaling.ComputeUnit,
 		Resources:    resources,
 		LastPermit:   lastPermit,
-		Metrics:      metrics,
 	}
 
 	// make sure we log any error we're returning:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -85,8 +85,17 @@ const (
 	//
 	// * Removed AgentRequest.metrics fields loadAvg5M and memoryUsageBytes
 	//
-	// Currently the latest version.
+	// Last used in release version v0.36.2.
 	PluginProtoV5_0
+
+	// PluginProtoV6_0 represents v6.0 of the agent<->scheduler plugin protocol.
+	//
+	// Changes from v5.0:
+	//
+	// * Removed AgentRequest.metrics
+	//
+	// Currently the latest version.
+	PluginProtoV6_0
 
 	// latestPluginProtoVersion represents the latest version of the agent<->scheduler plugin
 	// protocol
@@ -117,6 +126,8 @@ func (v PluginProtoVersion) String() string {
 		return "v4.0"
 	case PluginProtoV5_0:
 		return "v5.0"
+	case PluginProtoV6_0:
+		return "v6.0"
 	default:
 		diff := v - latestPluginProtoVersion
 		return fmt.Sprintf("<unknown = %v + %d>", latestPluginProtoVersion, diff)
@@ -202,21 +213,6 @@ type AgentRequest struct {
 	// In case of a failure, the new running scheduler uses LastPermit to recover the previous state.
 	// LastPermit may be nil.
 	LastPermit *Resources `json:"lastPermit"`
-	// Metrics provides information about the VM's current load, so that the scheduler may
-	// prioritize which pods to migrate
-	//
-	// In some protocol versions, this field may be nil.
-	Metrics *Metrics `json:"metrics"`
-}
-
-// Metrics gives the information pulled from vector.dev that the scheduler may use to prioritize
-// which pods it should migrate.
-type Metrics struct {
-	LoadAverage1Min float32 `json:"loadAvg1M"`
-	// DEPRECATED. Will be removed in an upcoming release.
-	LoadAverage5Min *float32 `json:"loadAvg5M,omitempty"`
-	// DEPRECATED. Will be removed in an upcoming release.
-	MemoryUsageBytes *float32 `json:"memoryUsageBytes,omitempty"`
 }
 
 // ProtocolRange returns a VersionRange exactly equal to r.ProtoVersion

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -231,10 +231,6 @@ func (s *podState) dump() podStateDump {
 
 func (s *vmPodState) dump() vmPodState {
 	// Copy some of the "may be nil" pointer fields
-	var metrics *api.Metrics
-	if s.Metrics != nil {
-		metrics = lo.ToPtr(*s.Metrics)
-	}
 	var migrationState *podMigrationState
 	if s.MigrationState != nil {
 		migrationState = &podMigrationState{
@@ -244,9 +240,9 @@ func (s *vmPodState) dump() vmPodState {
 
 	return vmPodState{
 		Name:           s.Name,
+		PodCreatedAt:   s.PodCreatedAt,
 		MemSlotSize:    s.MemSlotSize,
 		Config:         s.Config,
-		Metrics:        metrics,
 		MqIndex:        s.MqIndex,
 		MigrationState: migrationState,
 	}

--- a/pkg/plugin/prommetrics.go
+++ b/pkg/plugin/prommetrics.go
@@ -70,7 +70,7 @@ func (p *AutoscaleEnforcer) makePrometheusRegistry() *prometheus.Registry {
 				Name: "autoscaling_plugin_resource_requests_results_total",
 				Help: "Number of resource requests to the scheduler plugin with various results",
 			},
-			[]string{"code", "node", "has_metrics"},
+			[]string{"code", "node"},
 		)),
 		nodeCPUResources: util.RegisterMetric(reg, prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{


### PR DESCRIPTION
AFAICT is a requirement for #995 — otherwise we need to continue updating every pod regularly, which may overload etcd. In the longer term, we may wish to have the scheduler fetch its own metrics, e.g. via the metrics API [1] [2]. In the meantime, this PR implements a metric-less approach for prioritizing live migrating by preferring to migrate the older pods on a node, with the intent being that this will naturally be _somewhat_ fair so that individual VMs are not migrated too much.

[1]: https://pkg.go.dev/k8s.io/metrics
[2]: https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/

**Notes for review:** ~~This PR currently builds upon #1143 and #1144. Only the final commit in this PR (e385e408dbb72fe42a9be4829c9b921cae95aaa6) is the actual intended change here.~~

~~Also, I think the other PRs are probably more clearly worthwhile than this one~~ — I'm happy to leave this as a draft until I have something building on it.