### PR TITLE
cluster-autoscaler: Fix go image version in dockerfile

### DIFF
--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -1,6 +1,6 @@
 # NOTE: This must match CA's builder/Dockerfile:
 # https://github.com/kubernetes/autoscaler/blob/<GIT_TAG>/builder/Dockerfile
-FROM golang:1.21.6 AS builder
+FROM golang:1.22.2 AS builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Release workflow failed due to this issue, here: https://github.com/neondatabase/autoscaling/actions/runs/12998905924/job/36253091744#step:25:410

Missed it in #1161, per the [upgrade checklist](https://github.com/neondatabase/autoscaling/tree/main/cluster-autoscaler#version-upgrade-checklist).