### PR TITLE
ci/build-images: Don't push neonvm-daemon to ECR

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -331,7 +331,6 @@ jobs:
             neonvm-controller \
             neonvm-vxlan-controller \
             neonvm-runner \
-            neonvm-daemon \
             vm-kernel \
             autoscale-scheduler \
             autoscaler-agent \


### PR DESCRIPTION
It's causing the release workflow to fail ([link](https://github.com/neondatabase/autoscaling/actions/runs/12207391166/job/34058771593)), and at this point it's not necessary because the neonvm-daemon image is only needed when running vm-builder to build VM images (rather than e.g., being required at runtime).

Follow-up to #1168.