### PR TITLE
Always register metrics during construction

### DIFF
--- a/pkg/agent/billing/prommetrics.go
+++ b/pkg/agent/billing/prommetrics.go
@@ -9,6 +9,7 @@ import (
 
 	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
 	"github.com/neondatabase/autoscaling/pkg/reporting"
+	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
 type PromMetrics struct {
@@ -18,31 +19,25 @@ type PromMetrics struct {
 	vmsCurrent        *prometheus.GaugeVec
 }
 
-func NewPromMetrics() PromMetrics {
+func NewPromMetrics(reg prometheus.Registerer) PromMetrics {
 	return PromMetrics{
-		reporting: reporting.NewEventSinkMetrics("autoscaling_agent_billing"),
+		reporting: reporting.NewEventSinkMetrics("autoscaling_agent_billing", reg),
 
-		vmsProcessedTotal: prometheus.NewCounterVec(
+		vmsProcessedTotal: util.RegisterMetric(reg, prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "autoscaling_agent_billing_vms_processed_total",
 				Help: "Total number of times the autoscaler-agent's billing subsystem processes any VM",
 			},
 			[]string{"is_endpoint", "autoscaling_enabled", "phase"},
-		),
-		vmsCurrent: prometheus.NewGaugeVec(
+		)),
+		vmsCurrent: util.RegisterMetric(reg, prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "autoscaling_agent_billing_vms_current",
 				Help: "Total current VMs visible to the autoscaler-agent's billing subsystem, labeled by some bits of metadata",
 			},
 			[]string{"is_endpoint", "autoscaling_enabled", "phase"},
-		),
+		)),
 	}
-}
-
-func (m PromMetrics) MustRegister(reg *prometheus.Registry) {
-	m.reporting.MustRegister(reg)
-	reg.MustRegister(m.vmsProcessedTotal)
-	reg.MustRegister(m.vmsCurrent)
 }
 
 type batchMetrics struct {

--- a/pkg/agent/entrypoint.go
+++ b/pkg/agent/entrypoint.go
@@ -34,9 +34,10 @@ func (r MainRunner) Run(logger *zap.Logger, ctx context.Context) error {
 		}
 	}
 
-	watchMetrics := watch.NewMetrics("autoscaling_agent_watchers")
-
+	globalMetrics, globalPromReg := makeGlobalMetrics()
 	perVMMetrics, vmPromReg := makePerVMMetrics()
+
+	watchMetrics := watch.NewMetrics("autoscaling_agent_watchers", globalPromReg)
 
 	logger.Info("Starting VM watcher")
 	vmWatchStore, err := startVMWatcher(ctx, logger, r.Config, r.VMClient, watchMetrics, perVMMetrics, r.EnvArgs.K8sNodeName, pushToQueue)
@@ -52,21 +53,18 @@ func (r MainRunner) Run(logger *zap.Logger, ctx context.Context) error {
 	}
 	defer schedTracker.Stop()
 
-	scalingEventsMetrics := scalingevents.NewPromMetrics()
+	scalingEventsMetrics := scalingevents.NewPromMetrics(globalPromReg)
 	scalingReporter, err := scalingevents.NewReporter(ctx, logger, &r.Config.ScalingEvents, scalingEventsMetrics)
 	if err != nil {
 		return fmt.Errorf("Error creating scaling events reporter: %w", err)
 	}
 
-	globalState, globalPromReg := r.newAgentState(logger, r.EnvArgs.K8sPodIP, schedTracker, scalingReporter)
-	watchMetrics.MustRegister(globalPromReg)
-	scalingEventsMetrics.MustRegister(globalPromReg)
+	globalState := r.newAgentState(logger, r.EnvArgs.K8sPodIP, schedTracker, scalingReporter, globalMetrics)
 
 	logger.Info("Starting billing metrics collector")
 	storeForNode := watch.NewIndexedStore(vmWatchStore, billing.NewVMNodeIndex(r.EnvArgs.K8sNodeName))
 
-	metrics := billing.NewPromMetrics()
-	metrics.MustRegister(globalPromReg)
+	billingMetrics := billing.NewPromMetrics(globalPromReg)
 
 	promLogger := logger.Named("prometheus")
 	if err := util.StartPrometheusMetricsServer(ctx, promLogger.Named("global"), 9100, globalPromReg); err != nil {
@@ -83,7 +81,7 @@ func (r MainRunner) Run(logger *zap.Logger, ctx context.Context) error {
 		}
 	}
 
-	mc, err := billing.NewMetricsCollector(ctx, logger, &r.Config.Billing, metrics)
+	mc, err := billing.NewMetricsCollector(ctx, logger, &r.Config.Billing, billingMetrics)
 	if err != nil {
 		return fmt.Errorf("error creating billing metrics collector: %w", err)
 	}

--- a/pkg/agent/globalstate.go
+++ b/pkg/agent/globalstate.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
 	"k8s.io/client-go/kubernetes"
@@ -50,10 +49,9 @@ func (r MainRunner) newAgentState(
 	podIP string,
 	schedTracker *schedwatch.SchedulerTracker,
 	scalingReporter *scalingevents.Reporter,
-) (*agentState, *prometheus.Registry) {
-	metrics, promReg := makeGlobalMetrics()
-
-	state := &agentState{
+	metrics GlobalMetrics,
+) *agentState {
+	return &agentState{
 		lock:         util.NewChanMutex(),
 		pods:         make(map[util.NamespacedName]*podState),
 		baseLogger:   baseLogger,
@@ -66,8 +64,6 @@ func (r MainRunner) newAgentState(
 
 		scalingReporter: scalingReporter,
 	}
-
-	return state, promReg
 }
 
 func vmIsOurResponsibility(vm *vmv1.VirtualMachine, config *Config, nodeName string) bool {

--- a/pkg/agent/scalingevents/prommetrics.go
+++ b/pkg/agent/scalingevents/prommetrics.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/neondatabase/autoscaling/pkg/reporting"
+	"github.com/neondatabase/autoscaling/pkg/util"
 )
 
 type PromMetrics struct {
@@ -13,22 +14,17 @@ type PromMetrics struct {
 	totalCount *prometheus.GaugeVec
 }
 
-func NewPromMetrics() PromMetrics {
+func NewPromMetrics(reg prometheus.Registerer) PromMetrics {
 	return PromMetrics{
-		reporting: reporting.NewEventSinkMetrics("autoscaling_agent_scalingevents"),
-		totalCount: prometheus.NewGaugeVec(
+		reporting: reporting.NewEventSinkMetrics("autoscaling_agent_scalingevents", reg),
+		totalCount: util.RegisterMetric(reg, prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Name: "autoscaling_agent_scaling_events_total",
 				Help: "Total number of scaling events generated",
 			},
 			[]string{"kind"},
-		),
+		)),
 	}
-}
-
-func (m PromMetrics) MustRegister(reg *prometheus.Registry) {
-	m.reporting.MustRegister(reg)
-	reg.MustRegister(m.totalCount)
 }
 
 func (m PromMetrics) recordSubmitted(event ScalingEvent) {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -196,7 +196,7 @@ func makeAutoscaleEnforcerPlugin(
 		},
 	}
 
-	watchMetrics := watch.NewMetrics("autoscaling_plugin_watchers")
+	watchMetrics := watch.NewMetrics("autoscaling_plugin_watchers", promReg)
 
 	logger.Info("Starting node watcher")
 	nodeStore, err := p.watchNodeEvents(ctx, logger, watchMetrics, nwc)
@@ -224,8 +224,6 @@ func makeAutoscaleEnforcerPlugin(
 	if _, err := p.watchMigrationEvents(ctx, logger, watchMetrics, mwc); err != nil {
 		return nil, fmt.Errorf("Error starting VM Migration watcher: %w", err)
 	}
-
-	watchMetrics.MustRegister(promReg)
 
 	// Set up tracking the initial events, now that we know the count:
 	totalQueued := initEventsCount.Load()


### PR DESCRIPTION
This is a deeper fix for #1231: We wouldn't need to remember to register metrics if they were always registered during construction.

So this is a codebase-wide switch from patterns like:

```go
func NewMetrics() Metrics {
    // ...
}

func (m Metrics) MustRegister(reg prometheus.Registerer) {
    // ...
}
```

to patterns like:

```go
func NewMetrics(reg prometheus.Registerer) {
    // ...
}
```

As it stands, this only really affects the autoscaler-agent.

<!-- affects all --> <!-- need to include that to allow the PR title to not reference a component -->

---

~~**Note: This PR builds on #1231 and must not be merged before it.**~~