### PR TITLE
Add cluster-trace-collector tool

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -59,6 +59,7 @@ env:
   IMG_AUTOSCALER_AGENT:   "neondatabase/autoscaler-agent"
   IMG_DAEMON:             "neondatabase/neonvm-daemon"
   IMG_CLUSTER_AUTOSCALER: "neondatabase/cluster-autoscaler-neonvm"
+  IMG_TRACE_COLLECTOR:    "neondatabase/cluster-trace-collector"
   ECR_DEV:                "369495373322.dkr.ecr.eu-central-1.amazonaws.com"
   ECR_PROD:               "093970136003.dkr.ecr.eu-central-1.amazonaws.com"
 
@@ -83,6 +84,7 @@ jobs:
       runner:             ${{ steps.show-tags.outputs.runner }}
       scheduler:          ${{ steps.show-tags.outputs.scheduler }}
       autoscaler-agent:   ${{ steps.show-tags.outputs.autoscaler-agent }}
+      trace-collector:    ${{ steps.show-tags.outputs.trace-collector }}
       cluster-autoscaler: ${{ steps.show-tags.outputs.cluster-autoscaler }}
       daemon:             ${{ steps.show-tags.outputs.daemon }}
     runs-on: ubuntu-latest
@@ -94,6 +96,7 @@ jobs:
           echo "runner=${{ env.IMG_RUNNER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
           echo "scheduler=${{ env.IMG_SCHEDULER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
           echo "autoscaler-agent=${{ env.IMG_AUTOSCALER_AGENT }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
+          echo "trace-collector=${{ env.IMG_TRACE_COLLECTOR }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
           echo "cluster-autoscaler=${{ env.IMG_CLUSTER_AUTOSCALER }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
           echo "daemon=${{ env.IMG_DAEMON }}:${{ inputs.tag }}" | tee -a $GITHUB_OUTPUT
 
@@ -311,6 +314,19 @@ jobs:
           build-args: |
             GO_BASE_IMG=${{ env.GO_BASE_IMG }}            
 
+      - name: Build and push cluster-trace-collector image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          file: cluster-trace-collector/Dockerfile
+          cache-from: type=registry,ref=cache.neon.build/cluster-trace-collector:cache
+          cache-to: ${{ github.ref_name == 'main' && 'type=registry,ref=cache.neon.build/cluster-trace-collector:cache,mode=max' || '' }}
+          tags: ${{ needs.tags.outputs.trace-collector }}
+          build-args: |
+            GO_BASE_IMG=${{ env.GO_BASE_IMG }}
+
       - name: Build and push cluster-autoscaler image
         uses: docker/build-push-action@v6
         if: ${{ format('{0}', inputs.build-cluster-autoscaler) == 'true' }}
@@ -332,6 +348,7 @@ jobs:
             vm-kernel \
             autoscale-scheduler \
             autoscaler-agent \
+            cluster-trace-collector \
             cluster-autoscaler-neonvm \
             ; do
             echo Copy ${image}:${{ inputs.tag }} to dev ECR

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ IMG_RUNNER ?= runner:dev
 IMG_DAEMON ?= daemon:dev
 IMG_SCHEDULER ?= autoscale-scheduler:dev
 IMG_AUTOSCALER_AGENT ?= autoscaler-agent:dev
+IMG_TRACE_COLLECTOR ?= cluster-trace-collector:dev
 
 # Shared base image for caching compiled dependencies.
 # It's only used during image builds, so doesn't need to be pushed.
@@ -165,7 +166,7 @@ lint: ## Run golangci-lint against code.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: docker-build-controller docker-build-runner docker-build-daemon docker-build-vxlan-controller docker-build-autoscaler-agent docker-build-scheduler ## Build docker images for NeonVM controllers, NeonVM runner, autoscaler-agent, scheduler
+docker-build: docker-build-controller docker-build-runner docker-build-daemon docker-build-vxlan-controller docker-build-autoscaler-agent docker-build-scheduler docker-build-trace-collector ## Build docker images for NeonVM controllers, NeonVM runner, autoscaler-agent, scheduler
 
 .PHONY: docker-push
 docker-push: docker-build ## Push docker images to docker registry
@@ -174,6 +175,7 @@ docker-push: docker-build ## Push docker images to docker registry
 	docker push -q $(IMG_VXLAN_CONTROLLER)
 	docker push -q $(IMG_SCHEDULER)
 	docker push -q $(IMG_AUTOSCALER_AGENT)
+	docker push -q $(IMG_TRACE_COLLECTOR)
 
 .PHONY: docker-build-go-base
 docker-build-go-base:
@@ -233,6 +235,14 @@ docker-build-scheduler: docker-build-go-base ## Build docker image for (autoscal
 		--build-arg GO_BASE_IMG=$(GO_BASE_IMG) \
 		--build-arg "GIT_INFO=$(GIT_INFO)" \
 		--file autoscale-scheduler/Dockerfile \
+		.
+
+.PHONY: docker-build-trace-collector
+docker-build-trace-collector: docker-build-go-base ## Build docker image for cluster trace collector
+	docker buildx build \
+		--tag $(IMG_TRACE_COLLECTOR) \
+		--build-arg GO_BASE_IMG=$(GO_BASE_IMG) \
+		--file cluster-trace-collector/Dockerfile \
 		.
 
 .PHONY: docker-build-examples

--- a/cluster-trace-collector/Dockerfile
+++ b/cluster-trace-collector/Dockerfile
@@ -1,0 +1,11 @@
+ARG GO_BASE_IMG=autoscaling-go-base:dev
+FROM $GO_BASE_IMG AS builder
+
+COPY . .
+# NOTE: Build flags here must be the same as in the base image, otherwise we'll rebuild
+# dependencies. See /Dockerfile.go-base for detail on the "why".
+RUN CGO_ENABLED=0 go build cluster-trace-collector/cmd/*.go
+
+FROM alpine:3.19
+COPY --from=builder /workspace/main /usr/bin/cluster-trace-collector
+ENTRYPOINT ["/usr/bin/cluster-trace-collector"]

--- a/cluster-trace-collector/cmd/event.go
+++ b/cluster-trace-collector/cmd/event.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+	"github.com/neondatabase/autoscaling/pkg/api"
+)
+
+type TraceEvent struct {
+	// Timestamp is the time at which this event was observed.
+	Timestamp metav1.Time `json:"ts"`
+
+	EventKind EventKind `json:"eventKind"`
+
+	ObjectKind string `json:"objectKind"`
+
+	// Name is the (potentially namespaced) name of the object. If the object *is* namespaced, this
+	// field has the format "<namespace>/<name>". Otherwise it's just the object's metadata.name.
+	Name string `json:"name"`
+	// UID is the value of the object's metadata.uid field.
+	UID string `json:"uid"`
+
+	// Labels is the subset of the object's labels that were configured to be preserved in the events
+	Labels map[string]string `json:"labels"`
+
+	// Preexisting, if present, indicates whether the object in a Created event already existed
+	// within the cluster (which will be the case on initial startup).
+	Preexisting *bool `json:"preexisting,omitempty"`
+
+	// DeletionRequested is true iff the object's metadata.deletionTimestamp field is set.
+	DeletionRequested bool `json:"deletionRequested"`
+
+	*ErrorData
+	*PodData
+	*NodeData
+}
+
+type EventKind string
+
+const (
+	EventCreated  EventKind = "Created"
+	EventModified EventKind = "Modified"
+	EventDeleted  EventKind = "Deleted"
+	EventError    EventKind = "Error"
+)
+
+type ErrorData struct {
+	Error string `json:"error"`
+}
+
+type PodData struct {
+	// NodeName is the node that the Pod has been scheduled onto, if it has been scheduled.
+	NodeName string `json:"nodeName"`
+
+	// IsVirtualMachine is true iff the
+	IsVirtualMachine bool `json:"IsVirtualMachine"`
+
+	// Resources gives the requested resources of the pod (if not a VM), or the VM's current
+	// requested CPU and memory amounts (if a VM).
+	Resources vmv1.VirtualMachineUsage `json:"resources"`
+
+	Priority                  *int32                            `json:"priority"`
+	Affinity                  *corev1.Affinity                  `json:"affinity"`
+	NodeSelector              map[string]string                 `json:"nodeSelector"`
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints"`
+	Tolerations               []corev1.Toleration               `json:"tolerations"`
+
+	*VirtualMachinePodData
+}
+
+type VirtualMachinePodData struct {
+	// SpecResourceBounds give the values of the VM's resource bounds, as configured by in the spec,
+	// for absolute limits on the size of the VM.
+	SpecResourceBounds vmv1.VirtualMachineResources `json:"SpecResourceBounds"`
+
+	AutoscalingEnabled bool `json:"autoscalingEnabled"`
+
+	// AutoscalingBounds give the resource bounds specified in the autoscaling bounds annotation, if
+	// autoscaling is enabled and the annotation is present.
+	AutoscalingBounds *api.ScalingBounds `json:"autoscalingBounds"`
+}
+
+func ExtractPodData(pod *corev1.Pod) (*PodData, error) {
+	_, isVM := vmv1.VirtualMachineOwnerForPod(pod)
+
+	var resources vmv1.VirtualMachineUsage
+	var vmData *VirtualMachinePodData
+
+	if !isVM {
+		cpu := new(resource.Quantity)
+		mem := new(resource.Quantity)
+
+		for _, container := range pod.Spec.Containers {
+			cpu.Add(*container.Resources.Requests.Cpu())
+			mem.Add(*container.Resources.Requests.Memory())
+		}
+
+		resources = vmv1.VirtualMachineUsage{CPU: cpu, Memory: mem}
+	} else {
+		var err error
+		vmData, resources, err = extractVirtualMachinePodData(pod)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &PodData{
+		NodeName:                  pod.Spec.NodeName,
+		IsVirtualMachine:          isVM,
+		Resources:                 resources,
+		Priority:                  pod.Spec.Priority,
+		Affinity:                  pod.Spec.Affinity,
+		NodeSelector:              pod.Spec.NodeSelector,
+		TopologySpreadConstraints: pod.Spec.TopologySpreadConstraints,
+		Tolerations:               pod.Spec.Tolerations,
+		VirtualMachinePodData:     vmData,
+	}, nil
+}
+
+func extractVirtualMachinePodData(
+	pod *corev1.Pod,
+) (*VirtualMachinePodData, vmv1.VirtualMachineUsage, error) {
+	usage, err := vmv1.VirtualMachineUsageFromPod(pod)
+	if err != nil {
+		usage := lo.Empty[vmv1.VirtualMachineUsage]()
+		return nil, usage, fmt.Errorf("failed to get VirtualMachine usage from annotation: %w", err)
+	}
+
+	specBounds, err := vmv1.VirtualMachineResourcesFromPod(pod)
+	if err != nil {
+		return nil, *usage, fmt.Errorf("failed to get VirtualMachine spec resources from annotation: %w", err)
+	}
+
+	autoscalingEnabled := api.HasAutoscalingEnabled(pod)
+
+	var autoscalingBounds *api.ScalingBounds
+	if autoscalingEnabled {
+		if ann, ok := pod.Annotations[api.AnnotationAutoscalingBounds]; ok {
+			autoscalingBounds = new(api.ScalingBounds)
+			if err := json.Unmarshal([]byte(ann), autoscalingBounds); err != nil {
+				return nil, *usage, fmt.Errorf("failed to parse autoscaling bounds annotation: %w", err)
+			}
+		}
+	}
+
+	data := &VirtualMachinePodData{
+		SpecResourceBounds: *specBounds,
+		AutoscalingEnabled: autoscalingEnabled,
+		AutoscalingBounds:  autoscalingBounds,
+	}
+
+	return data, *usage, nil
+}
+
+type NodeData struct {
+	AllocatableResources vmv1.VirtualMachineUsage `json:"allocatableResources"`
+
+	// Unschedulable gives the value of the Node's spec.unschedulable field, which is set to true
+	// when the node is cordoned.
+	Unschedulable bool `json:"unschedulable"`
+	// Ready is true iff the node has a "Ready" condition set to True.
+	Ready bool `json:"ready"`
+}
+
+func ExtractNodeData(node *corev1.Node) *NodeData {
+	var ready bool
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == "Ready" {
+			ready = condition.Status == "True"
+			break
+		}
+	}
+
+	return &NodeData{
+		AllocatableResources: vmv1.VirtualMachineUsage{
+			CPU:    node.Status.Allocatable.Cpu(),
+			Memory: node.Status.Allocatable.Memory(),
+		},
+		Unschedulable: node.Spec.Unschedulable,
+		Ready:         ready,
+	}
+}

--- a/cluster-trace-collector/cmd/main.go
+++ b/cluster-trace-collector/cmd/main.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/lithammer/shortuuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/neondatabase/autoscaling/pkg/reporting"
+	"github.com/neondatabase/autoscaling/pkg/util"
+)
+
+func main() {
+	logConfig := zap.NewProductionConfig()
+	logConfig.Sampling = nil                // Disable sampling, which the production config enables by default.
+	logConfig.Level.SetLevel(zap.InfoLevel) // Only "info" level and above (i.e. not debug logs)
+	logger := zap.Must(logConfig.Build()).Named("cluster-trace-collector")
+	defer logger.Sync() //nolint:errcheck // what are we gonna do, log something about it?
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer cancel()
+
+	args, err := getCli()
+	if err != nil {
+		logger.Fatal("could not get args from CLI", zap.Error(err))
+	}
+
+	k8sConfig, err := rest.InClusterConfig()
+	if err != nil {
+		logger.Fatal("could not get k8s client config", zap.Error(err))
+	}
+	k8sClient, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		logger.Fatal("could not create k8s client", zap.Error(err))
+	}
+
+	reg := prometheus.NewRegistry()
+
+	if err := util.StartPrometheusMetricsServer(ctx, logger.Named("prometheus"), 9100, reg); err != nil {
+		logger.Fatal("failed to start prometheus metrics server", zap.Error(err))
+	}
+
+	eventSink, err := setupReporting(ctx, logger, args, reg)
+	if err != nil {
+		logger.Fatal("failed to set up event reporting", zap.Error(err))
+	}
+
+	err = startK8sWatches(ctx, logger, k8sClient, reg, eventSink, args.keepPodLabels, args.keepNodeLabels)
+	if err != nil {
+		logger.Fatal("failed to start k8s watches", zap.Error(err))
+	}
+
+	// wait to be canceled by SIGTERM
+	<-ctx.Done()
+}
+
+func newBlobStorageKeyGenerator(prefix string) func() string {
+	return func() string {
+		now := time.Now().UTC()
+		id := shortuuid.New()
+
+		return fmt.Sprintf(
+			"%s/%d/%02d/%02d/%02d_events_%s.ndjson.gz",
+			prefix,
+			now.Year(), now.Month(), now.Day(),
+			now.Hour(), id,
+		)
+	}
+}
+
+type CliArgs struct {
+	// bucketPrefix is the prefix to use for files written to the S3 bucket or Azure Blob Storage
+	// container.
+	bucketPrefix string
+	// baseConfig is the shared configuration for event reporting
+	baseConfig *reporting.BaseClientConfig
+
+	// s3Config and AzureBlobConfig configure events are written to S3 / Azure Blob Storage.
+	// Exactly one of these must be present.
+	s3Config        *reporting.S3ClientConfig
+	azureBlobConfig *reporting.AzureBlobStorageClientConfig
+
+	keepPodLabels  []string
+	keepNodeLabels []string
+}
+
+func getCli() (*CliArgs, error) {
+	args := &CliArgs{
+		bucketPrefix:    "",
+		baseConfig:      nil,
+		s3Config:        nil,
+		azureBlobConfig: nil,
+		keepPodLabels:   []string{},
+		keepNodeLabels:  []string{},
+	}
+
+	flag.StringVar(
+		&args.bucketPrefix, "bucket-prefix", "",
+		"Sets the prefix to use for files written to the S3 bucket or Azure Blob Storage container",
+	)
+	flag.Func("base-config", "Sets the base configuration for event reporting", func(v string) error {
+		var cfg reporting.BaseClientConfig
+		if err := json.Unmarshal([]byte(v), &cfg); err != nil {
+			return fmt.Errorf("falied to unmarshal json: %w", err)
+		}
+		args.baseConfig = &cfg
+		return nil
+	})
+	flag.Func("s3-config", "Configures writing events to S3", func(v string) error {
+		var cfg reporting.S3ClientConfig
+		if err := json.Unmarshal([]byte(v), &cfg); err != nil {
+			return fmt.Errorf("falied to unmarshal json: %w", err)
+		}
+		args.s3Config = &cfg
+		return nil
+	})
+	flag.Func("azure-blob-config", "Configures writing events to Azure Blob Storage", func(v string) error {
+		var cfg reporting.AzureBlobStorageClientConfig
+		if err := json.Unmarshal([]byte(v), &cfg); err != nil {
+			return fmt.Errorf("falied to unmarshal json: %w", err)
+		}
+		args.azureBlobConfig = &cfg
+		return nil
+	})
+	flag.Func("keep-pod-labels", "Comma-separated list of Pod labels to preserve in events", func(v string) error {
+		if v != "" {
+			args.keepPodLabels = strings.Split(v, ",")
+		}
+		return nil
+	})
+	flag.Func("keep-node-labels", "Comma-separated list of Node labels to preserve in events", func(v string) error {
+		if v != "" {
+			args.keepNodeLabels = strings.Split(v, ",")
+		}
+		return nil
+	})
+
+	flag.Parse()
+
+	var errs []error
+
+	if args.bucketPrefix == "" {
+		errs = append(errs, errors.New("missing required argument '--bucket-prefix'"))
+	}
+	if args.baseConfig == nil {
+		errs = append(errs, errors.New("missing required argument '--base-config"))
+	}
+	if args.s3Config == nil && args.azureBlobConfig == nil {
+		errs = append(errs, errors.New(
+			"missing bucket configuration, must have '--s3-config' or '--azure-blob-config'",
+		))
+	} else if args.s3Config != nil && args.azureBlobConfig != nil {
+		errs = append(errs, errors.New(
+			"conflicting arguments '--s3-config' and '--azure-blob-config', must have just one",
+		))
+	}
+
+	if len(errs) != 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return args, nil
+}

--- a/cluster-trace-collector/cmd/reporting.go
+++ b/cluster-trace-collector/cmd/reporting.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	"github.com/neondatabase/autoscaling/pkg/reporting"
+)
+
+func setupReporting(
+	ctx context.Context,
+	logger *zap.Logger,
+	args *CliArgs,
+	reg *prometheus.Registry, // FIXME: change this to prometheus.Registerer after #1232
+) (*reporting.EventSink[TraceEvent], error) {
+	generateKey := newBlobStorageKeyGenerator(args.bucketPrefix)
+
+	var baseClient reporting.BaseClient
+	var clientName string
+
+	switch {
+	case args.s3Config != nil:
+		c, err := reporting.NewS3Client(ctx, *args.s3Config, generateKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up S3 client: %w", err)
+		}
+		baseClient = c
+		clientName = "s3"
+	case args.azureBlobConfig != nil:
+		c, err := reporting.NewAzureBlobStorageClient(*args.azureBlobConfig, generateKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up Azure Blob Storage client: %w", err)
+		}
+		baseClient = c
+		clientName = "azureblob"
+	default:
+		panic("expected to have one client")
+	}
+
+	metrics := reporting.NewEventSinkMetrics("autoscaling_trace_collector_reporting", reg)
+
+	client := reporting.Client[TraceEvent]{
+		Name:           clientName,
+		Base:           baseClient,
+		BaseConfig:     *args.baseConfig,
+		SerializeBatch: reporting.WrapSerialize[TraceEvent](reporting.GZIPCompress, reporting.JSONLinesMarshalBatch),
+	}
+
+	sink := reporting.NewEventSink[TraceEvent](logger.Named("reporting"), metrics, client)
+	return sink, nil
+}

--- a/cluster-trace-collector/cmd/watch.go
+++ b/cluster-trace-collector/cmd/watch.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/neondatabase/autoscaling/pkg/reporting"
+	"github.com/neondatabase/autoscaling/pkg/util"
+	"github.com/neondatabase/autoscaling/pkg/util/watch"
+)
+
+func startK8sWatches(
+	ctx context.Context,
+	logger *zap.Logger,
+	client clientset.Interface,
+	reg prometheus.Registerer,
+	sink *reporting.EventSink[TraceEvent],
+	keepPodLabels []string,
+	keepNodeLabels []string,
+) error {
+	metrics := watch.NewMetrics("autoscaling_trace_collector_watch", reg)
+
+	podsLogger := logger.Named("watch-pods")
+	_, err := watch.Watch(
+		ctx,
+		podsLogger.Named("watch"),
+		client.CoreV1().Pods(corev1.NamespaceAll),
+		watch.Config{
+			ObjectNameLogField: "Pod",
+			Metrics: watch.MetricsConfig{
+				Metrics:  metrics,
+				Instance: "Pods",
+			},
+			RetryRelistAfter: util.NewTimeRange(time.Millisecond, 500, 1000),
+			RetryWatchAfter:  util.NewTimeRange(time.Millisecond, 500, 1000),
+		},
+		watch.Accessors[*corev1.PodList, corev1.Pod]{
+			Items: func(list *corev1.PodList) []corev1.Pod { return list.Items },
+		},
+		watch.InitModeDefer,
+		metav1.ListOptions{},
+		watchHandlers(podsLogger, true, keepPodLabels, sink, func(event *TraceEvent, pod *corev1.Pod) error {
+			podData, err := ExtractPodData(pod)
+			if err != nil {
+				return err
+			}
+			event.PodData = podData
+			return nil
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to start pod watcher: %w", err)
+	}
+
+	nodesLogger := logger.Named("watch-nodes")
+	_, err = watch.Watch(
+		ctx,
+		nodesLogger.Named("watch"),
+		client.CoreV1().Nodes(),
+		watch.Config{
+			ObjectNameLogField: "Node",
+			Metrics: watch.MetricsConfig{
+				Metrics:  metrics,
+				Instance: "Nodes",
+			},
+			RetryRelistAfter: util.NewTimeRange(time.Millisecond, 500, 1000),
+			RetryWatchAfter:  util.NewTimeRange(time.Millisecond, 500, 1000),
+		},
+		watch.Accessors[*corev1.NodeList, corev1.Node]{
+			Items: func(list *corev1.NodeList) []corev1.Node { return list.Items },
+		},
+		watch.InitModeDefer,
+		metav1.ListOptions{},
+		watchHandlers(nodesLogger, false, keepNodeLabels, sink, func(event *TraceEvent, node *corev1.Node) error {
+			event.NodeData = ExtractNodeData(node)
+			return nil
+		}),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to start node watcher: %w", err)
+	}
+
+	return nil
+}
+
+func watchHandlers[T interface {
+	metav1.ObjectMetaAccessor
+	runtime.Object
+}](
+	logger *zap.Logger,
+	namespaced bool,
+	keepLabels []string,
+	sink *reporting.EventSink[TraceEvent],
+	setObjData func(*TraceEvent, T) error,
+) watch.HandlerFuncs[T] {
+	baseEvent := func(now time.Time, obj T, kind EventKind) TraceEvent {
+		ts := metav1.NewTime(now)
+
+		meta := obj.GetObjectMeta()
+		name := meta.GetName()
+		if namespaced {
+			ns := meta.GetNamespace()
+			if ns == "" {
+				ns = "default"
+			}
+			name = fmt.Sprint(ns, "/", name)
+		}
+		uid := meta.GetUID()
+
+		eventLabels := make(map[string]string)
+		objLabels := meta.GetLabels()
+		for _, label := range keepLabels {
+			if value, ok := objLabels[label]; ok {
+				eventLabels[label] = value
+			}
+		}
+
+		deletionRequested := meta.GetDeletionTimestamp() != nil
+
+		objKind := obj.GetObjectKind().GroupVersionKind().Kind
+
+		return TraceEvent{
+			Timestamp:         ts,
+			EventKind:         kind,
+			ObjectKind:        objKind,
+			Name:              name,
+			UID:               string(uid),
+			Labels:            eventLabels,
+			Preexisting:       nil, // Will be set by caller, only on Add
+			DeletionRequested: deletionRequested,
+			PodData:           nil, // Set by caller
+			NodeData:          nil, // Set by caller
+			ErrorData:         nil, // Set by caller
+		}
+	}
+
+	submitError := func(obj T, err error, preexisting *bool) {
+		event := baseEvent(time.Now(), obj, EventError)
+		event.Preexisting = preexisting
+		event.ErrorData = &ErrorData{
+			Error: err.Error(),
+		}
+
+		logger.Error(
+			fmt.Sprintf("Failed to extract object data from %s", event.ObjectKind),
+			zap.String("name", event.Name),
+			zap.Error(err),
+		)
+		sink.Enqueue(event)
+	}
+
+	return watch.HandlerFuncs[T]{
+		AddFunc: func(obj T, preexisting bool) {
+			event := baseEvent(time.Now(), obj, EventCreated)
+			event.Preexisting = &preexisting
+
+			err := setObjData(&event, obj)
+			if err != nil {
+				submitError(obj, err, &preexisting)
+				return
+			}
+
+			sink.Enqueue(event)
+		},
+		UpdateFunc: func(oldObj T, newObj T) {
+			now := time.Now()
+			oldEvent := baseEvent(now, oldObj, EventModified)
+			newEvent := baseEvent(now, newObj, EventModified)
+
+			oldErr := setObjData(&oldEvent, oldObj)
+			newErr := setObjData(&newEvent, newObj)
+
+			// emit an error if EITHER it's newly erroring, or it's already erroring but the error
+			// message changed.
+			emitError := (oldErr == nil && newErr != nil) ||
+				(oldErr != nil && newErr != nil && oldErr.Error() != newErr.Error())
+
+			if newErr != nil {
+				if emitError {
+					submitError(newObj, newErr, nil)
+				}
+				return
+			}
+
+			// Emit this event only if newEvent != oldEvent
+			if !reflect.DeepEqual(oldEvent, newEvent) {
+				sink.Enqueue(newEvent)
+			}
+		},
+		DeleteFunc: func(obj T, mayBeStale bool) {
+			event := baseEvent(time.Now(), obj, EventCreated)
+
+			err := setObjData(&event, obj)
+			if err != nil {
+				submitError(obj, err, nil)
+				return
+			}
+
+			sink.Enqueue(event)
+		},
+	}
+}

--- a/pkg/util/watch/watch.go
+++ b/pkg/util/watch/watch.go
@@ -120,6 +120,16 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 		panic(errors.New("accessors.Items == nil"))
 	}
 
+	// Workaround for https://github.com/kubernetes/kubernetes/issues/98925 :
+	//
+	// Pre-calculate the GVK for the object types, because List() operations only set the
+	// Kind+APIVersion on the List type, and not the individual elements.
+	sampleObj := P(new(T))
+	gvk, err := util.LookupGVKForType(sampleObj)
+	if err != nil {
+		return nil, err
+	}
+
 	// do the conversion from P -> *T. We wanted the handlers to be provided with P so that the
 	// caller doesn't need to manually specify the generics, but in order to store the callbacks
 	// inside the watch store, we need to convert them so we're not carrying around more generic
@@ -193,6 +203,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 	} else {
 		for i := range items {
 			obj := &items[i]
+			P(obj).GetObjectKind().SetGroupVersionKind(gvk)
 			uid := P(obj).GetObjectMeta().GetUID()
 			store.objects[uid] = obj
 			store.handlers.AddFunc(obj, true)
@@ -248,6 +259,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 		// deal with possible racy operations (including adding an index).
 		for i := range deferredAdds {
 			obj := &deferredAdds[i]
+			P(obj).GetObjectKind().SetGroupVersionKind(gvk)
 			uid := P(obj).GetObjectMeta().GetUID()
 			store.objects[uid] = obj
 			store.handlers.AddFunc(obj, true)
@@ -311,6 +323,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 						)
 						continue
 					}
+					P(obj).GetObjectKind().SetGroupVersionKind(gvk)
 
 					meta := obj.GetObjectMeta()
 					// Update ResourceVersion so subsequent calls to client.Watch won't include this
@@ -455,6 +468,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 					for i := range relistItems {
 						obj := &relistItems[i]
 						uid := P(obj).GetObjectMeta().GetUID()
+						P(obj).GetObjectKind().SetGroupVersionKind(gvk)
 
 						store.objects[uid] = obj
 						oldObj, hasObj := oldObjects[uid]


### PR DESCRIPTION
This new tool exists so that we can capture a scheduling/scaling "trace" from production (basically: a record of exactly all the operations that happened). This way, we have some real data available to use in simulations for changes to our scheduling policies, AND we can use that data to extrapolate out to how changes in load will be handled.

The architecture is pretty simple:

* Reuse `pkg/util/watch` to get a stream of events on Pod and Node objects
* Extract the useful bits out of each event
* If the useful bits changed, send it off to S3/Azure Blob with an event sink from `pkg/reporting`

ref neondatabase/cloud#23343

---

**Notes:**

- This is currently hacked together pretty quickly! Planning to add docs before requesting review.
- Currently the deployment manifest isn't managed here. I think that _maybe_ makes sense? Not sure -- would be good to discuss!
- This PR builds on a handful of commits from #1163 -- notably *not* the scheduler changes, but virtually everything else around it