### PR TITLE
vxlan-controller: fix hardcoded urls to use TARGET_ARCH

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -64,6 +64,8 @@ env:
   # Otherwise, if we just try to use a local image, it fails trying to pull it from dockerhub.
   # See https://github.com/moby/buildkit/issues/2343 for more information.
   GO_BASE_IMG: "localhost:5000/neondatabase/autoscaling-go-base:dev"
+  # Default architecture to build. In future it would be changed to multi-arch build or separate builds for each arch
+  TARGET_ARCH: "amd64"
 
 defaults:
   run:
@@ -262,6 +264,7 @@ jobs:
           tags: ${{ needs.tags.outputs.vxlan-controller }}
           build-args: |
             GO_BASE_IMG=${{ env.GO_BASE_IMG }}
+            TARGET_ARCH=${{ env.TARGET_ARCH }}
 
       - name: Build and push autoscale-scheduler image
         uses: docker/build-push-action@v6

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ docker-build-vxlan-controller: docker-build-go-base ## Build docker image for Ne
 	docker build \
 		--tag $(IMG_VXLAN_CONTROLLER) \
 		--build-arg GO_BASE_IMG=$(GO_BASE_IMG) \
+		--build-arg TARGET_ARCH=$(TARGET_ARCH) \
 		--file neonvm-vxlan-controller/Dockerfile \
 		.
 

--- a/neonvm-vxlan-controller/Dockerfile
+++ b/neonvm-vxlan-controller/Dockerfile
@@ -6,6 +6,9 @@ RUN CGO_ENABLED=0 go build -o /vxlan-controller neonvm-vxlan-controller/cmd/*.go
 
 FROM alpine:3.19
 
+ARG TARGET_ARCH
+ENV TARGET_ARCH=$TARGET_ARCH
+
 RUN apk add --no-cache \
     tini \
     dnsmasq \
@@ -14,13 +17,13 @@ RUN apk add --no-cache \
 
 # add CNI plugins
 RUN set -e \
-    && wget -q https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-amd64-v1.2.0.tgz -O cni.tgz \
+    && wget -q https://github.com/containernetworking/plugins/releases/download/v1.2.0/cni-plugins-linux-$TARGET_ARCH-v1.2.0.tgz -O cni.tgz \
     && mkdir -p /opt/cni/bin \
     && tar -xzf cni.tgz -C /opt/cni/bin \
     && rm -f cni.tgz
 
 RUN set -e \
-    && wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/latest/download/grpc_health_probe-linux-amd64 -O /usr/bin/grpc_health_probe \
+    && wget -q https://github.com/grpc-ecosystem/grpc-health-probe/releases/latest/download/grpc_health_probe-linux-$TARGET_ARCH -O /usr/bin/grpc_health_probe \
     && chmod +x /usr/bin/grpc_health_probe
 
 COPY --from=builder /vxlan-controller /usr/bin/vxlan-controller


### PR DESCRIPTION
Download target-specific binary to work as multiplatform image. Related to #850 