### PR TITLE
agent/billing: Require OS hostname

### DIFF
--- a/pkg/agent/billing/hostname.go
+++ b/pkg/agent/billing/hostname.go
@@ -2,7 +2,6 @@ package billing
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 )
 
@@ -12,7 +11,7 @@ func init() {
 	var err error
 	hostname, err = os.Hostname()
 	if err != nil {
-		hostname = fmt.Sprintf("unknown-%d", rand.Intn(1000))
+		panic(fmt.Errorf("failed to get hostname: %w", err))
 	}
 }
 


### PR DESCRIPTION
Fixes #1257; the random hostname generation is a fallback that isn't ever used, so we should remove it to reduce confusion.