### PR TITLE
neonvm-runner: Reduce startup logs

### DIFF
--- a/neonvm-runner/cmd/disks.go
+++ b/neonvm-runner/cmd/disks.go
@@ -171,7 +171,7 @@ func createISO9660runtime(
 	}
 
 	mounts := []string{
-		"set -euxo pipefail",
+		"set -euo pipefail",
 	}
 	if enableSSH {
 		mounts = append(mounts, "/neonvm/bin/mkdir -p /mnt/ssh")

--- a/neonvm-runner/cmd/disks.go
+++ b/neonvm-runner/cmd/disks.go
@@ -230,7 +230,7 @@ func createISO9660runtime(
 	if swapSize != nil {
 		lines := []string{
 			`#!/neonvm/bin/sh`,
-			`set -euxo pipefail`,
+			`set -euo pipefail`,
 			// this script may be run as root, so we should avoid potentially-malicious path
 			// injection
 			`export PATH="/neonvm/bin"`,

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -409,7 +409,8 @@ func buildQEMUCmd(
 }
 
 const (
-	baseKernelCmdline          = "panic=-1 init=/neonvm/bin/init loglevel=7 root=/dev/vda rw"
+	// this loglevel is used only during startup, later it is overriden during vminit
+	baseKernelCmdline          = "panic=-1 init=/neonvm/bin/init loglevel=6 root=/dev/vda rw"
 	kernelCmdlineVirtioMemTmpl = "memhp_default_state=online memory_hotplug.online_policy=auto-movable memory_hotplug.auto_movable_ratio=%s"
 )
 

--- a/neonvm-runner/cmd/net.go
+++ b/neonvm-runner/cmd/net.go
@@ -163,7 +163,7 @@ func defaultNetwork(logger *zap.Logger, cidr string, ports []vmv1.Port) (mac.MAC
 	// pass incoming traffic to .Guest.Spec.Ports into VM
 	var iptablesArgs []string
 	for _, port := range ports {
-		logger.Info(fmt.Sprintf("setup DNAT rule for incoming traffic to port %d", port.Port))
+		logger.Debug(fmt.Sprintf("setup DNAT rule for incoming traffic to port %d", port.Port))
 		iptablesArgs = []string{
 			"-t", "nat", "-A", "PREROUTING",
 			"-i", "eth0", "-p", fmt.Sprint(port.Protocol), "--dport", fmt.Sprint(port.Port),
@@ -173,7 +173,7 @@ func defaultNetwork(logger *zap.Logger, cidr string, ports []vmv1.Port) (mac.MAC
 			logger.Error("could not set up DNAT rule for incoming traffic", zap.Error(err))
 			return nil, err
 		}
-		logger.Info(fmt.Sprintf("setup DNAT rule for traffic originating from localhost to port %d", port.Port))
+		logger.Debug(fmt.Sprintf("setup DNAT rule for traffic originating from localhost to port %d", port.Port))
 		iptablesArgs = []string{
 			"-t", "nat", "-A", "OUTPUT",
 			"-m", "addrtype", "--src-type", "LOCAL", "--dst-type", "LOCAL",
@@ -184,7 +184,7 @@ func defaultNetwork(logger *zap.Logger, cidr string, ports []vmv1.Port) (mac.MAC
 			logger.Error("could not set up DNAT rule for traffic from localhost", zap.Error(err))
 			return nil, err
 		}
-		logger.Info(fmt.Sprintf("setup ACCEPT rule for traffic originating from localhost to port %d", port.Port))
+		logger.Debug(fmt.Sprintf("setup ACCEPT rule for traffic originating from localhost to port %d", port.Port))
 		iptablesArgs = []string{
 			"-A", "OUTPUT",
 			"-s", "127.0.0.1", "-d", ipVm.String(),
@@ -196,7 +196,7 @@ func defaultNetwork(logger *zap.Logger, cidr string, ports []vmv1.Port) (mac.MAC
 			return nil, err
 		}
 	}
-	logger.Info("setup MASQUERADE rule for traffic originating from localhost")
+	logger.Debug("setup MASQUERADE rule for traffic originating from localhost")
 	iptablesArgs = []string{
 		"-t", "nat", "-A", "POSTROUTING",
 		"-m", "addrtype", "--src-type", "LOCAL", "--dst-type", "UNICAST",

--- a/vm-builder/files/set-disk-quota.sh
+++ b/vm-builder/files/set-disk-quota.sh
@@ -18,6 +18,7 @@ echo "Setting disk quota for $mountpoint to $size KB"
 # setquota -P <project_id> <block-softlimit> <block-hardlimit> <inode-softlimit> <inode-hardlimit> <filesystem>
 /neonvm/bin/setquota -P 0 0 "$size" 0 0 "$mountpoint"
 
-echo "DONE! Disk quota set"
-/neonvm/bin/repquota -P -a
+# Don't print the quota report, it's too verbose
+# echo "DONE! Disk quota set"
+# /neonvm/bin/repquota -P -a
 

--- a/vm-builder/files/vminit
+++ b/vm-builder/files/vminit
@@ -25,6 +25,9 @@ mount -t proc  proc  /proc
 mount -t sysfs sysfs /sys
 mount -t cgroup2 cgroup2 /sys/fs/cgroup
 
+# change kernel log level to DEBUG
+echo 7 > /proc/sys/kernel/printk
+
 # Allow all users to move processes to/from the root cgroup.
 #
 # This is required in order to be able to 'cgexec' anything, if the entrypoint is not being run as

--- a/vm-builder/files/vminit
+++ b/vm-builder/files/vminit
@@ -60,4 +60,4 @@ ip link set up dev eth0
 
 # ssh
 # we use ed25519 keys and -N "" skips setting up a passphrase
-/neonvm/bin/ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+/neonvm/bin/ssh-keygen -q -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""


### PR DESCRIPTION
This PR disables verbose logging for repetitive startup logs, such as kernel debug boot logs.

It sets default kernel loglevel as INFO (https://docs.kernel.org/core-api/printk-basics.html) and vminit script sets loglevel back to DEBUG after booting has completed.

The full list of changes can be seen in commit messages.

Startup logs before this PR (559 lines): https://gist.github.com/petuhovskiy/cfa0e7654cd25b37247694a33a9d556b
Startup logs after this PR (123 lines): https://gist.github.com/petuhovskiy/a85a7dad7bb4015d2f1f33fcd6cce9fd

Closes https://github.com/neondatabase/cloud/issues/19678