### PR TITLE
Fix vm-monitor build in test images

### DIFF
--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -51,7 +51,7 @@ files:
 
 build: |
   # Build vm-monitor
-  FROM rust:1.83-alpine AS monitor-builder
+  FROM rust:1.85-alpine AS monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -36,7 +36,7 @@ files:
     hostPath: cgconfig.conf
 build: |
   # Build vm-monitor
-  FROM rust:1.83-alpine AS monitor-builder
+  FROM rust:1.85-alpine AS monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev


### PR DESCRIPTION
PR https://github.com/neondatabase/neon/pull/10916 updated the rust edition in the neon repository. Need to use a newer Rust compiler now.