### PR TITLE
neonvm/multus-aks: Fix ineffectual secret namespace

### DIFF
--- a/neonvm/config/multus-aks/secret.yaml
+++ b/neonvm/config/multus-aks/secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/service-account-token
-namespace: kube-system
 metadata:
   name: multus-long-lived
+  namespace: kube-system
   annotations:
     kubernetes.io/service-account.name: multus


### PR DESCRIPTION
Follow-up to #1202, namespace should be under the metadata field. Without this, kubectl says `Warning: unknown field "namespace"` and tries to create the secret in the default namespace (not what we want)