### PR TITLE
ci: add sbom and provenance fields equal false

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -209,6 +209,8 @@ jobs:
         uses: docker/build-push-action@v6
         id: build-go-dependencies-image
         with:
+          provenance: false
+          sbom: false
           context: .
           platforms: linux/amd64
           push: true
@@ -220,6 +222,8 @@ jobs:
       - name: Build and push neonvm-runner image
         uses: docker/build-push-action@v6
         with:
+          provenance: false
+          sbom: false
           context: .
           platforms: linux/amd64
           push: true
@@ -244,6 +248,8 @@ jobs:
       - name: Build and push neonvm-controller image
         uses: docker/build-push-action@v6
         with:
+          provenance: false
+          sbom: false
           context: .
           platforms: linux/amd64
           push: true
@@ -259,6 +265,8 @@ jobs:
       - name: Build and push neonvm-vxlan-controller image
         uses: docker/build-push-action@v6
         with:
+          provenance: false
+          sbom: false
           context: .
           platforms: linux/amd64
           push: true
@@ -273,6 +281,8 @@ jobs:
       - name: Build and push autoscale-scheduler image
         uses: docker/build-push-action@v6
         with:
+          provenance: false
+          sbom: false
           context: .
           platforms: linux/amd64
           push: true
@@ -287,6 +297,8 @@ jobs:
       - name: Build and push autoscaler-agent image
         uses: docker/build-push-action@v6
         with:
+          provenance: false
+          sbom: false
           context: .
           platforms: linux/amd64
           push: true
@@ -301,6 +313,8 @@ jobs:
       - name: Build and push neonvm-daemon image
         uses: docker/build-push-action@v6
         with:
+          provenance: false
+          sbom: false
           context: .
           platforms: linux/amd64
           push: true
@@ -315,6 +329,8 @@ jobs:
         uses: docker/build-push-action@v6
         if: ${{ format('{0}', inputs.build-cluster-autoscaler) == 'true' }}
         with:
+          provenance: false
+          sbom: false
           context: cluster-autoscaler
           platforms: linux/amd64
           push: true

--- a/.github/workflows/vm-kernel.yaml
+++ b/.github/workflows/vm-kernel.yaml
@@ -192,6 +192,8 @@ jobs:
           # Push kernel image only for scheduled builds or if workflow_dispatch/workflow_call input is true
           push: true
           pull: true
+          provenance: false
+          sbom: false
           file: neonvm-kernel/Dockerfile.kernel-builder
           cache-from: type=registry,ref=cache.neon.build/vm-kernel:cache
           cache-to: ${{ github.ref_name == 'main' && 'type=registry,ref=cache.neon.build/vm-kernel:cache,mode=max' || '' }}


### PR DESCRIPTION
Add sbom and provenance fields equal false to
docker/build-push-action calls to avoid
issues with copying images to ECR

#1251

More context in discussion https://github.com/neondatabase/autoscaling/pull/1138#discussion_r1945634996