### PR TITLE
make generate: Remove generated files beforehand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ help: ## Display this help.
 generate: ## Generate boilerplate DeepCopy methods, manifests, and Go client
 	# Use uid and gid of current user to avoid mismatched permissions
 	set -e ; \
+	rm -rf neonvm/client neonvm/apis/neonvm/v1/zz_generated.deepcopy.go
 	iidfile=$$(mktemp /tmp/iid-XXXXXX) ; \
 	docker build \
 		--build-arg USER_ID=$(shell id -u $(USER)) \


### PR DESCRIPTION
Spawned out of conversation with @edude03 for #1158 — basically, it's hard to be sure that updates to controller-gen are working correctly, so making sure that all old files are removed before re-generating can help provide assurances that all files continue to be generated after a change.