### PR TITLE
CI(lint): golangci-lint v1.64.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and
           # should be specified with patch version.
-          version: v1.62.2
+          version: v1.64.5
           args: --timeout 5m
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/pkg/reporting/client_azureblob.go
+++ b/pkg/reporting/client_azureblob.go
@@ -110,7 +110,7 @@ func (r *azureRequest) LogFields() zap.Field {
 func (r *azureRequest) Send(ctx context.Context, payload []byte) SimplifiableError {
 	var err error
 
-	opts := azblob.UploadBufferOptions{} //nolint:exhaustruct // It's part of Azure SDK
+	opts := azblob.UploadBufferOptions{}
 	_, err = r.client.UploadBuffer(ctx, r.cfg.Container, r.key, payload, &opts)
 	if err != nil {
 		return AzureError{Err: err}

--- a/pkg/reporting/client_azureblobbilling_test.go
+++ b/pkg/reporting/client_azureblobbilling_test.go
@@ -79,7 +79,7 @@ func TestAzureClient_send(t *testing.T) {
 				require.Error(t, o.err)
 				var azErr AzureError
 				require.ErrorAs(t, o.err, &azErr)
-				rErr := &azcore.ResponseError{} //nolint:exhaustruct // OK for tests
+				rErr := &azcore.ResponseError{}
 				require.ErrorAs(t, o.err, &rErr)
 				require.Equal(t, 404, rErr.StatusCode)
 			},
@@ -88,7 +88,7 @@ func TestAzureClient_send(t *testing.T) {
 			name: "can write then read it",
 			when: func(t *testing.T, i *input) {
 				_, err := i.client.client.CreateContainer(i.ctx, i.cfg.Container,
-					&azblob.CreateContainerOptions{}, //nolint:exhaustruct // OK for tests
+					&azblob.CreateContainerOptions{},
 				)
 				require.NoError(t, err)
 			},
@@ -97,7 +97,7 @@ func TestAzureClient_send(t *testing.T) {
 				b := make([]byte, 1000)
 				const expectedText = "hello, billing data is here"
 				read, err := o.c.client.DownloadBuffer(o.ctx, "test-container", "test-blob-name", b,
-					&azblob.DownloadBufferOptions{}, //nolint:exhaustruct // OK for tests
+					&azblob.DownloadBufferOptions{},
 				)
 				b = b[0:read]
 				require.NoError(t, err)


### PR DESCRIPTION
Bump `golangci-lint` to the latest version