### PR TITLE
neonvm: ensure the TLS mount directory is available in the VM

### DIFF
--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -230,11 +230,10 @@ func run(logger *zap.Logger) error {
 		// add the tls path.
 		// this is needed to just `mkdir` the mounting directory.
 		if vmSpec.TLS != nil {
-			watch := true
 			disks = append(disks, vmv1.Disk{
 				Name:      "tls-keys",
 				MountPath: vmSpec.TLS.MountPath,
-				Watch:     &watch,
+				Watch:     lo.ToPtr(true),
 				ReadOnly:  nil,
 				DiskSource: vmv1.DiskSource{
 					EmptyDisk: nil,

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -225,13 +225,33 @@ func run(logger *zap.Logger) error {
 
 	// create iso9660 disk with runtime options (command, args, envs, mounts)
 	tg.Go("iso9660-runtime", func(logger *zap.Logger) error {
+		disks := vmSpec.Disks
+
+		// add the tls path.
+		// this is needed to just `mkdir` the mounting directory.
+		if vmSpec.TLS != nil {
+			watch := true
+			disks = append(disks, vmv1.Disk{
+				Name:      "tls-keys",
+				MountPath: vmSpec.TLS.MountPath,
+				Watch:     &watch,
+				ReadOnly:  nil,
+				DiskSource: vmv1.DiskSource{
+					EmptyDisk: nil,
+					ConfigMap: nil,
+					Secret:    nil,
+					Tmpfs:     nil,
+				},
+			})
+		}
+
 		return createISO9660runtime(
 			runtimeDiskPath,
 			vmSpec.Guest.Command,
 			vmSpec.Guest.Args,
 			sysctl,
 			vmSpec.Guest.Env,
-			vmSpec.Disks,
+			disks,
 			enableSSH,
 			swapSize,
 			shmSize,
@@ -686,8 +706,9 @@ func monitorFiles(ctx context.Context, logger *zap.Logger, wg *sync.WaitGroup, v
 	}
 
 	if vmSpec.TLS != nil {
-		secrets["/vm/mounts/var/tls/..data"] = "/var/tls"
-		secretsOrd = append(secretsOrd, "/vm/mounts/var/tls/..data")
+		dataDir := fmt.Sprintf("/vm/mounts%s/..data", vmSpec.TLS.MountPath)
+		secrets[dataDir] = vmSpec.TLS.MountPath
+		secretsOrd = append(secretsOrd, dataDir)
 	}
 
 	if len(secretsOrd) == 0 {

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -182,6 +182,12 @@ type TLSProvisioning struct {
 
 	// This is the common name for the TLS certificate
 	ServerName string `json:"serverName,omitempty"`
+
+	// Which directory in the VM these certificates should be mounted to.
+	// Will be exposed as `tls.key` and `tls.crt`.
+	// +kubebuilder:default:=/var/tls
+	// +optional
+	MountPath string `json:"mountPath,omitempty"`
 }
 
 func (spec *VirtualMachineSpec) Resources() VirtualMachineResources {

--- a/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -3010,6 +3010,12 @@ spec:
                     description: This is required to set the duration that the certificate
                       should be valid for before expiring
                     type: string
+                  mountPath:
+                    default: /var/tls
+                    description: |-
+                      Which directory in the VM these certificates should be mounted to.
+                      Will be exposed as `tls.key` and `tls.crt`.
+                    type: string
                   renewBefore:
                     description: This is required to set the duration before certificate
                       expiration that the certificate is renewed

--- a/pkg/neonvm/controllers/vm_controller.go
+++ b/pkg/neonvm/controllers/vm_controller.go
@@ -1691,7 +1691,7 @@ func podSpec(
 		// Add TLS secret
 		mnt := corev1.VolumeMount{
 			Name:      "tls",
-			MountPath: fmt.Sprintf("/vm/mounts%s", "/var/tls"),
+			MountPath: fmt.Sprintf("/vm/mounts%s", vm.Spec.TLS.MountPath),
 		}
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, mnt)
 		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{

--- a/tests/e2e/vm-tls/00-assert.yaml
+++ b/tests/e2e/vm-tls/00-assert.yaml
@@ -1,6 +1,11 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 70
+commands:
+  - script: |
+      set -eux
+      pod="$(kubectl get neonvm -n "$NAMESPACE" example -o jsonpath='{.status.podName}')"
+      kubectl exec -n "$NAMESPACE" $pod -- scp guest-vm:/var/tls/tls.crt tls.crt
 ---
 apiVersion: vm.neon.tech/v1
 kind: VirtualMachine


### PR DESCRIPTION
While testing, I noticed that the certificates were not getting copied inside the VM, but they were available in the pod.

I remember thinking about it, but it seems like I forgot that the `mounts.sh` still needs to `mkdir -p ...` the directory for the secrets.

In the process, I decided to make the mount dir configurable and add an additional test to check the file exists in the VM.