### PR TITLE
neonvm: continuous synchronisation of files in pod/vm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/docker/cli v25.0.3+incompatible
 	github.com/docker/docker v24.0.9+incompatible
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20210525090646-64b7a4574d14
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/jpillora/backoff v1.0.0
@@ -127,7 +128,6 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/docker/cli v25.0.3+incompatible
 	github.com/docker/docker v24.0.9+incompatible
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20210525090646-64b7a4574d14
-	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/jpillora/backoff v1.0.0
@@ -128,6 +127,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/neonvm-daemon/cmd/main.go
+++ b/neonvm-daemon/cmd/main.go
@@ -102,20 +102,15 @@ func (s *cpuServer) handleSetCPUStatus(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (s *cpuServer) getFile(path string) (string, error) {
-	if !filepath.IsLocal(path) {
-		return "", fmt.Errorf("\"%s\" is not a local path", path)
-	}
-	//nolint:gocritic // filepathJoin lint wrongly complains about path separators
-	path = filepath.Clean(filepath.Join("/var/sync", path))
-	return path, nil
+func (s *cpuServer) getMountDir(path string) (string, error) {
+	return fmt.Sprintf("/%s", path), nil
 }
 
 func (s *cpuServer) handleGetFileChecksum(w http.ResponseWriter, path string) {
 	s.fileOperationsMutex.Lock()
 	defer s.fileOperationsMutex.Unlock()
 
-	path, err := s.getFile(path)
+	path, err := s.getMountDir(path)
 	if err != nil {
 		s.logger.Error("invalid file path", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)
@@ -145,7 +140,7 @@ func (s *cpuServer) handleUploadFile(w http.ResponseWriter, r *http.Request, pat
 	s.fileOperationsMutex.Lock()
 	defer s.fileOperationsMutex.Unlock()
 
-	path, err := s.getFile(path)
+	path, err := s.getMountDir(path)
 	if err != nil {
 		s.logger.Error("invalid file path", zap.Error(err))
 		w.WriteHeader(http.StatusBadRequest)

--- a/neonvm-daemon/cmd/main.go
+++ b/neonvm-daemon/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
 	k8sutil "k8s.io/kubernetes/pkg/volume/util"
 
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"

--- a/neonvm-daemon/cmd/main.go
+++ b/neonvm-daemon/cmd/main.go
@@ -125,11 +125,10 @@ func (s *cpuServer) handleGetFileChecksum(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte(checksum)); err != nil {
 		s.logger.Error("could not write response", zap.Error(err))
 	}
-
-	w.WriteHeader(http.StatusOK)
 }
 
 func (s *cpuServer) handleUploadFile(w http.ResponseWriter, r *http.Request) {

--- a/neonvm-daemon/cmd/main.go
+++ b/neonvm-daemon/cmd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -101,7 +100,7 @@ func (s *cpuServer) handleSetCPUStatus(w http.ResponseWriter, r *http.Request) {
 
 func (s *cpuServer) getFile(path string) (string, error) {
 	if !filepath.IsLocal(path) {
-		return "", errors.New("non-local path")
+		return "", fmt.Errorf("\"%s\" is not a local path", path)
 	}
 	path = filepath.Clean(filepath.Join("var", "sync", path))
 	return path, nil

--- a/neonvm-daemon/cmd/main.go
+++ b/neonvm-daemon/cmd/main.go
@@ -102,7 +102,8 @@ func (s *cpuServer) getFile(path string) (string, error) {
 	if !filepath.IsLocal(path) {
 		return "", fmt.Errorf("\"%s\" is not a local path", path)
 	}
-	path = filepath.Clean(filepath.Join("var", "sync", path))
+	//nolint:gocritic // filepathJoin lint wrongly complains about path separators
+	path = filepath.Clean(filepath.Join("/var/sync", path))
 	return path, nil
 }
 

--- a/neonvm-runner/cmd/disks.go
+++ b/neonvm-runner/cmd/disks.go
@@ -184,12 +184,12 @@ func createISO9660runtime(
 
 	if len(disks) != 0 {
 		for _, disk := range disks {
+			if disk.MountPath != "" {
+				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/mkdir -p %s`, disk.MountPath))
+			}
 			if diskNeedsSynchronisation(disk) {
 				// do nothing as we will mount it into the VM via neonvm-daemon later
 				continue
-			}
-			if disk.MountPath != "" {
-				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/mkdir -p %s`, disk.MountPath))
 			}
 			switch {
 			case disk.EmptyDisk != nil:

--- a/neonvm-runner/cmd/disks.go
+++ b/neonvm-runner/cmd/disks.go
@@ -187,7 +187,7 @@ func createISO9660runtime(
 			if disk.MountPath != "" {
 				mounts = append(mounts, fmt.Sprintf(`/neonvm/bin/mkdir -p %s`, disk.MountPath))
 			}
-			if diskNeedsSynchronisation(disk) {
+			if disk.Watch != nil && *disk.Watch {
 				// do nothing as we will mount it into the VM via neonvm-daemon later
 				continue
 			}
@@ -276,22 +276,6 @@ func createISO9660runtime(
 	}
 
 	return nil
-}
-
-func diskNeedsSynchronisation(disk vmv1.Disk) bool {
-	if disk.DiskSource.Secret == nil {
-		// only supporting secrets at the moment
-		return false
-	}
-
-	// for now, `/var/sync` is our sentinal that this is synchronised.
-	// TODO: should we instead put a sync flag on the Disk object itself?
-	rel, err := filepath.Rel("/var/sync", disk.MountPath)
-	if err != nil {
-		return false
-	}
-
-	return filepath.IsLocal(rel)
 }
 
 func calcDirUsage(dirPath string) (int64, error) {

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -706,6 +706,8 @@ func monitorFiles(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup) {
 		}
 	}
 
+	ticker := time.After(5 * time.Minute)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -720,7 +722,7 @@ func monitorFiles(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup) {
 			if err := sendFileToNeonvmDaemon(event.Name, guestPath); err != nil {
 				logger.Error("failed to upload file to vm guest", zap.Error(err))
 			}
-		case <-time.After(5 * time.Minute):
+		case <-ticker:
 			for hostpath, guestpath := range synchronisedFiles {
 				hostsum, err := util.ChecksumFile(hostpath)
 				if err != nil {

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -721,7 +721,7 @@ func monitorFiles(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup, d
 	// Wait a bit to reduce the chance we attempt dialing before
 	// QEMU is started
 	select {
-	case <-time.After(200 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 	case <-ctx.Done():
 		logger.Warn("QEMU shut down too soon to start forwarding logs")
 	}

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -725,11 +725,14 @@ func monitorFiles(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup, d
 
 		select {
 		case <-time.After(1 * time.Second):
+			continue
 		case <-ctx.Done():
-			logger.Warn("QEMU shut down too soon to start forwarding logs")
+			return
 		}
 	}
 
+	// For the entire duration the VM is alive, periodically check whether any of the watched disks
+	// still match what's inside the VM, and if not, send the update.
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -712,9 +712,15 @@ func monitorFiles(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup, d
 		}
 	}
 
-	for k := range synchronisedFiles {
+	for k, _ := range synchronisedFiles {
 		if err := notify.Add(k); err != nil {
 			logger.Error("failed to add file to inotify instance", zap.Error(err))
+		}
+	}
+
+	for hostpath, guestpath := range synchronisedFiles {
+		if err := sendFileToNeonvmDaemon(hostpath, guestpath); err != nil {
+			logger.Error("failed to upload file to vm guest", zap.Error(err))
 		}
 	}
 

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -897,11 +897,11 @@ func sendFilesToNeonvmDaemon(ctx context.Context, hostpath, guestpath string) er
 		return fmt.Errorf("could not open file: %w", err)
 	}
 
-	dto := make(map[string]File)
+	encodedFiles := make(map[string]File)
 	for k, v := range files {
-		dto[k] = File{Data: base64.StdEncoding.EncodeToString(v)}
+		encodedFiles[k] = File{Data: base64.StdEncoding.EncodeToString(v)}
 	}
-	body, err := json.Marshal(dto)
+	body, err := json.Marshal(encodedFiles)
 	if err != nil {
 		return fmt.Errorf("could not encode files: %w", err)
 	}

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -511,6 +511,12 @@ type Disk struct {
 	// Path within the virtual machine at which the disk should be mounted.  Must
 	// not contain ':'.
 	MountPath string `json:"mountPath"`
+	// The disk source is monitored for changes if true, otherwise it is only read on VM startup (false or unspecified).
+	// This only works if the disk source is a configmap, a secret, or a projected volume.
+	// Defaults to false.
+	// +optional
+	// +kubebuilder:default:=false
+	Watch *bool `json:"watch,omitempty"`
 	// DiskSource represents the location and type of the mounted disk.
 	DiskSource `json:",inline"`
 }

--- a/neonvm/apis/neonvm/v1/zz_generated.deepcopy.go
+++ b/neonvm/apis/neonvm/v1/zz_generated.deepcopy.go
@@ -49,6 +49,11 @@ func (in *Disk) DeepCopyInto(out *Disk) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Watch != nil {
+		in, out := &in.Watch, &out.Watch
+		*out = new(bool)
+		**out = **in
+	}
 	in.DiskSource.DeepCopyInto(&out.DiskSource)
 }
 

--- a/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -1193,6 +1193,13 @@ spec:
                       required:
                       - size
                       type: object
+                    watch:
+                      default: false
+                      description: |-
+                        The disk source is monitored for changes if true, otherwise it is only read on VM startup (false or unspecified).
+                        This only works if the disk source is a configmap, a secret, or a projected volume.
+                        Defaults to false.
+                      type: boolean
                   required:
                   - mountPath
                   - name

--- a/pkg/util/checksum.go
+++ b/pkg/util/checksum.go
@@ -2,31 +2,71 @@ package util
 
 import (
 	"encoding/base64"
-	"io"
+	"encoding/binary"
 	"os"
+	"path/filepath"
+	"sort"
 
 	"golang.org/x/crypto/blake2b"
 )
 
-func ChecksumFile(path string) (string, error) {
-	file, err := os.Open(path)
-	if err != nil && os.IsNotExist(err) {
-		return "", nil
-	} else if err != nil {
+// Calculate the checksum over all files in a directory, assuming the directory is flat (contains no subdirs).
+func ChecksumFlatDir(path string) (string, error) {
+	files, err := ReadAllFiles(path)
+	if err != nil {
 		return "", err
 	}
-	defer file.Close()
+
+	// sort the file names for a reproducible hash
+	var keys []string
+	for k := range files {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 
 	hasher, err := blake2b.New256(nil)
 	if err != nil {
 		return "", err
 	}
 
-	if _, err := io.Copy(hasher, file); err != nil {
-		return "", err
+	for _, filename := range keys {
+		data := files[filename]
+		var length []byte
+
+		// hash as "{name}\0{len(data)}{data}"
+		// this prevents any possible hash confusion problems
+		hasher.Write([]byte(filename))
+		hasher.Write([]byte{0})
+		hasher.Write(binary.LittleEndian.AppendUint64(length, uint64(len(data))))
+		hasher.Write(data)
 	}
 
 	sum := hasher.Sum(nil)
 	sumBase64 := base64.RawStdEncoding.EncodeToString(sum)
 	return sumBase64, nil
+}
+
+// Read all files in a directory, assuming the directory is flat (contains no subdirs).
+func ReadAllFiles(path string) (map[string][]byte, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+
+	output := make(map[string][]byte)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(path, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		output[entry.Name()] = data
+	}
+
+	return output, nil
 }

--- a/pkg/util/checksum.go
+++ b/pkg/util/checksum.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"encoding/base64"
+	"io"
+	"os"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+func ChecksumFile(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil && os.IsNotExist(err) {
+		return "", nil
+	} else if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hasher, err := blake2b.New256(nil)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+
+	sum := hasher.Sum(nil)
+	sumBase64 := base64.RawStdEncoding.EncodeToString(sum)
+	return sumBase64, nil
+}

--- a/tests/e2e/vm-secret-sync/00-assert.yaml
+++ b/tests/e2e/vm-secret-sync/00-assert.yaml
@@ -1,12 +1,13 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 90
+timeout: 70
 commands:
   - script: |
       set -eux
       pod="$(kubectl get neonvm -n "$NAMESPACE" example -o jsonpath='{.status.podName}')"
+      kubectl exec -n "$NAMESPACE" $pod -- grep -q "hello world" /vm/mounts/var/sync/example/foo
       kubectl exec -n "$NAMESPACE" $pod -- scp guest-vm:/var/sync/example/foo testfile
-      grep -q "hello world" testfile
+      kubectl exec -n "$NAMESPACE" $pod -- grep -q "hello world" testfile
 ---
 apiVersion: vm.neon.tech/v1
 kind: VirtualMachine

--- a/tests/e2e/vm-secret-sync/00-assert.yaml
+++ b/tests/e2e/vm-secret-sync/00-assert.yaml
@@ -1,0 +1,22 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+commands:
+  - script: |
+      set -eux
+      pod="$(kubectl get neonvm -n "$NAMESPACE" example -o jsonpath='{.status.podName}')"
+      kubectl exec -n "$NAMESPACE" $pod -- scp guest-vm:/var/sync/example/foo testfile
+      grep -q "hello world" testfile
+---
+apiVersion: vm.neon.tech/v1
+kind: VirtualMachine
+metadata:
+  name: example
+status:
+  phase: Running
+  restartCount: 0
+  conditions:
+    - type: Available
+      status: "True"
+  cpus: 250m
+  memorySize: 1Gi

--- a/tests/e2e/vm-secret-sync/00-create-vm.yaml
+++ b/tests/e2e/vm-secret-sync/00-create-vm.yaml
@@ -1,0 +1,39 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+unitTest: false
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-secret
+data:
+  foo: aGVsbG8gd29ybGQ=
+---
+apiVersion: vm.neon.tech/v1
+kind: VirtualMachine
+metadata:
+  name: example
+spec:
+  schedulerName: autoscale-scheduler
+  enableSSH: true
+  guest:
+    cpus:
+      min: 0.25
+      use: 0.25
+      max: 0.25
+    memorySlotSize: 1Gi
+    memorySlots:
+      min: 1
+      use: 1
+      max: 1
+    rootDisk:
+      image: vm-postgres:15-bullseye
+      size: 1Gi
+  disks:
+  - secret:
+      secretName: example-secret
+      items:
+      - key: foo
+        path: foo
+    mountPath: /var/sync/example
+    name: secret-foo

--- a/tests/e2e/vm-secret-sync/00-create-vm.yaml
+++ b/tests/e2e/vm-secret-sync/00-create-vm.yaml
@@ -32,8 +32,5 @@ spec:
   disks:
   - secret:
       secretName: example-secret
-      items:
-      - key: foo
-        path: foo
     mountPath: /var/sync/example
     name: secret-foo

--- a/tests/e2e/vm-secret-sync/00-create-vm.yaml
+++ b/tests/e2e/vm-secret-sync/00-create-vm.yaml
@@ -7,6 +7,7 @@ kind: Secret
 metadata:
   name: example-secret
 data:
+  # "hello world"
   foo: aGVsbG8gd29ybGQ=
 ---
 apiVersion: vm.neon.tech/v1
@@ -34,3 +35,4 @@ spec:
       secretName: example-secret
     mountPath: /var/sync/example
     name: secret-foo
+    watch: true

--- a/tests/e2e/vm-secret-sync/01-assert.yaml
+++ b/tests/e2e/vm-secret-sync/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 70
+timeout: 120
 commands:
   - script: |
       set -eux

--- a/tests/e2e/vm-secret-sync/01-assert.yaml
+++ b/tests/e2e/vm-secret-sync/01-assert.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+commands:
+  - script: |
+      set -eux
+      pod="$(kubectl get neonvm -n "$NAMESPACE" example -o jsonpath='{.status.podName}')"
+      kubectl exec -n "$NAMESPACE" $pod -- scp guest-vm:/var/sync/example/foo testfile
+      grep -q "goodbye world" testfile

--- a/tests/e2e/vm-secret-sync/01-assert.yaml
+++ b/tests/e2e/vm-secret-sync/01-assert.yaml
@@ -1,9 +1,10 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 90
+timeout: 70
 commands:
   - script: |
       set -eux
       pod="$(kubectl get neonvm -n "$NAMESPACE" example -o jsonpath='{.status.podName}')"
+      kubectl exec -n "$NAMESPACE" $pod -- grep -q "goodbye world" /vm/mounts/var/sync/example/foo
       kubectl exec -n "$NAMESPACE" $pod -- scp guest-vm:/var/sync/example/foo testfile
-      grep -q "goodbye world" testfile
+      kubectl exec -n "$NAMESPACE" $pod -- grep -q "goodbye world" testfile

--- a/tests/e2e/vm-secret-sync/01-update-secret.yaml
+++ b/tests/e2e/vm-secret-sync/01-update-secret.yaml
@@ -7,4 +7,5 @@ kind: Secret
 metadata:
   name: example-secret
 data:
+  # "goodbye world"
   foo: Z29vZGJ5ZSB3b3JsZA==

--- a/tests/e2e/vm-secret-sync/01-update-secret.yaml
+++ b/tests/e2e/vm-secret-sync/01-update-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+unitTest: false
+commands:
+  - script: |
+      set -eux
+      pod="$(kubectl get neonvm -n "$NAMESPACE" example -o jsonpath='{.status.podName}')"
+      new_size=$(( 1 * 1024 * 1024 )) # 1 Gi
+      mountpoint="/var/db/postgres/compute"
+      kubectl exec -n "$NAMESPACE" "$pod" -- ssh guest-vm /neonvm/bin/set-disk-quota "$new_size" "$mountpoint"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-secret
+data:
+  foo: Z29vZGJ5ZSB3b3JsZA==

--- a/tests/e2e/vm-secret-sync/01-update-secret.yaml
+++ b/tests/e2e/vm-secret-sync/01-update-secret.yaml
@@ -1,13 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 unitTest: false
-commands:
-  - script: |
-      set -eux
-      pod="$(kubectl get neonvm -n "$NAMESPACE" example -o jsonpath='{.status.podName}')"
-      new_size=$(( 1 * 1024 * 1024 )) # 1 Gi
-      mountpoint="/var/db/postgres/compute"
-      kubectl exec -n "$NAMESPACE" "$pod" -- ssh guest-vm /neonvm/bin/set-disk-quota "$new_size" "$mountpoint"
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
For #1213 I need the renewed certificate secret to be updated within the vm. 

It's ok if there's some lag on this synchronisation as certificates are renewed with generous amount of time left until expiry.

Design:
neonvm-runner will subscribe to inotify events for a specific list of secrets. If an event is detected, the secret contents are sent in a http request to neonvm-daemon.

The files will be owned by the daemon user, and read-only by postgres.

If there's an error when uploading, then there's a secondary loop every 5 minutes to catch up, using a checksum to compare.

We mirror kubernetes and use atomicwriter to atomically update multiple files in the secret.

Useful links:
https://ahmet.im/blog/kubernetes-secret-volumes-delay/
https://ahmet.im/blog/kubernetes-inotify/

Some discussion here:
https://neondb.slack.com/archives/C03TN5G758R/p1737723555448339
https://neondb.slack.com/archives/C03TN5G758R/p1738669103059979