### PR TITLE
Give multus a non expiring token

### DIFF
--- a/neonvm/config/multus-aks/kustomization.yaml
+++ b/neonvm/config/multus-aks/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 bases:
 - ../multus-common
 
+resources:
+  - secret.yaml
+
 images:
 - name: multus-cni
   newName: ghcr.io/k8snetworkplumbingwg/multus-cni
@@ -25,4 +28,23 @@ patches:
         - "--multus-master-cni-file-name=10-azure.conflist"
         - "--multus-log-level=error"
         - "--multus-log-file=/var/log/neon-multus.log"
-
+- target:
+    kind: DaemonSet
+    name: kube-multus-ds
+  patch: |-
+    - op: remove
+      path: /spec/template/spec/serviceAccountName
+    - op: add
+      path: /spec/template/spec/automountServiceAccountToken
+      value: false
+    - op: add
+      path: /spec/template/spec/volumes/-
+      value:
+        name: secret
+        secret:
+          secretName: multus-long-lived
+    - op: add
+      path: /spec/template/spec/containers/0/volumeMounts/-
+      value:
+        name: secret
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount/

--- a/neonvm/config/multus-aks/secret.yaml
+++ b/neonvm/config/multus-aks/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: multus-long-lived
+  annotations:
+    kubernetes.io/service-account.name: multus


### PR DESCRIPTION
<!-- affects all -->

TL;DR [uses this](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#create-token) to give multus a token that won't expire - therefore, preventing the issue with its token expiring. 

Essentially, we manually create a token, then mount it where the automatically created token would normally be, and everything works as expected (AFAICT, but pods are being scheduled and multus still works after an hour - so a win is a win)

Long story I'm writing up as to why this is needed and what we should really do about it. 