### PR TITLE
[draft] go 1.24

### DIFF
--- a/Dockerfile.go-base
+++ b/Dockerfile.go-base
@@ -1,6 +1,6 @@
 # Base image for go dependencies, to speed up builds when they haven't changed.
 # For more, see https://github.com/neondatabase/go-chef
-FROM golang:1.23-alpine AS chef
+FROM golang:1.24-alpine AS chef
 
 ARG GO_CHEF_VERSION=v0.1.0
 RUN go install github.com/neondatabase/go-chef@$GO_CHEF_VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/neondatabase/autoscaling
 
-go 1.23.0
+go 1.24.0
 
 replace (
 	github.com/google/gnostic => github.com/google/gnostic v0.7.0

--- a/neonvm/hack/Dockerfile.generate
+++ b/neonvm/hack/Dockerfile.generate
@@ -1,4 +1,4 @@
-FROM golang:1.23
+FROM golang:1.24
 
 RUN apt-get update && apt-get install -y patch
 


### PR DESCRIPTION
Keeping this in draft until go 1.24.1 is released.

https://go.dev/blog/go1.24