### PR TITLE
neonvm-daemon: Use go-chef in Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ docker-build-runner: docker-build-go-base ## Build docker image for NeonVM runne
 		.
 
 .PHONY: docker-build-daemon
-docker-build-daemon: ## Build docker image for NeonVM daemon.
+docker-build-daemon: docker-build-go-base ## Build docker image for NeonVM daemon.
 	docker build \
 		--tag $(IMG_DAEMON) \
 		--file neonvm-daemon/Dockerfile \

--- a/neonvm-daemon/Dockerfile
+++ b/neonvm-daemon/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.23-alpine AS builder
+ARG GO_BASE_IMG=autoscaling-go-base:dev
+FROM $GO_BASE_IMG AS builder
 
 # Build the Go binary
 COPY . .


### PR DESCRIPTION
Probably an inadvertent merge conflict between #1090 and #989 meaning we accidentally weren't using go-chef for neonvm-daemon.

Noticed this while working on #1163 locally and saw that it was re-downloading all of the dependencies for neonvm-daemon every time, even though I was making changes in the scheduler and the dependencies hadn't changed.