### PR TITLE
plugin: Set k8s client QPS to 1k/s

### DIFF
--- a/pkg/plugin/entrypoint.go
+++ b/pkg/plugin/entrypoint.go
@@ -37,6 +37,7 @@ func NewAutoscaleEnforcerPlugin(
 	// The handler's ContentType is not the default "application/json" (it's protobuf), so we need
 	// to set it back to JSON because NeonVM doesn't support protobuf.
 	vmConfig.ContentType = "application/json"
+	vmConfig.QPS = 1000 // default QPS is 5. That's too little to handle thousands of pods.
 	vmClient, err := vmclient.NewForConfig(vmConfig)
 	if err != nil {
 		return nil, fmt.Errorf("could not create NeonVM client: %w", err)


### PR DESCRIPTION
The default if unset is 5/s — the config we inherit from the core scheduler is definitely more than that, but also clearly much less than 1k/s, which is more likely to be sufficient.