### PR TITLE
Specify namespace so secret is applied in the right place

### DIFF
--- a/neonvm/config/multus-aks/secret.yaml
+++ b/neonvm/config/multus-aks/secret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/service-account-token
+namespace: kube-system
 metadata:
   name: multus-long-lived
   annotations:


### PR DESCRIPTION
<!-- affects all -->
Small fixup for https://github.com/neondatabase/autoscaling/pull/1201 - I realized that when testing I was in the `kube-system` namespace already, but when applying the patch normally with `kustomize` it would create the secret in the `default` namespace. 

It's fixed in production, but not in the repo.