### PR TITLE
CI: push images to ACR

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -3,3 +3,11 @@ self-hosted-runner:
     - gen3
     - large
     - small
+config-variables:
+  - AZURE_DEV_CLIENT_ID
+  - AZURE_DEV_REGISTRY_NAME
+  - AZURE_DEV_SUBSCRIPTION_ID
+  - AZURE_PROD_CLIENT_ID
+  - AZURE_PROD_REGISTRY_NAME
+  - AZURE_PROD_SUBSCRIPTION_ID
+  - AZURE_TENANT_ID

--- a/.github/workflows/_push-to-acr.yaml
+++ b/.github/workflows/_push-to-acr.yaml
@@ -1,0 +1,58 @@
+name: Push images to ACR
+on:
+  workflow_call:
+    inputs:
+      client_id:
+        description: Client ID of Azure managed identity or Entra app
+        required: true
+        type: string
+      image_tag:
+        description: Tag for the container images
+        required: true
+        type: string
+      images:
+        description: List of images
+        required: true
+        type: string
+      registry_name:
+        description: Name of the container registry
+        required: true
+        type: string
+      subscription_id:
+        description: Azure subscription ID
+        required: true
+        type: string
+      tenant_id:
+        description: Azure tenant ID
+        required: true
+        type: string
+
+jobs:
+  push-to-acr:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read  # This is required for actions/checkout
+      id-token: write # This is required for Azure Login to work.
+
+    steps:
+      - name: Azure login
+        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a  # @v2.1.1
+        with:
+          client-id: ${{ inputs.client_id }}
+          subscription-id: ${{ inputs.subscription_id }}
+          tenant-id: ${{ inputs.tenant_id }}
+
+      - name: Login to ACR
+        run: |
+          az acr login --name=${{ inputs.registry_name }}
+
+      - name: Copy docker images to ACR ${{ inputs.registry_name }}
+        env:
+          IMAGES: ${{ inputs.images }}
+          TAG: ${{ inputs.image_tag }}
+        run: |
+          for image in ${IMAGES}; do
+            docker buildx imagetools create \
+              -t ${{ inputs.registry_name }}.azurecr.io/neondatabase/${image}:${TAG} \
+                                                        neondatabase/${image}:${TAG}
+          done

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -22,7 +22,7 @@ on:
         description: 'ONLY USE FOR E2E TESTS: Set neonvm-controller to never delete VM runner pods'
         type: boolean
         required: false
-      upload-to-ecr:
+      upload-to-ecr-acr:
         description: 'Should images be uploaded to neon ECR'
         type: boolean
         required: false
@@ -354,7 +354,7 @@ jobs:
           password: ${{ secrets.NEON_DOCKERHUB_PASSWORD }}
 
       - name: Configure dev AWS credentials
-        if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+        if: ${{ format('{0}', inputs.upload-to-ecr-acr) == 'true' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
@@ -362,13 +362,13 @@ jobs:
           role-to-assume: ${{ secrets.DEV_GHA_OIDC_ECR_ROLE }}
 
       - name: Login to dev ECR
-        if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+        if: ${{ format('{0}', inputs.upload-to-ecr-acr) == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.ECR_DEV }}
 
       - name: Configure prod AWS credentials
-        if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+        if: ${{ format('{0}', inputs.upload-to-ecr-acr) == 'true' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: eu-central-1
@@ -376,7 +376,7 @@ jobs:
           role-to-assume: ${{ secrets.PROD_GHA_OIDC_ECR_ROLE }}
 
       - name: Login to prod ECR
-        if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+        if: ${{ format('{0}', inputs.upload-to-ecr-acr) == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.ECR_PROD }}
@@ -403,7 +403,7 @@ jobs:
           done
 
       - name: Copy all merged images to ECR
-        if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+        if: ${{ format('{0}', inputs.upload-to-ecr-acr) == 'true' }}
         run: |
           images=("neonvm-controller" \
           "neonvm-vxlan-controller" \
@@ -422,7 +422,7 @@ jobs:
           done
 
   push-to-acr-dev:
-    if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+    if: ${{ format('{0}', inputs.upload-to-ecr-acr) == 'true' }}
     needs: [ merge-images ]
     uses: ./.github/workflows/_push-to-acr.yaml
     with:
@@ -435,7 +435,7 @@ jobs:
     secrets: inherit
 
   push-to-acr-prod:
-    if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+    if: ${{ format('{0}', inputs.upload-to-ecr-acr) == 'true' }}
     needs: [ merge-images ]
     uses: ./.github/workflows/_push-to-acr.yaml
     with:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -420,3 +420,29 @@ jobs:
             docker buildx imagetools create -t ${{ env.ECR_PROD }}/${image}:${{ inputs.tag }} \
                                                neondatabase/${image}:${{ inputs.tag }}
           done
+
+  push-to-acr-dev:
+    if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+    needs: [ merge-images ]
+    uses: ./.github/workflows/_push-to-acr.yaml
+    with:
+      client_id: ${{ vars.AZURE_DEV_CLIENT_ID }}
+      image_tag: ${{ inputs.tag }}
+      images: neonvm-controller neonvm-vxlan-controller neonvm-runner autoscale-scheduler autoscaler-agent cluster-autoscaler-neonvm
+      registry_name: ${{ vars.AZURE_DEV_REGISTRY_NAME }}
+      subscription_id: ${{ vars.AZURE_DEV_SUBSCRIPTION_ID }}
+      tenant_id: ${{ vars.AZURE_TENANT_ID }}
+    secrets: inherit
+
+  push-to-acr-prod:
+    if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+    needs: [ merge-images ]
+    uses: ./.github/workflows/_push-to-acr.yaml
+    with:
+      client_id: ${{ vars.AZURE_PROD_CLIENT_ID }}
+      images: neonvm-controller neonvm-vxlan-controller neonvm-runner autoscale-scheduler autoscaler-agent cluster-autoscaler-neonvm
+      image_tag: ${{ inputs.tag }}
+      registry_name: ${{ vars.AZURE_PROD_REGISTRY_NAME }}
+      tenant_id: ${{ vars.AZURE_TENANT_ID }}
+      subscription_id: ${{ vars.AZURE_PROD_SUBSCRIPTION_ID }}
+    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
     needs: get-tag
     with:
       tag: ${{ needs.get-tag.outputs.tag }}
-      upload-to-ecr: true
+      upload-to-ecr-acr: true
       archs: '["amd64","arm64"]'
     secrets: inherit
 


### PR DESCRIPTION
This PR begins pushing images to ACR (along with ECR) for releases.

- Added `.github/workflows/_push-to-acr.yaml` workflow to push images to ACR (copied from `cloud` repo)
- Renamed `inputs.upload-to-ecr` to `inputs.upload-to-ecr-acr`


