### PR TITLE
agent/billing: reset metrics right before setting it

### DIFF
--- a/pkg/agent/billing/prommetrics.go
+++ b/pkg/agent/billing/prommetrics.go
@@ -59,8 +59,6 @@ type batchMetricsLabels struct {
 }
 
 func (m PromMetrics) forBatch() batchMetrics {
-	m.vmsCurrent.Reset()
-
 	return batchMetrics{
 		total: make(map[batchMetricsLabels]int),
 
@@ -88,6 +86,8 @@ func (b batchMetrics) inc(isEndpoint isEndpointFlag, autoscalingEnabled autoscal
 }
 
 func (b batchMetrics) finish() {
+	b.vmsCurrent.Reset()
+
 	for key, count := range b.total {
 		b.vmsCurrent.WithLabelValues(key.isEndpoint, key.autoscalingEnabled, key.phase).Set(float64(count))
 	}


### PR DESCRIPTION
Right now we sometimes see gaps in metrics, which can be explained by too much time between Reset() and the next Set().

See example: https://neondb.slack.com/archives/C03TN5G758R/p1731596259801509