### PR TITLE
plugin/metrics: Update metrics in-place when possible

### DIFF
--- a/pkg/plugin/metrics/metrics.go
+++ b/pkg/plugin/metrics/metrics.go
@@ -20,7 +20,7 @@ type Plugin struct {
 	nodeLabels nodeLabeling
 
 	Framework Framework
-	Nodes     Node
+	Nodes     *Node
 	Reconcile Reconcile
 
 	ResourceRequests      *prometheus.CounterVec

--- a/pkg/plugin/metrics/node.go
+++ b/pkg/plugin/metrics/node.go
@@ -23,12 +23,12 @@ type Node struct {
 	mem *prometheus.GaugeVec
 }
 
-func buildNodeMetrics(labels nodeLabeling, reg prometheus.Registerer) Node {
+func buildNodeMetrics(labels nodeLabeling, reg prometheus.Registerer) *Node {
 	finalMetricLabels := []string{"node"}
 	finalMetricLabels = append(finalMetricLabels, labels.metricLabelNames...)
 	finalMetricLabels = append(finalMetricLabels, "field")
 
-	return Node{
+	return &Node{
 		InheritedLabels: labels.k8sLabelNames,
 
 		mu:         sync.Mutex{},


### PR DESCRIPTION
Fixes #1276.

Currently, the way we update these node metrics is by removing all the old ones, then adding back the current values. We do it that way so that the old values can be cleaned up when there's label changes.

However: if metrics are scraped in between removing the old and adding the new, we can end up with single-datapoint gaps for one node at a time.

So to fix this, we should avoid removing the old metrics if and only if the labels are unchanged -- which we can check just by storing the previous labels we used.