### PR TITLE
neonvm: mv root disk from init container, not cp

### DIFF
--- a/pkg/neonvm/controllers/vm_controller.go
+++ b/pkg/neonvm/controllers/vm_controller.go
@@ -1321,7 +1321,7 @@ func podSpec(
 					}},
 					Command: []string{
 						"sh", "-c",
-						"cp /disk.qcow2 /vm/images/rootdisk.qcow2 && " +
+						"mv /disk.qcow2 /vm/images/rootdisk.qcow2 && " +
 							/* uid=36(qemu) gid=34(kvm) groups=34(kvm) */
 							"chown 36:34 /vm/images/rootdisk.qcow2 && " +
 							"sysctl -w net.ipv4.ip_forward=1",


### PR DESCRIPTION
This commit is relatively straightforward: In the neonvm-runner init container, switch from copying the root disk into `/vm/images` to *moving* it there.

Copying necessarily causes a lot of disk writes, but moving may not. If the init container's `disk.qcow2` is on the same underlying filesystem as the `/vm/images` volume, then the kernel MAY do the move very efficiently.

To be clear: I'm not totally sure whether this will help — it may be that moving files out of an overlayfs still requires copying. But if it helps, it could dramatically reduce our disk IO usage when many computes are started at once. And even if it doesn't help, it's probably a better default to move instead of copying.