### PR TITLE
Use 'vmv1' for neonvm API import everywhere

### DIFF
--- a/autoscaler-agent/cmd/main.go
+++ b/autoscaler-agent/cmd/main.go
@@ -13,7 +13,7 @@ import (
 	scheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	vmclient "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
 	"github.com/neondatabase/autoscaling/pkg/agent"
 	"github.com/neondatabase/autoscaling/pkg/util"
@@ -46,7 +46,7 @@ func main() {
 	if err != nil {
 		logger.Panic("Failed to make K8S client", zap.Error(err))
 	}
-	if err = vmapi.AddToScheme(scheme.Scheme); err != nil {
+	if err = vmv1.AddToScheme(scheme.Scheme); err != nil {
 		logger.Panic("Failed to add NeonVM scheme", zap.Error(err))
 	}
 

--- a/pkg/agent/billing/billing.go
+++ b/pkg/agent/billing/billing.go
@@ -10,7 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/billing"
 	"github.com/neondatabase/autoscaling/pkg/reporting"
@@ -51,7 +51,7 @@ func (m *metricsTimeSlice) Duration() time.Duration { return m.endTime.Sub(m.sta
 
 type vmMetricsInstant struct {
 	// cpu stores the cpu allocation at a particular instant.
-	cpu vmapi.MilliCPU
+	cpu vmv1.MilliCPU
 }
 
 // vmMetricsSeconds is like vmMetrics, but the values cover the allocation over time
@@ -141,11 +141,11 @@ func (s *metricsState) collect(logger *zap.Logger, store VMStoreForNode, metrics
 
 	old := s.present
 	s.present = make(map[metricsKey]vmMetricsInstant)
-	var vmsOnThisNode []*vmapi.VirtualMachine
+	var vmsOnThisNode []*vmv1.VirtualMachine
 	if store.Failing() {
 		logger.Error("VM store is currently stopped. No events will be recorded")
 	} else {
-		vmsOnThisNode = store.ListIndexed(func(i *VMNodeIndex) []*vmapi.VirtualMachine {
+		vmsOnThisNode = store.ListIndexed(func(i *VMNodeIndex) []*vmv1.VirtualMachine {
 			return i.List()
 		})
 	}

--- a/pkg/agent/billing/indexedstore.go
+++ b/pkg/agent/billing/indexedstore.go
@@ -6,11 +6,11 @@ package billing
 import (
 	"k8s.io/apimachinery/pkg/types"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/pkg/util/watch"
 )
 
-type VMStoreForNode = watch.IndexedStore[vmapi.VirtualMachine, *VMNodeIndex]
+type VMStoreForNode = watch.IndexedStore[vmv1.VirtualMachine, *VMNodeIndex]
 
 // VMNodeIndex is a watch.Index that stores all of the VMs for a particular node
 //
@@ -21,35 +21,35 @@ type VMStoreForNode = watch.IndexedStore[vmapi.VirtualMachine, *VMNodeIndex]
 // This comment in particular was particularly instructive:
 // https://github.com/kubernetes/kubernetes/issues/53459#issuecomment-1146200268
 type VMNodeIndex struct {
-	forNode map[types.UID]*vmapi.VirtualMachine
+	forNode map[types.UID]*vmv1.VirtualMachine
 	node    string
 }
 
 func NewVMNodeIndex(node string) *VMNodeIndex {
 	return &VMNodeIndex{
-		forNode: make(map[types.UID]*vmapi.VirtualMachine),
+		forNode: make(map[types.UID]*vmv1.VirtualMachine),
 		node:    node,
 	}
 }
 
-func (i *VMNodeIndex) Add(vm *vmapi.VirtualMachine) {
+func (i *VMNodeIndex) Add(vm *vmv1.VirtualMachine) {
 	if vm.Status.Node == i.node {
 		i.forNode[vm.UID] = vm
 	}
 }
 
-func (i *VMNodeIndex) Update(oldVM, newVM *vmapi.VirtualMachine) {
+func (i *VMNodeIndex) Update(oldVM, newVM *vmv1.VirtualMachine) {
 	i.Delete(oldVM)
 	i.Add(newVM)
 }
 
-func (i *VMNodeIndex) Delete(vm *vmapi.VirtualMachine) {
+func (i *VMNodeIndex) Delete(vm *vmv1.VirtualMachine) {
 	// note: delete is a no-op if the key isn't present.
 	delete(i.forNode, vm.UID)
 }
 
-func (i *VMNodeIndex) List() []*vmapi.VirtualMachine {
-	items := make([]*vmapi.VirtualMachine, 0, len(i.forNode))
+func (i *VMNodeIndex) List() []*vmv1.VirtualMachine {
+	items := make([]*vmv1.VirtualMachine, 0, len(i.forNode))
 	for _, vm := range i.forNode {
 		items = append(items, vm)
 	}

--- a/pkg/agent/billing/prommetrics.go
+++ b/pkg/agent/billing/prommetrics.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/pkg/reporting"
 )
 
@@ -74,7 +74,7 @@ type (
 	autoscalingEnabledFlag bool
 )
 
-func (b batchMetrics) inc(isEndpoint isEndpointFlag, autoscalingEnabled autoscalingEnabledFlag, phase vmapi.VmPhase) {
+func (b batchMetrics) inc(isEndpoint isEndpointFlag, autoscalingEnabled autoscalingEnabledFlag, phase vmv1.VmPhase) {
 	key := batchMetricsLabels{
 		isEndpoint:         strconv.FormatBool(bool(isEndpoint)),
 		autoscalingEnabled: strconv.FormatBool(bool(autoscalingEnabled)),

--- a/pkg/agent/core/testhelpers/construct.go
+++ b/pkg/agent/core/testhelpers/construct.go
@@ -6,7 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/pkg/agent/core"
 	"github.com/neondatabase/autoscaling/pkg/api"
 )
@@ -70,9 +70,9 @@ func CreateVmInfo(config InitialVmInfoConfig, opts ...VmInfoOpt) api.VmInfo {
 		Name:      "test",
 		Namespace: "test",
 		Cpu: api.VmCpuInfo{
-			Min: vmapi.MilliCPU(config.MinCU) * config.ComputeUnit.VCPU,
-			Use: vmapi.MilliCPU(config.MinCU) * config.ComputeUnit.VCPU,
-			Max: vmapi.MilliCPU(config.MaxCU) * config.ComputeUnit.VCPU,
+			Min: vmv1.MilliCPU(config.MinCU) * config.ComputeUnit.VCPU,
+			Use: vmv1.MilliCPU(config.MinCU) * config.ComputeUnit.VCPU,
+			Max: vmv1.MilliCPU(config.MaxCU) * config.ComputeUnit.VCPU,
 		},
 		Mem: api.VmMemInfo{
 			SlotSize: config.MemorySlotSize,
@@ -162,7 +162,7 @@ func WithCurrentCU(cu uint16) VmInfoOpt {
 	})
 }
 
-func WithCurrentRevision(rev vmapi.RevisionWithTime) VmInfoOpt {
+func WithCurrentRevision(rev vmv1.RevisionWithTime) VmInfoOpt {
 	return vmInfoModifier(func(c InitialVmInfoConfig, vm *api.VmInfo) {
 		vm.CurrentRevision = &rev
 	})

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -15,7 +15,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	vmclient "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
 	"github.com/neondatabase/autoscaling/pkg/agent/schedwatch"
 	"github.com/neondatabase/autoscaling/pkg/api"
@@ -64,9 +64,9 @@ func (r MainRunner) newAgentState(
 	return state, promReg
 }
 
-func vmIsOurResponsibility(vm *vmapi.VirtualMachine, config *Config, nodeName string) bool {
+func vmIsOurResponsibility(vm *vmv1.VirtualMachine, config *Config, nodeName string) bool {
 	return vm.Status.Node == nodeName &&
-		(vm.Status.Phase.IsAlive() && vm.Status.Phase != vmapi.VmMigrating) &&
+		(vm.Status.Phase.IsAlive() && vm.Status.Phase != vmv1.VmMigrating) &&
 		vm.Status.PodIP != "" &&
 		api.HasAutoscalingEnabled(vm) &&
 		vm.Spec.SchedulerName == config.Scheduler.SchedulerName

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -10,7 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
@@ -295,7 +295,7 @@ func (b Bytes) Format(state fmt.State, verb rune) {
 //
 // In all cases, each resource type is considered separately from the others.
 type Resources struct {
-	VCPU vmapi.MilliCPU `json:"vCPUs"`
+	VCPU vmv1.MilliCPU `json:"vCPUs"`
 	// Mem gives the number of bytes of memory requested
 	Mem Bytes `json:"mem"`
 }
@@ -376,7 +376,7 @@ func (r Resources) SaturatingSub(other Resources) Resources {
 // Mul returns the result of multiplying each resource by factor
 func (r Resources) Mul(factor uint16) Resources {
 	return Resources{
-		VCPU: vmapi.MilliCPU(factor) * r.VCPU,
+		VCPU: vmv1.MilliCPU(factor) * r.VCPU,
 		Mem:  Bytes(factor) * r.Mem,
 	}
 }
@@ -461,13 +461,13 @@ func (m MoreResources) And(cmp MoreResources) MoreResources {
 // VCPUChange is used to notify runner that it had some changes in its CPUs
 // runner uses this info to adjust qemu cgroup
 type VCPUChange struct {
-	VCPUs vmapi.MilliCPU
+	VCPUs vmv1.MilliCPU
 }
 
 // VCPUCgroup is used in runner to reply to controller
 // it represents the vCPU usage as controlled by cgroup
 type VCPUCgroup struct {
-	VCPUs vmapi.MilliCPU
+	VCPUs vmv1.MilliCPU
 }
 
 // this a similar version type for controller <-> runner communications

--- a/pkg/plugin/ARCHITECTURE.md
+++ b/pkg/plugin/ARCHITECTURE.md
@@ -113,7 +113,7 @@ resource-related types are:
 type nodeState struct {
     pods map[util.NamespacedName]*podState
 
-    cpu nodeResourceState[vmapi.MilliCPU]
+    cpu nodeResourceState[vmv1.MilliCPU]
     mem nodeResourceState[api.Bytes]
 
     // -- other fields omitted --
@@ -134,7 +134,7 @@ type podState struct {
     name util.NamespacedName
 
     // -- other fields omitted --
-    cpu podResourceState[vmapi.MilliCPU]
+    cpu podResourceState[vmv1.MilliCPU]
     mem podResourceState[api.Bytes]
 }
 

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -10,7 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/pkg/api"
 )
 
@@ -222,12 +222,12 @@ func (c *Config) ignoredNamespace(namespace string) bool {
 	return slices.Contains(c.IgnoreNamespaces, namespace)
 }
 
-func (c *nodeConfig) vCpuLimits(total *resource.Quantity) nodeResourceState[vmapi.MilliCPU] {
+func (c *nodeConfig) vCpuLimits(total *resource.Quantity) nodeResourceState[vmv1.MilliCPU] {
 	totalMilli := total.MilliValue()
 
-	return nodeResourceState[vmapi.MilliCPU]{
-		Total:                vmapi.MilliCPU(totalMilli),
-		Watermark:            vmapi.MilliCPU(c.Cpu.Watermark * float32(totalMilli)),
+	return nodeResourceState[vmv1.MilliCPU]{
+		Total:                vmv1.MilliCPU(totalMilli),
+		Watermark:            vmv1.MilliCPU(c.Cpu.Watermark * float32(totalMilli)),
 		Reserved:             0,
 		Buffer:               0,
 		CapacityPressure:     0,

--- a/pkg/plugin/dumpstate.go
+++ b/pkg/plugin/dumpstate.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
 )
@@ -103,8 +103,8 @@ type pluginStateDump struct {
 
 	Pods []podNameAndPointer `json:"pods"`
 
-	MaxTotalReservableCPU vmapi.MilliCPU `json:"maxTotalReservableCPU"`
-	MaxTotalReservableMem api.Bytes      `json:"maxTotalReservableMem"`
+	MaxTotalReservableCPU vmv1.MilliCPU `json:"maxTotalReservableCPU"`
+	MaxTotalReservableMem api.Bytes     `json:"maxTotalReservableMem"`
 
 	Conf Config `json:"config"`
 }
@@ -121,19 +121,19 @@ type nodeStateDump struct {
 	Name             string                                     `json:"name"`
 	NodeGroup        string                                     `json:"nodeGroup"`
 	AvailabilityZone string                                     `json:"availabilityZone"`
-	CPU              nodeResourceState[vmapi.MilliCPU]          `json:"cpu"`
+	CPU              nodeResourceState[vmv1.MilliCPU]           `json:"cpu"`
 	Mem              nodeResourceState[api.Bytes]               `json:"mem"`
 	Pods             []keyed[util.NamespacedName, podStateDump] `json:"pods"`
 	Mq               []*podNameAndPointer                       `json:"mq"`
 }
 
 type podStateDump struct {
-	Obj  pointerString                    `json:"obj"`
-	Name util.NamespacedName              `json:"name"`
-	Node pointerString                    `json:"node"`
-	CPU  podResourceState[vmapi.MilliCPU] `json:"cpu"`
-	Mem  podResourceState[api.Bytes]      `json:"mem"`
-	VM   *vmPodState                      `json:"vm"`
+	Obj  pointerString                   `json:"obj"`
+	Name util.NamespacedName             `json:"name"`
+	Node pointerString                   `json:"node"`
+	CPU  podResourceState[vmv1.MilliCPU] `json:"cpu"`
+	Mem  podResourceState[api.Bytes]     `json:"mem"`
+	VM   *vmPodState                     `json:"vm"`
 }
 
 func makePointerString[T any](t *T) pointerString {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -15,7 +15,7 @@ import (
 	rest "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	vmclient "github.com/neondatabase/autoscaling/neonvm/client/clientset/versioned"
 	"github.com/neondatabase/autoscaling/pkg/api"
 	"github.com/neondatabase/autoscaling/pkg/util"
@@ -43,7 +43,7 @@ type AutoscaleEnforcer struct {
 
 // abbreviations, because these types are pretty verbose
 type (
-	IndexedVMStore   = watch.IndexedStore[vmapi.VirtualMachine, *watch.NameIndex[vmapi.VirtualMachine]]
+	IndexedVMStore   = watch.IndexedStore[vmv1.VirtualMachine, *watch.NameIndex[vmv1.VirtualMachine]]
 	IndexedNodeStore = watch.IndexedStore[corev1.Node, *watch.FlatNameIndex[corev1.Node]]
 )
 
@@ -77,7 +77,7 @@ func makeAutoscaleEnforcerPlugin(
 	logger.Info("Initializing plugin")
 
 	// create the NeonVM client
-	if err := vmapi.AddToScheme(scheme.Scheme); err != nil {
+	if err := vmv1.AddToScheme(scheme.Scheme); err != nil {
 		return nil, err
 	}
 	vmConfig := rest.CopyConfig(h.KubeConfig())
@@ -190,7 +190,7 @@ func makeAutoscaleEnforcerPlugin(
 		},
 	}
 	mwc := migrationWatchCallbacks{
-		submitMigrationFinished: func(vmm *vmapi.VirtualMachineMigration) {
+		submitMigrationFinished: func(vmm *vmv1.VirtualMachineMigration) {
 			// When cleaning up migrations, we don't want to process those events synchronously.
 			// So instead, we'll spawn a goroutine to delete the completed migration.
 			go p.cleanupMigration(hlogger, vmm)

--- a/pkg/plugin/run.go
+++ b/pkg/plugin/run.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tychoish/fun/srv"
 	"go.uber.org/zap"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/pkg/api"
 )
 
@@ -290,7 +290,7 @@ func (e *AutoscaleEnforcer) handleResources(
 	}
 	memFactor := cu.Mem
 
-	var lastCPUPermit *vmapi.MilliCPU
+	var lastCPUPermit *vmv1.MilliCPU
 	var lastMemPermit *api.Bytes
 	if lastPermit != nil {
 		lastCPUPermit = &lastPermit.VCPU

--- a/pkg/util/vmlogfield.go
+++ b/pkg/util/vmlogfield.go
@@ -8,7 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	vmapi "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 )
 
 type nameFields struct {
@@ -27,7 +27,7 @@ func (f nameFields) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-func VMNameFields(vm *vmapi.VirtualMachine) zap.Field {
+func VMNameFields(vm *vmv1.VirtualMachine) zap.Field {
 	vmName := GetNamespacedName(vm)
 
 	// If the VM has a pod, log both the VM and the pod, otherwise just the VM.
@@ -46,7 +46,7 @@ func VMNameFields(vm *vmapi.VirtualMachine) zap.Field {
 func PodNameFields(pod *corev1.Pod) zap.Field {
 	podName := GetNamespacedName(pod)
 
-	if vmName, ok := pod.Labels[vmapi.VirtualMachineNameLabel]; ok {
+	if vmName, ok := pod.Labels[vmv1.VirtualMachineNameLabel]; ok {
 		vmName := NamespacedName{Namespace: pod.Namespace, Name: vmName}
 
 		return zap.Inline(nameFields{


### PR DESCRIPTION
Within neonvm-controller, we're consistently using `vmv1` to refer to the `.../apis/neonvm/v1` import, but elsewhere we're using `vmapi` instead.

`vmv1` is closer to the typical kubernetes imports like `corev1` and `metav1`, even if it doesn't exactly match the import path.

---

**Notes for review:** Low priority, been on my todo list for a while and I figured that #995 was a good enough excuse to do it. Also, this is probably a good candidate to add to `.git-blame-ignore-revs` after merging, because otherwise it's a lot of noise.

<!-- affects all -->