### PR TITLE
ci: fix fail status in conclusion job

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -287,4 +287,4 @@ jobs:
       - name: Fail the job if any of the dependencies do not succeed or are skipped
         run: exit 1
         if: |
-          contains(needs.*.result, 'failed') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+          contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')


### PR DESCRIPTION
Use 'failure' instead of 'failed'