### PR TITLE
neonvm: Bump max mem slots to 512

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -413,15 +413,15 @@ func (m MilliCPU) Format(state fmt.State, verb rune) {
 
 type MemorySlots struct {
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=128
+	// +kubebuilder:validation:Maximum=512
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	Min int32 `json:"min"`
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=128
+	// +kubebuilder:validation:Maximum=512
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	Max int32 `json:"max"`
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=128
+	// +kubebuilder:validation:Maximum=512
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	Use int32 `json:"use"`
 }

--- a/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -2600,17 +2600,17 @@ spec:
                     properties:
                       max:
                         format: int32
-                        maximum: 128
+                        maximum: 512
                         minimum: 1
                         type: integer
                       min:
                         format: int32
-                        maximum: 128
+                        maximum: 512
                         minimum: 1
                         type: integer
                       use:
                         format: int32
-                        maximum: 128
+                        maximum: 512
                         minimum: 1
                         type: integer
                     required:


### PR DESCRIPTION
In practice this is limiting the maximum size of our computes, even though memory slots aren't physically used since we switched to virtio-mem.

ref neondatabase/cloud#18281