### PR TITLE
neonvm: Small changes for stateless scheduler

### DIFF
--- a/neonvm/apis/neonvm/v1/pod_helpers.go
+++ b/neonvm/apis/neonvm/v1/pod_helpers.go
@@ -1,0 +1,62 @@
+package v1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// VirtualMachineOwnerForPod returns the OwnerReference for the VirtualMachine that owns the pod, if
+// there is one.
+//
+// When a live migration is ongoing, only the source Pod will be marked as owned by the
+// VirtualMachine.
+func VirtualMachineOwnerForPod(pod *corev1.Pod) (_ metav1.OwnerReference, ok bool) {
+	gv := SchemeGroupVersion.String()
+
+	for _, ref := range pod.OwnerReferences {
+		if ref.APIVersion == gv && ref.Kind == "VirtualMachine" {
+			return ref, true
+		}
+	}
+
+	var empty metav1.OwnerReference
+	return empty, false
+}
+
+// MigrationRole represents the role that a Pod is taking during a live migration -- either the
+// source or target of the migration.
+type MigrationRole string
+
+const (
+	MigrationRoleSource MigrationRole = "source"
+	MigrationRoleTarget MigrationRole = "target"
+)
+
+// MigrationOwnerForPod returns the OwnerReference for the live migration that this Pod is a part
+// of, if there is one ongoing.
+//
+// The MigrationRole returned also indicates whether the Pod is the source or the target of the
+// migration.
+func MigrationOwnerForPod(pod *corev1.Pod) (metav1.OwnerReference, MigrationRole, bool) {
+	gv := SchemeGroupVersion.String()
+
+	for _, ref := range pod.OwnerReferences {
+		if ref.APIVersion == gv && ref.Kind == "VirtualMachineMigration" {
+			var role MigrationRole
+			if ref.Controller != nil && *ref.Controller {
+				// the migration only ever "controls" the target pod. When the migration is ongoing,
+				// the virtual machine controls the source, and when it's over, the migration stops
+				// owning the target and transfers "control" to the virtual machine object, while
+				// keeping the source pod as a non-controlling reference.
+				role = MigrationRoleTarget
+			} else {
+				role = MigrationRoleSource
+			}
+
+			return ref, role, true
+		}
+	}
+
+	var emptyRef metav1.OwnerReference
+	return emptyRef, "", false
+}

--- a/pkg/neonvm/controllers/vm_controller.go
+++ b/pkg/neonvm/controllers/vm_controller.go
@@ -469,6 +469,13 @@ func (r *VMReconciler) doReconcile(ctx context.Context, vm *vmv1.VirtualMachine)
 			log.Error(err, "Failed to get vm-runner Pod")
 			return err
 		}
+
+		// Update the metadata (including "usage" annotation) before anything else, so that it
+		// will be correctly set even if the rest of the reconcile operation fails.
+		if err := updatePodMetadataIfNecessary(ctx, r.Client, vm, vmRunner); err != nil {
+			log.Error(err, "Failed to sync pod labels and annotations", "VirtualMachine", vm.Name)
+		}
+
 		// runner pod found, check phase
 		switch runnerStatus(vmRunner) {
 		case runnerRunning:

--- a/pkg/util/k8s.go
+++ b/pkg/util/k8s.go
@@ -3,9 +3,9 @@ package util
 // Kubernetes-specific utility functions
 
 import (
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
+
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 )
 
 // PodReady returns true iff the pod is marked as ready (as determined by the pod's
@@ -74,35 +74,24 @@ func PodPreferredAZIfPresent(pod *corev1.Pod) string {
 // TryPodOwnerVirtualMachine returns the name of the VirtualMachine that owns the pod, if there is
 // one that does. Otherwise returns nil.
 func TryPodOwnerVirtualMachine(pod *corev1.Pod) *NamespacedName {
-	for _, ref := range pod.OwnerReferences {
-		// For NeonVM, *at time of writing*, the OwnerReference has an APIVersion of
-		// "vm.neon.tech/v1". But:
-		//
-		// 1. It's good to be extra-safe around possible name collisions for the
-		//    "VirtualMachineMigration" name, even though *practically* it's not going to happen;
-		// 2. We can disambiguate with the APIVersion; and
-		// 3. We don't want to match on a fixed version, in case we want to change the version
-		//    number later.
-		//
-		// So, given that the format is "<NAME>/<VERSION>", we can just match on the "<NAME>/" part
-		// of the APIVersion to have the safety we want with the flexibility we need.
-		if strings.HasPrefix(ref.APIVersion, "vm.neon.tech/") && ref.Kind == "VirtualMachine" {
-			// note: OwnerReferences are not permitted to have a different namespace than the owned
-			// object, so because VirtualMachineMigrations are namespaced, it must have the same
-			// namespace as the Pod.
-			return &NamespacedName{Namespace: pod.Namespace, Name: ref.Name}
-		}
+	ref, ok := vmv1.VirtualMachineOwnerForPod(pod)
+	if !ok {
+		return nil
 	}
-	return nil
+
+	// note: OwnerReferences are not permitted to have a different namespace than the owned
+	// object, so because VirtualMachineMigrations are namespaced, it must have the same
+	// namespace as the Pod.
+	return &NamespacedName{Namespace: pod.Namespace, Name: ref.Name}
 }
 
 // TryPodOwnerVirtualMachineMigration returns the name of the VirtualMachineMigration that owns the
 // pod, if there is one. Otherwise returns nil.
 func TryPodOwnerVirtualMachineMigration(pod *corev1.Pod) *NamespacedName {
-	for _, ref := range pod.OwnerReferences {
-		if strings.HasPrefix(ref.APIVersion, "vm.neon.tech/") && ref.Kind == "VirtualMachineMigration" {
-			return &NamespacedName{Namespace: pod.Namespace, Name: ref.Name}
-		}
+	ref, _, ok := vmv1.MigrationOwnerForPod(pod)
+	if !ok {
+		return nil
 	}
-	return nil
+
+	return &NamespacedName{Namespace: pod.Namespace, Name: ref.Name}
 }


### PR DESCRIPTION
Extracted out of #1163, as suggested by https://github.com/neondatabase/autoscaling/pull/1163#discussion_r1890406226 and https://github.com/neondatabase/autoscaling/pull/1163#issuecomment-2556855781.

These are _mostly_ three unrelated commits among the broader theme of making stronger guarantees about what the Pods look like.

I'm intending to merge via rebase-and-merge to keep these commits separate.