### PR TITLE
tests,examples: Bump Rust 1.79 -> 1.83

### DIFF
--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -51,7 +51,7 @@ files:
 
 build: |
   # Build vm-monitor
-  FROM rust:1.79-alpine AS monitor-builder
+  FROM rust:1.83-alpine AS monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -36,7 +36,7 @@ files:
     hostPath: cgconfig.conf
 build: |
   # Build vm-monitor
-  FROM rust:1.79-alpine AS monitor-builder
+  FROM rust:1.83-alpine AS monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev


### PR DESCRIPTION
We haven't updated in a while, 1.83 was recently released, and we should keep up-to-date with `neondatabase/neon` so that vm-monitor in CI continues to work as expected.

See also neondatabase/neon#9926

---

~~**Edit:** Seems like the 1.83 images aren't on dockerhub yet? Leaving this until then.~~