### PR TITLE
Makefile: separate coverage-html into a separate step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,15 @@ test: vet envtest ## Run tests.
 	find $(KUBEBUILDER_ASSETS) -type d -exec chmod 0755 {} \; ; \
 	CGO_ENABLED=0 \
 		go test $(TESTARGS) -coverprofile cover.out
+	make coverage-html
+
+.PHONY: coverage-html
+coverage-html: ## Generate HTML coverage report.
 	go tool cover -html=cover.out -o cover.html
+
+.PHONY: show-coverage
+show-coverage: ## Show coverage report.
+	open cover.html
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,14 @@ vet: ## Run go vet against code.
 	# ref https://github.com/golang/go/issues/56755
 	GOOS=linux CGO_ENABLED=0 go vet ./...
 
+##@ Tests
 
 TESTARGS ?= ./...
 .PHONY: test
-test: vet envtest ## Run tests.
+test: vet envtest run-test coverage-html
+
+.PHONY: run-test
+run-test:
 	# chmodding KUBEBUILDER_ASSETS dir to make it deletable by owner,
 	# otherwise it fails with actions/checkout on self-hosted GitHub runners
 	# 	ref: https://github.com/kubernetes-sigs/controller-runtime/pull/2245
@@ -137,14 +141,13 @@ test: vet envtest ## Run tests.
 	find $(KUBEBUILDER_ASSETS) -type d -exec chmod 0755 {} \; ; \
 	CGO_ENABLED=0 \
 		go test $(TESTARGS) -coverprofile cover.out
-	make coverage-html
 
 .PHONY: coverage-html
 coverage-html: ## Generate HTML coverage report.
 	go tool cover -html=cover.out -o cover.html
 
 .PHONY: show-coverage
-show-coverage: ## Show coverage report.
+show-coverage: coverage-html
 	open cover.html
 
 ##@ Build


### PR DESCRIPTION
More convenient for local dev. 