### PR TITLE
golangci-lint: Bump v1.60.3 -> v1.62.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and
           # should be specified with patch version.
-          version: v1.60.3
+          version: v1.62.2
           args: --timeout 5m
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Extracted from #1163, where `gci` incorrectly groups the `"iter"` import away from other stdlib pacakges, because it was only added in Go 1.23.