### PR TITLE
Introduce neonvm-guest, for running payload in a container in the VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ else ifdef USER
 else
   CLUSTER_NAME = neonvm
 endif
+CLUSTER_NAME=neon-local
+
 
 .PHONY: all
 all: build lint
@@ -420,7 +422,7 @@ k3d-load: k3d # Push docker images to the k3d cluster.
 		$(IMG_VXLAN_CONTROLLER) \
 		$(IMG_SCHEDULER) \
 		$(IMG_AUTOSCALER_AGENT) \
-		--cluster $(CLUSTER_NAME) --mode direct
+		--cluster $(CLUSTER_NAME)
 
 ##@ End-to-End tests
 

--- a/README-NeonVM.md
+++ b/README-NeonVM.md
@@ -58,6 +58,22 @@ kubectl exec -it $(kubectl get neonvm vm-debian -ojsonpath='{.status.podName}') 
 
 #### Pseudoterminal
 
+The VM has two serials:
+
+amd64:
+/dev/ttyS0 : for console login, we run getty on it
+/dev/ttyS1 : for log output, goes to QEMU stdout, and on to the kubernetes log in the host
+
+console=/dev/ttyS1 is passed on the command line
+
+arm64:
+/dev/ttyAMA0 : for console login
+/dev/hvc0 : for log output, goes to QEMU stdout, and on to the kubernetes log in the host
+
+console=/dev/hvc0 is passed on the command line
+
+
+
 ```console
 kubectl exec -it $(kubectl get neonvm vm-debian -ojsonpath='{.status.podName}') -- screen /dev/pts/0
 

--- a/neonvm-runner/Dockerfile
+++ b/neonvm-runner/Dockerfile
@@ -1,5 +1,133 @@
 ARG GO_BASE_IMG=autoscaling-go-base:dev
-FROM $GO_BASE_IMG AS builder
+ARG IMG_DAEMON=daemon:dev
+
+FROM $IMG_DAEMON AS neonvm-daemon-loader
+
+#########################################################################################
+#
+# neonvm-guest: Build 'vector' into /neonvm/bin in layer 'vector-build'
+#
+#########################################################################################
+FROM debian:bookworm-slim AS vector-build
+# Temporarily
+RUN apt update
+RUN apt install --no-install-recommends --no-install-suggests -y \
+  ca-certificates \
+  wget
+
+# Install vector.dev binary
+RUN mkdir -p /neonvm/bin
+RUN set -e \
+    && ARCH=$( [ "$TARGET_ARCH" = "linux/arm64" ] && echo "aarch64" || echo "x86_64") \
+    && wget https://packages.timber.io/vector/0.26.0/vector-${ARCH}-unknown-linux-musl.tar.gz -O - \
+    | tar xzvf - --strip-components 3 -C /neonvm/bin/ ./vector-${ARCH}-unknown-linux-musl/bin/vector
+
+#########################################################################################
+#
+# neonvm-guest: Build final layer
+#
+#########################################################################################
+
+FROM debian:bookworm-slim AS neonvm-guest-rootfs
+
+# Temporarily
+RUN apt update
+RUN apt install --no-install-recommends --no-install-suggests -y \
+    systemd \
+    cgroup-tools \
+    chrony \
+    openssh-server \
+    quota \
+    systemd-container \
+    systemd-sysv \
+    udev
+
+# Convenience
+RUN apt install --no-install-recommends --no-install-suggests -y \
+    nano \
+    less
+
+# FIXME: on arm it's different tty
+COPY neonvm-runner/neonvm-guest/files/serial-getty-autologin.conf /etc/systemd/system/serial-getty@ttyS0.service.d/autologin.conf
+RUN systemctl enable   serial-getty@ttyS0.service
+
+COPY neonvm-runner/neonvm-guest/files/50-dhcp.network /etc/systemd/network/
+RUN systemctl enable systemd-networkd.service
+
+# udev rule for auto-online hotplugged CPUs
+COPY neonvm-runner/neonvm-guest/files/99-hotplug-cpu.rules /lib/udev/rules.d/99-hotplug-cpu.rules
+
+RUN useradd vector
+COPY --from=vector-build /neonvm/ /neonvm/
+RUN mkdir /etc/vector
+COPY neonvm-runner/neonvm-guest/files/vector.yaml /etc/vector/vector.yaml
+COPY neonvm-runner/neonvm-guest/files/vector.service /etc/systemd/system/vector.service
+RUN systemctl enable vector
+
+COPY --from=neonvm-daemon-loader /neonvmd /neonvm/bin/neonvmd
+COPY neonvm-runner/neonvm-guest/files/neonvmd.service /etc/systemd/system
+RUN systemctl enable neonvmd.service
+
+# FIXME: the default debian config configures to use debian's pool. Disable it?
+COPY neonvm-runner/neonvm-guest/files/chrony.conf /etc/chrony/conf.d/neonvm-chrony.conf
+
+COPY neonvm-runner/neonvm-guest/files/mnt-ssh.mount /etc/systemd/system/
+# FIXME: or should we replace the config wholesale?
+COPY neonvm-runner/neonvm-guest/files/sshd_config /etc/ssh/sshd_config.d/neonvm-sshd.conf
+COPY neonvm-runner/neonvm-guest/files/neonvm-banner /etc/ssh/neonvm-banner
+RUN systemctl enable ssh mnt-ssh.mount
+
+# Mount runtime image under /neonvm/runtime. It contains configuration files, generated
+# dynamically by neonvm-runner
+COPY neonvm-runner/neonvm-guest/files/neonvm-runtime.mount /etc/systemd/system/
+RUN systemctl enable neonvm-runtime.mount
+
+# Disable services we don't need
+RUN systemctl disable \
+    dpkg-db-backup.timer \
+    e2scrub_all.timer \
+    systemd-tmpfiles-clean.timer \
+    apt-daily.timer \
+    apt-daily-upgrade.timer
+
+# This is where machinectl looks for images
+RUN ln -s /neonvm/payload /var/lib/machines/neonvm-payload
+COPY neonvm-runner/neonvm-guest/files/neonvm-payload.mount /etc/systemd/system/
+
+COPY neonvm-runner/neonvm-guest/files/neonvm-payload-10-netns.conf /etc/systemd/system/systemd-nspawn@neonvm-payload.service.d/10-netns.conf
+COPY neonvm-runner/neonvm-guest/files/neonvm-payload.nspawn /etc/systemd/nspawn/neonvm-payload.nspawn
+RUN systemctl enable neonvm-payload.mount
+RUN systemctl enable systemd-nspawn@neonvm-payload
+
+
+#########################################################################################
+#
+# neonvm-guest: Build QCOW2 layer
+#
+#########################################################################################
+
+FROM debian:bookworm-slim AS neonvm-guest-qcow2-img
+ARG DISK_SIZE=2G
+
+# tools for qemu disk creation
+RUN apt update
+RUN apt install --no-install-recommends --no-install-suggests -y \
+    qemu-utils \
+    e2fsprogs
+
+COPY --from=neonvm-guest-rootfs / /rootdisk/
+
+RUN set -e \
+    && mkfs.ext4 -L neonvm-guest -d /rootdisk /disk.raw ${DISK_SIZE} \
+    && qemu-img convert -f raw -O qcow2 -o cluster_size=2M,lazy_refcounts=on /disk.raw /neonvm-guest.qcow2
+
+
+#########################################################################################
+#
+# Build the final 'neonvm-runner' image
+#
+#########################################################################################
+FROM $GO_BASE_IMG AS neonvm-runner-builder
 
 COPY . .
 # Build
@@ -26,10 +154,12 @@ RUN apk add --no-cache \
     openssh
 
 
-COPY --from=builder /runner /usr/bin/runner
+COPY --from=neonvm-runner-builder /runner /usr/bin/runner
 COPY neonvm-kernel/vmlinuz /vm/kernel/vmlinuz
 COPY neonvm-runner/ssh_config /etc/ssh/ssh_config
 # QEMU_EFI used only by runner running on the arm architecture
 RUN wget https://releases.linaro.org/components/kernel/uefi-linaro/16.02/release/qemu64/QEMU_EFI.fd -O /vm/QEMU_EFI_ARM.fd
+
+COPY --from=neonvm-guest-qcow2-img /neonvm-guest.qcow2 /
 
 ENTRYPOINT ["/sbin/tini", "--", "runner"]

--- a/neonvm-runner/cmd/disks.go
+++ b/neonvm-runner/cmd/disks.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/alessio/shellescape"
@@ -21,7 +22,16 @@ import (
 )
 
 const (
+	// In the new system, neonvm-runner launches the 'neonvm-guest' disk in
+	// the VM, and the payload comes in a different image, 'neonvm-payload'.
+	guestDiskPath   = "/neonvm-guest.qcow2"
+	payloadDiskPath = "/vm/images/neonvm-payload.qcow2"
+
+	// In the old system, the 'rootdisk' is mounted directly as the root
+	// filesystem. The basic neonvm guest services are built into the rootdisk
+	// image directly, by vm-builder.
 	rootDiskPath    = "/vm/images/rootdisk.qcow2"
+
 	runtimeDiskPath = "/vm/images/runtime.iso"
 	mountedDiskPath = "/vm/images"
 
@@ -31,9 +41,26 @@ const (
 	swapName = "swapdisk"
 )
 
+// Should we use 'neonvm-guest' to launch the payload?
+func shouldUseNeonVMGuest(logger *zap.Logger) (bool, error) {
+	_, err := os.Stat(payloadDiskPath);
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			logger.Info(fmt.Sprintf("neonvm-payload.qcow2 does not exist, using legacy rootdisk.qcow2"))
+			return false, nil
+		} else {
+			return false, err
+		}
+	} else {
+		logger.Info(fmt.Sprintf("using neonvm-payload.qcow2"))
+		return true, nil
+	}
+}
+
 // setupVMDisks creates the disks for the VM and returns the appropriate QEMU args
 func setupVMDisks(
 	logger *zap.Logger,
+	useNeonVMGuest bool,
 	diskCacheSettings string,
 	enableSSH bool,
 	swapSize *resource.Quantity,
@@ -41,7 +68,13 @@ func setupVMDisks(
 ) ([]string, error) {
 	var qemuCmd []string
 
-	qemuCmd = append(qemuCmd, "-drive", fmt.Sprintf("id=rootdisk,file=%s,if=virtio,media=disk,index=0,%s", rootDiskPath, diskCacheSettings))
+	if !useNeonVMGuest {
+		qemuCmd = append(qemuCmd, "-drive", fmt.Sprintf("id=rootdisk,file=%s,if=virtio,media=disk,index=0,%s", rootDiskPath, diskCacheSettings))
+	} else {
+		qemuCmd = append(qemuCmd, "-drive", fmt.Sprintf("id=neonvm-guest,file=%s,if=virtio,media=disk,index=0,%s", guestDiskPath, diskCacheSettings))
+		qemuCmd = append(qemuCmd, "-drive", fmt.Sprintf("id=neonvm-payload,file=%s,if=virtio,media=disk,index=1,%s", payloadDiskPath, diskCacheSettings))
+	}
+
 	qemuCmd = append(qemuCmd, "-drive", fmt.Sprintf("id=runtime,file=%s,if=virtio,media=cdrom,readonly=on,cache=none", runtimeDiskPath))
 
 	if enableSSH {
@@ -90,13 +123,13 @@ func setupVMDisks(
 	return qemuCmd, nil
 }
 
-func resizeRootDisk(logger *zap.Logger, vmSpec *vmv1.VirtualMachineSpec) error {
-	// resize rootDisk image of size specified and new size more than current
+// resize disk image at diskPath to specified targetSize (unless it's already larger)
+func resizeDisk(logger *zap.Logger, diskPath string, targetSize resource.Quantity) error {
 	type QemuImgOutputPartial struct {
 		VirtualSize int64 `json:"virtual-size"`
 	}
-	// get current disk size by qemu-img info command
-	qemuImgOut, err := exec.Command(qemuImgBin, "info", "--output=json", rootDiskPath).Output()
+	// get current size by qemu-img info command
+	qemuImgOut, err := exec.Command(qemuImgBin, "info", "--output=json", diskPath).Output()
 	if err != nil {
 		return fmt.Errorf("could not get root image size: %w", err)
 	}
@@ -107,17 +140,25 @@ func resizeRootDisk(logger *zap.Logger, vmSpec *vmv1.VirtualMachineSpec) error {
 	imageSizeQuantity := resource.NewQuantity(imageSize.VirtualSize, resource.BinarySI)
 
 	// going to resize
-	if !vmSpec.Guest.RootDisk.Size.IsZero() {
-		if vmSpec.Guest.RootDisk.Size.Cmp(*imageSizeQuantity) == 1 {
-			logger.Info(fmt.Sprintf("resizing rootDisk from %s to %s", imageSizeQuantity.String(), vmSpec.Guest.RootDisk.Size.String()))
-			if err := execFg(qemuImgBin, "resize", rootDiskPath, fmt.Sprintf("%d", vmSpec.Guest.RootDisk.Size.Value())); err != nil {
+	if !targetSize.IsZero() {
+		if targetSize.Cmp(*imageSizeQuantity) == 1 {
+			logger.Info(fmt.Sprintf("resizing %s from %s to %s", diskPath, imageSizeQuantity.String(), targetSize.String()))
+			if err := execFg(qemuImgBin, "resize", diskPath, fmt.Sprintf("%d", targetSize.Value())); err != nil {
 				return fmt.Errorf("failed to resize rootDisk: %w", err)
 			}
 		} else {
-			logger.Info(fmt.Sprintf("rootDisk.size (%s) is less than than image size (%s)", vmSpec.Guest.RootDisk.Size.String(), imageSizeQuantity.String()))
+			logger.Info(fmt.Sprintf("targetSize (%s) is less than than image size (%s)", targetSize.String(), imageSizeQuantity.String()))
 		}
 	}
 	return nil
+}
+
+func resizeRootDisk(logger *zap.Logger, useNeonVMGuest bool, vmSpec *vmv1.VirtualMachineSpec) error {
+	if useNeonVMGuest {
+		return resizeDisk(logger, payloadDiskPath, vmSpec.Guest.RootDisk.Size)
+	} else {
+		return resizeDisk(logger, rootDiskPath, vmSpec.Guest.RootDisk.Size)
+	}
 }
 
 func createISO9660runtime(
@@ -169,6 +210,26 @@ func createISO9660runtime(
 			return err
 		}
 	}
+
+	// Put the same in a .env file. That format is easier to process in systemd-based neonvm-guest.
+	// (we could gate this on useNeonVMGuest, but there's no harm in always including it.)
+	envFileLines := []string{
+		"# Generated by neonvm-runner",
+	}
+
+	if len(command) != 0 {
+		commandAndArgs := shellescape.QuoteCommand(
+			slices.Concat(command, args),
+		)
+		envFileLines = append(envFileLines, fmt.Sprintf("NEONVM_COMMAND=%s", commandAndArgs))
+	}
+
+	for _, e := range env {
+		envFileLines = append(envFileLines, fmt.Sprintf(`%s=`, e.Name, shellescape.Quote(e.Value)))
+	}
+	envFileLines = append(envFileLines, "") // for newline after last line
+
+	err = writer.AddFile(bytes.NewReader([]byte(strings.Join(envFileLines,"\n"))), "command.env")
 
 	mounts := []string{
 		"set -euxo pipefail",

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -111,6 +111,10 @@ type Config struct {
 	cpuScalingMode vmv1.CpuScalingMode
 	// System CPU architecture. Set automatically equal to runtime.GOARCH.
 	architecture string
+
+	// Use neonvm-guest to launch the payload? This is derived from whether
+	// neonvm-payload.qcow2 is present.
+	useNeonVMGuest       bool
 }
 
 func newConfig(logger *zap.Logger) *Config {
@@ -192,6 +196,11 @@ func run(logger *zap.Logger) error {
 		enableSSH = true
 	}
 
+	cfg.useNeonVMGuest, err = shouldUseNeonVMGuest(logger)
+	if err != nil {
+		return fmt.Errorf("failed to check the existence of neonvm-payload.qcow2: %w", err)
+	}
+
 	// Set hostname, with "vm-" prefix to distinguish it from the pod name
 	//
 	// This is just to reduce the risk of mixing things up when ssh'ing to different
@@ -246,7 +255,7 @@ func run(logger *zap.Logger) error {
 
 	tg.Go("rootDisk", func(logger *zap.Logger) error {
 		// resize rootDisk image of size specified and new size more than current
-		return resizeRootDisk(logger, vmSpec)
+		return resizeRootDisk(logger, cfg.useNeonVMGuest, vmSpec)
 	})
 	var qemuCmd []string
 
@@ -296,7 +305,7 @@ func buildQEMUCmd(
 		"-device", "virtserialport,chardev=log,name=tech.neon.log.0",
 	}
 
-	qemuDiskArgs, err := setupVMDisks(logger, cfg.diskCacheSettings, enableSSH, swapSize, vmSpec.Disks)
+	qemuDiskArgs, err := setupVMDisks(logger, cfg.useNeonVMGuest, cfg.diskCacheSettings, enableSSH, swapSize, vmSpec.Disks)
 	if err != nil {
 		return nil, err
 	}
@@ -399,13 +408,17 @@ func buildQEMUCmd(
 }
 
 const (
-	baseKernelCmdline          = "panic=-1 init=/neonvm/bin/init loglevel=7 root=/dev/vda rw"
+	baseKernelCmdline          = "panic=-1 loglevel=7 root=/dev/vda rw"
 	kernelCmdlineDIMMSlots     = "memhp_default_state=online_movable"
 	kernelCmdlineVirtioMemTmpl = "memhp_default_state=online memory_hotplug.online_policy=auto-movable memory_hotplug.auto_movable_ratio=%s"
 )
 
 func makeKernelCmdline(cfg *Config, logger *zap.Logger, vmSpec *vmv1.VirtualMachineSpec, vmStatus *vmv1.VirtualMachineStatus, hostname string) string {
 	cmdlineParts := []string{baseKernelCmdline}
+
+	if !cfg.useNeonVMGuest {
+		cmdlineParts = append(cmdlineParts, "init=/neonvm/bin/init")
+	}
 
 	switch cfg.memoryProvider {
 	case vmv1.MemoryProviderDIMMSlots:
@@ -423,6 +436,7 @@ func makeKernelCmdline(cfg *Config, logger *zap.Logger, vmSpec *vmv1.VirtualMach
 
 	if len(hostname) != 0 {
 		cmdlineParts = append(cmdlineParts, fmt.Sprintf("hostname=%s", hostname))
+		cmdlineParts = append(cmdlineParts, fmt.Sprintf("systemd.hostname=%s", hostname))
 	}
 
 	if cfg.appendKernelCmdline != "" {
@@ -444,6 +458,7 @@ func makeKernelCmdline(cfg *Config, logger *zap.Logger, vmSpec *vmv1.VirtualMach
 	default:
 		logger.Fatal("unsupported architecture", zap.String("architecture", cfg.architecture))
 	}
+	cmdlineParts = append(cmdlineParts, "systemd.getty_auto=no")
 
 	return strings.Join(cmdlineParts, " ")
 }

--- a/neonvm-runner/neonvm-guest/README.md
+++ b/neonvm-runner/neonvm-guest/README.md
@@ -1,0 +1,49 @@
+# neonvm-guest: Runs in the VM
+
+neonvm-guest is the image that runs in a VM started by neonvm-runner. It runs
+the basic services needed to interact with the host pod.
+
+## Building
+
+The neonvm-guest image is built by the Dockerfile in the parent directory. (XXX:
+The build instructions for neonvm-guest must be embedded in the neonvm-runner
+Dockerfile because there's no include mechanism Dockerfile; consider using a
+docker "bake file" though once that feature matures)
+
+
+## NeonVM Guest services
+
+- vector, needed for autoscaling
+- neonvmd
+
+- Launch the payload container
+
+
+In the VM, you can see all the processes with 'ps ax'. To see the view from
+within container, use "machinectl shell neonvm-payload"
+
+
+## NeonVM Payload
+
+The actual services are run in a container within the guest. The guest payload
+image is mounted under /payload/rootfs in the VM, and is run in a container
+using systemd-nspawn.
+
+The payload is expected to be a full system image with 'init'. The payload
+itself can use systemd to launch multiple services inside the container. Running
+systemd inside a docker container is generally not recommended and many consider
+it to be a bad practice, but we're not using docker, and nested systemd
+containers work just fine.
+
+
+## Namespaces
+
+Containers are implemented by namespaces in Linux. There are different
+namespaces for users, network, filesystems etc. For a maximally isolated
+container, you'd want the container to have an isolated namespace for each of
+those namespace kinds, but that's not necessarily the goal with NeonVM. The VM
+is the main security barrier to isolate tenants. Namespaces within the VM can
+provide extra hygiene, but should not be solely relied on for security.
+
+The payload container runs in the root network namespace. That is, there is no
+network isolation between the NeonVM Guest parent and the payload container.

--- a/neonvm-runner/neonvm-guest/files/50-dhcp.network
+++ b/neonvm-runner/neonvm-guest/files/50-dhcp.network
@@ -1,0 +1,5 @@
+[Match]
+Name=en*
+ 
+[Network]
+DHCP=yes

--- a/neonvm-runner/neonvm-guest/files/99-hotplug-cpu.rules
+++ b/neonvm-runner/neonvm-guest/files/99-hotplug-cpu.rules
@@ -1,0 +1,2 @@
+# udev rule for auto-online hotplugged CPUs
+SUBSYSTEM=="cpu", ACTION=="add", TEST=="online", ATTR{online}=="0", ATTR{online}="1"

--- a/neonvm-runner/neonvm-guest/files/chrony.conf
+++ b/neonvm-runner/neonvm-guest/files/chrony.conf
@@ -1,0 +1,4 @@
+refclock PHC /dev/ptp0 poll 2
+driftfile /var/lib/chrony/chrony.drift
+logdir /var/log/chrony
+rtcsync

--- a/neonvm-runner/neonvm-guest/files/mnt-ssh.mount
+++ b/neonvm-runner/neonvm-guest/files/mnt-ssh.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=ssh authorized_keys from host
+
+[Mount]
+What=LABEL=ssh-authorized-keys
+Where=/mnt/ssh
+#Type=iso9660
+Options=ro,defaults
+
+[Install]
+WantedBy=multi-user.target

--- a/neonvm-runner/neonvm-guest/files/neonvm-banner
+++ b/neonvm-runner/neonvm-guest/files/neonvm-banner
@@ -1,0 +1,6 @@
+This is neonvm-guest, the VM image that runs inside a NeonVM virtual machine.
+PostgreSQL or other payload runs in a container inside this VM. Use systemd
+machinectl to access it.
+
+    machinectl shell neonvm-payload
+

--- a/neonvm-runner/neonvm-guest/files/neonvm-payload-10-netns.conf
+++ b/neonvm-runner/neonvm-guest/files/neonvm-payload-10-netns.conf
@@ -1,0 +1,9 @@
+# Override the command line, to not create a private network namespace
+# XXX: I'm not sure if that's what we want.
+
+[Service]
+ExecStart=
+ExecStart=systemd-nspawn --quiet --keep-unit --boot --link-journal=try-guest -U --settings=override --machine=neonvm-payload
+
+
+

--- a/neonvm-runner/neonvm-guest/files/neonvm-payload.mount
+++ b/neonvm-runner/neonvm-guest/files/neonvm-payload.mount
@@ -1,0 +1,10 @@
+[Unit]
+Description=neonvm payload disk
+
+[Mount]
+What=LABEL=neonvm-payload
+Where=/neonvm/payload
+Options=rw,defaults
+
+[Install]
+WantedBy=systemd-nspawn@neonvm-payload.service

--- a/neonvm-runner/neonvm-guest/files/neonvm-payload.nspawn
+++ b/neonvm-runner/neonvm-guest/files/neonvm-payload.nspawn
@@ -1,0 +1,7 @@
+[Exec]
+# XXX: This isn't really necessary, Boot=true is the default when the machine
+# is launched as a service
+Boot=true
+
+[Files]
+BindReadOnly=/neonvm/runtime

--- a/neonvm-runner/neonvm-guest/files/neonvm-runtime.mount
+++ b/neonvm-runner/neonvm-guest/files/neonvm-runtime.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=neonvm configuration files
+
+[Mount]
+What=LABEL=vmruntime
+Where=/neonvm/runtime
+Options=rw,defaults
+
+[Install]
+WantedBy=multi-user.target
+WantedBy=systemd-nspawn@neonvm-payload.service

--- a/neonvm-runner/neonvm-guest/files/neonvmd.service
+++ b/neonvm-runner/neonvm-guest/files/neonvmd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=neonvmd daemon
+
+[Service]
+ExecStart=/neonvm/bin/neonvmd --addr=0.0.0.0:25183
+Restart=always
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+[Install]
+WantedBy=multi-user.target

--- a/neonvm-runner/neonvm-guest/files/resize-swap-internal.sh
+++ b/neonvm-runner/neonvm-guest/files/resize-swap-internal.sh
@@ -1,0 +1,23 @@
+#!/neonvm/bin/sh
+set -euxo pipefail
+
+new_size="$1"
+
+# this script may be run as root, so we should avoid potentially-malicious path injection
+export PATH="/neonvm/bin"
+
+swapdisk="$(/neonvm/bin/blkid -L swapdisk)"
+
+# disable swap. Allow it to fail if it's already disabled.
+swapoff "$swapdisk" || true
+
+# if the requested size is zero, then... just exit. There's nothing we need to do.
+if [ "$new_size" = '0' ]; then exit 0; fi
+
+# re-make the swap.
+#  mkswap expects the size to be given in KiB, so divide the new size by 1K
+mkswap -L swapdisk "$swapdisk" $(( new_size / 1024 ))
+# ... and then re-enable the swap
+#
+# nb: busybox swapon only supports '-d', not its long form '--discard'.
+swapon -d "$swapdisk"

--- a/neonvm-runner/neonvm-guest/files/resize-swap.sh
+++ b/neonvm-runner/neonvm-guest/files/resize-swap.sh
@@ -1,0 +1,33 @@
+#!/neonvm/bin/sh
+
+set -euo pipefail
+
+USAGE="USAGE: /neonvm/bin/resize-swap [ --once ] <NEW_SIZE_IN_BYTES>"
+
+if [ "$#" -eq 2 ]; then
+    if [ "$1" != '--once' ]; then
+        echo "expected first arg to be '--once'" >&2
+        echo "$USAGE" >&2
+        exit 1
+    fi
+    size="$2"
+    once=yes
+elif [ "$#" -eq 1 ]; then
+    size="$1"
+    once=no
+else
+    echo "expected 1 or 2 args, got $#" >&2
+    echo "$USAGE" >&2
+    exit 1
+fi
+
+if [ ! -f /neonvm/runtime/resize-swap-internal.sh ]; then
+    echo 'not found: swap may not be enabled' >&2
+    exit 1
+fi
+
+/neonvm/bin/sh /neonvm/runtime/resize-swap-internal.sh "$size"
+if [ "$once" = 'yes' ]; then
+    # remove *this* script so that it cannot be called again.
+    rm /neonvm/bin/resize-swap
+fi

--- a/neonvm-runner/neonvm-guest/files/serial-getty-autologin.conf
+++ b/neonvm-runner/neonvm-guest/files/serial-getty-autologin.conf
@@ -1,0 +1,4 @@
+# Drop-in to serial-getty service to enable autologin
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --login-pause --autologin root --keep-baud 115200,57600,38400,9600 - ${TERM}

--- a/neonvm-runner/neonvm-guest/files/set-disk-quota.sh
+++ b/neonvm-runner/neonvm-guest/files/set-disk-quota.sh
@@ -1,0 +1,23 @@
+#!/neonvm/bin/sh
+
+set -euo pipefail
+
+USAGE="USAGE: /neonvm/bin/set-disk-quota <NEW_SIZE_IN_KB> <MOUNTPOINT>"
+
+if [ "$#" -eq 2 ]; then
+    size="$1"
+    mountpoint="$2"
+else
+    echo "expected 2 args, got $#" >&2
+    echo "$USAGE" >&2
+    exit 1
+fi
+
+echo "Setting disk quota for $mountpoint to $size KB"
+
+# setquota -P <project_id> <block-softlimit> <block-hardlimit> <inode-softlimit> <inode-hardlimit> <filesystem>
+/neonvm/bin/setquota -P 0 0 "$size" 0 0 "$mountpoint"
+
+echo "DONE! Disk quota set"
+/neonvm/bin/repquota -P -a
+

--- a/neonvm-runner/neonvm-guest/files/ssh_authorized_keys.mount
+++ b/neonvm-runner/neonvm-guest/files/ssh_authorized_keys.mount
@@ -1,0 +1,10 @@
+[Unit]
+Description=ssh authorized_keys from host
+
+[Mount]
+What=LABEL=ssh-authorized-keys
+Where=/mnt/ssh
+Options=ro,defaults
+
+[Install]
+WantedBy=multi-user.target

--- a/neonvm-runner/neonvm-guest/files/sshd_config
+++ b/neonvm-runner/neonvm-guest/files/sshd_config
@@ -1,0 +1,84 @@
+#	$OpenBSD: sshd_config,v 1.104 2021/07/02 05:11:21 dtucker Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# sshd_config adapted from alpine:3.16 default sshd_config
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+PubkeyAuthentication yes
+AuthorizedKeysFile	/mnt/ssh/authorized_keys
+HostbasedAuthentication no
+PasswordAuthentication no
+
+# Change to no to disable s/key passwords
+#KbdInteractiveAuthentication yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the KbdInteractiveAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via KbdInteractiveAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and KbdInteractiveAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+# Feel free to re-enable these if your use case requires them.
+AllowTcpForwarding no
+GatewayPorts no
+X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+Banner /etc/ssh/neonvm-banner

--- a/neonvm-runner/neonvm-guest/files/vector.service
+++ b/neonvm-runner/neonvm-guest/files/vector.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Vector
+Documentation=https://vector.dev
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+User=vector
+Group=vector
+ExecStartPre=/neonvm/bin/vector validate --config-dir /etc/vector
+ExecStart=/neonvm/bin/vector --config-dir /etc/vector
+ExecReload=/neonvm/bin/vector validate --config-dir /etc/vector
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+EnvironmentFile=-/etc/default/vector
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
+[Install]
+WantedBy=multi-user.target

--- a/neonvm-runner/neonvm-guest/files/vector.yaml
+++ b/neonvm-runner/neonvm-guest/files/vector.yaml
@@ -1,0 +1,23 @@
+---
+data_dir: /tmp
+api:
+  enabled: true
+  address: "0.0.0.0:8686"
+  playground: false
+sources:
+  host_metrics:
+    filesystem:
+      devices:
+        excludes: [binfmt_misc]
+      filesystems:
+        excludes: [binfmt_misc]
+      mountPoints:
+        excludes: ["*/proc/sys/fs/binfmt_misc"]
+    type: host_metrics
+    scrape_interval_secs: 1 # default is 15, but we scrape every 5s in autoscaler-agent
+sinks:
+  prom_exporter:
+    type: prometheus_exporter
+    inputs:
+      - host_metrics
+    address: "0.0.0.0:9100"

--- a/neonvm-runner/neonvm-guest/files/vminit
+++ b/neonvm-runner/neonvm-guest/files/vminit
@@ -1,0 +1,63 @@
+## FIXME: This is unused with neonvm-guest. It's here just to remind that some
+## of this functionality still needs to be moved to systemd unit files
+
+#!/neonvm/bin/sh
+
+export PATH=/neonvm/bin
+
+# set links to libs
+mkdir -p /lib
+for l in $(find /neonvm/lib -type f); do
+    lib="$(basename $l)"
+    [ ! -e "/lib/${lib}" -a ! -e "/usr/lib/${lib}" ] && ln -s "${l}" "/lib/${lib}"
+done
+
+# udev rule for auto-online hotplugged CPUs
+mkdir -p /lib/udev/rules.d
+# taken from 50-udev-default.rules
+echo 'SUBSYSTEM=="virtio-ports", KERNEL=="vport*", ATTR{name}=="?*", SYMLINK+="virtio-ports/$attr{name}"' > /lib/udev/rules.d/99-virtio-ports.rules
+
+echo 'ATTR{name}=="tech.neon.log.0" MODE="0666"' > /lib/udev/rules.d/99-neon-log-port.rules
+echo 'SUBSYSTEM=="cpu", ACTION=="add", TEST=="online", ATTR{online}=="0", ATTR{online}="1"' > /lib/udev/rules.d/99-hotplug-cpu.rules
+
+# system mounts
+mkdir -p /dev/pts /dev/shm
+chmod 0755 /dev/pts
+chmod 1777 /dev/shm
+mount -t proc  proc  /proc
+mount -t sysfs sysfs /sys
+mount -t cgroup2 cgroup2 /sys/fs/cgroup
+
+# Allow all users to move processes to/from the root cgroup.
+#
+# This is required in order to be able to 'cgexec' anything, if the entrypoint is not being run as
+# root, because moving tasks between one cgroup and another *requires write access to the
+# cgroup.procs file of the common ancestor*, and because the entrypoint isn't already in a cgroup,
+# any new tasks are automatically placed in the top-level cgroup.
+#
+# This *would* be bad for security, if we relied on cgroups for security; but instead because they
+# are just used for cooperative signaling, this should be mostly ok.
+chmod go+w /sys/fs/cgroup/cgroup.procs
+
+mount -t devpts -o noexec,nosuid       devpts    /dev/pts
+mount -t tmpfs  -o noexec,nosuid,nodev shm-tmpfs /dev/shm
+
+# neonvm runtime params mounted as iso9660 disk
+mount -t iso9660 -o ro,mode=0644 /dev/vdb /neonvm/runtime
+
+# mount virtual machine .spec.disks
+test -f /neonvm/runtime/mounts.sh && /neonvm/bin/sh /neonvm/runtime/mounts.sh
+
+# set any user-supplied sysctl settings
+test -f /neonvm/runtime/sysctl.conf && /neonvm/bin/sysctl -p /neonvm/runtime/sysctl.conf
+
+# try resize filesystem
+resize2fs /dev/vda
+
+# networking
+ip link set up dev lo
+ip link set up dev eth0
+
+# ssh
+# we use ed25519 keys and -N "" skips setting up a passphrase
+/neonvm/bin/ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""

--- a/pkg/neonvm/controllers/vm_controller.go
+++ b/pkg/neonvm/controllers/vm_controller.go
@@ -1317,27 +1317,8 @@ func podSpec(
 			ServiceAccountName:            vm.Spec.ServiceAccountName,
 			SchedulerName:                 vm.Spec.SchedulerName,
 			Affinity:                      affinity,
-			InitContainers: []corev1.Container{
-				{
-					Image:           vm.Spec.Guest.RootDisk.Image,
-					Name:            "init",
-					ImagePullPolicy: vm.Spec.Guest.RootDisk.ImagePullPolicy,
-					VolumeMounts: []corev1.VolumeMount{{
-						Name:      "virtualmachineimages",
-						MountPath: "/vm/images",
-					}},
-					Command: []string{
-						"sh", "-c",
-						"mv /disk.qcow2 /vm/images/rootdisk.qcow2 && " +
-							/* uid=36(qemu) gid=34(kvm) groups=34(kvm) */
-							"chown 36:34 /vm/images/rootdisk.qcow2 && " +
-							"sysctl -w net.ipv4.ip_forward=1",
-					},
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: lo.ToPtr(true),
-					},
-				},
-			},
+			// will be added to later
+			InitContainers: []corev1.Container{},
 			// generate containers as an inline function so the context isn't isolated
 			Containers: func() []corev1.Container {
 				runner := corev1.Container{
@@ -1449,6 +1430,29 @@ func podSpec(
 			}(),
 		},
 	}
+
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
+		Image:           vm.Spec.Guest.RootDisk.Image,
+		Name:            "init",
+		ImagePullPolicy: vm.Spec.Guest.RootDisk.ImagePullPolicy,
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      "virtualmachineimages",
+			MountPath: "/vm/images",
+		}},
+		Command: []string{
+			"sh", "-c",
+			/* In the legacy VM images, the VM docker image contains disk.qcow2, and neonvm-runner expects rootdisk.qcow2.
+			 * In the new system, neonvm-runner expects neonvm-payload.qcow2 */
+			"if [ -f /disk.qcow2 ]; then SRC=/disk.qcow2 DST=/vm/images/rootdisk.qcow2; else SRC=/neonvm-payload.qcow2 DST=/vm/images/neonvm-payload.qcow2; fi && " +
+				"mv $SRC $DST && " +
+				/* uid=36(qemu) gid=34(kvm) groups=34(kvm) */
+				"chown 36:34 $DST && " +
+				"sysctl -w net.ipv4.ip_forward=1",
+		},
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: lo.ToPtr(true),
+		},
+	})
 
 	if sshSecret != nil {
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts,


### PR DESCRIPTION
In the new system, the "payload" is run in a container in the VM. In the usual setup, the payload is the compute-node image built from the main 'neon' repository, which includes "compute_ctl", pgbouncer and other such services that are needed to run a PostgreSQL compute endpoint. Like before, the payload is provided in a docker container which contains a QCOW2 image. But you don't need to use vm-builder to build the payload image anymore. The payload can use systemd to launch the services.

The VM now always boots the same disk image called "neonvm-guest". The neonvm-guest disk image is built into the neonvm-runner docker image. It's based on Debian bookworm and uses systemd to launch the services needed in all neonvm VMs: neonvmd, vector, and ssh for debugging.  At startup, alongside launching those common services, neonvm-guest mounts the payload image, and runs it as a container using systemd-nspawn.

Running the payload in a container provides some isolation between the common VM services and the real payload. It also allows using a different OS for the payload. We're standardizing on Debian bookworm, but as of this writing, older PostgreSQL versions still use a Debian bullseye based image.

This is based on Em's proposal at
https://www.notion.so/neondatabase/RFC-Containers-in-VMs-dd5f4d978ec6499aba0662bd54421b91#33c2929d8880494088331400213eea90

To make all this work, there are changes to:

- neonvm-runner: attach neonvm-guest and neonvm-payload as separate QCOW2 disk images to the VM. It still works with legacy VM images too; a neonvm-guest based image is detected by looking at the QCOW2 image name: if it's neonvm-payload.qcow rather than rootdisk.qcow, it uses the new system. The neonvm-guest disk image is always built into the neonnm-runner image, but it will go unused when launching a legacy VM image.

- neonvm-controller: Accept both disk.qcow2 and neonvm-payload.qcow2 images in the VM image.

This is supposed to be backwards-compatible, so that old VM images built using vm-builder  continue to work the same as before. I haven't yet tested that, however.

TODOs:

- Resizing swap setting  and disk quotas are not implemented in the new system yet.

- ARM support. I think the serial TTY name is wrong on ARM. Otherwise it should work, but is untested.

- I'd love to rewrite the way that the compute_ctl arguments are passed to the VM. Currently, they're put command.sh and args.sh files which are mounted in the VM under /neonvm/runtime/. That feels pretty janky, and it was hard to keep that system working with the new systemd-based approach. In fact I think that's broken at the moment.

- I originally started working on this in order to better support running one-time jobs in VMs, and in particular the fast_import tool that's part of the migration assistant feature. I'm thinking that it could be packaged as a different "payload" image. Or with different parameters to the same VM compute image. But this PR doesn't address that yet.

- If one of the services fails to start, should the VM be powered off? Which ones may fail, which ones are considered hard failures?

- I'd like to be able to use the same compute VM, with compute_ctl, for all PostgreSQL versions. The straightforward way to do that is to include the binaries of all PostgreSQL versions in the same payload image. Alternatively, include multiple payload images in the VM, and "mount" the correct one on the fly when we know which version is needed.

- Ideally, extensions and ad hoc compute images could be loaded on-demand too, while still using the VMs from the compute pool. That means lazily downloading the right image into the VM, after the spec file is received from the control plane. Need to figure out the best way to do that and the previous point.