### PR TITLE
CI: pin docker images to sha

### DIFF
--- a/autoscale-scheduler/Dockerfile
+++ b/autoscale-scheduler/Dockerfile
@@ -6,6 +6,6 @@ COPY . .
 # dependencies. See /go-base.Dockerfile for detail on the "why".
 RUN CGO_ENABLED=0 go build autoscale-scheduler/cmd/*.go
 
-FROM alpine:3.19
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377
 COPY --from=builder /workspace/main /usr/bin/kube-scheduler
 ENTRYPOINT ["/usr/bin/kube-scheduler"]

--- a/autoscaler-agent/Dockerfile
+++ b/autoscaler-agent/Dockerfile
@@ -6,6 +6,6 @@ COPY . .
 # dependencies.
 RUN CGO_ENABLED=0 go build autoscaler-agent/cmd/*.go
 
-FROM alpine:3.19
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377
 COPY --from=builder /workspace/main /usr/bin/autoscaler-agent
 ENTRYPOINT ["/usr/bin/autoscaler-agent"]

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -1,6 +1,6 @@
 # NOTE: This must match CA's builder/Dockerfile:
 # https://github.com/kubernetes/autoscaler/blob/<GIT_TAG>/builder/Dockerfile
-FROM golang:1.22.2 AS builder
+FROM golang:1.22.2@sha256:d5302d40dc5fbbf38ec472d1848a9d2391a13f93293a6a5b0b87c99dc0eaa6ae AS builder
 
 WORKDIR /workspace
 

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -31,7 +31,7 @@ RUN cd autoscaler/cluster-autoscaler \
 # https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-1.24.1/cluster-autoscaler/Dockerfile.amd64
 # modified in a way to use gcr.io/distroless/static:nonroot without specifying the architecture.
 
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:6ec5aa99dc335666e79dc64e4a6c8b89c33a543a1967f20d360922a80dd21f02
 
 WORKDIR /
 COPY --from=builder /workspace/cluster-autoscaler .

--- a/go-base.Dockerfile
+++ b/go-base.Dockerfile
@@ -1,6 +1,6 @@
 # Base image for go dependencies, to speed up builds when they haven't changed.
 # For more, see https://github.com/neondatabase/go-chef
-FROM golang:1.23-alpine AS chef
+FROM golang:1.23.7-alpine@sha256:e438c135c348bd7677fde18d1576c2f57f265d5dfa1a6b26fca975d4aa40b3bb AS chef
 
 ARG GO_CHEF_VERSION=v0.1.0
 RUN go install github.com/neondatabase/go-chef@$GO_CHEF_VERSION

--- a/neonvm-controller/Dockerfile
+++ b/neonvm-controller/Dockerfile
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=0 go build -tags=${BUILDTAGS} -o manager neonvm-controller/cmd/*
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:6ec5aa99dc335666e79dc64e4a6c8b89c33a543a1967f20d360922a80dd21f02
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/neonvm-kernel/Dockerfile
+++ b/neonvm-kernel/Dockerfile
@@ -60,7 +60,7 @@ RUN cd linux-${KERNEL_VERSION} && make ARCH=x86_64 CROSS_COMPILE=x86_64-linux-gn
 # Copy the kernel image to a separate step
 # Use alpine so that `cp` is available when loading custom kernels for the runner pod.
 # See the neonvm controller's pod creation logic for more detail.
-FROM --platform=linux/amd64 alpine:3.19 AS kernel_amd64
+FROM --platform=linux/amd64 alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377 AS kernel_amd64
 ARG KERNEL_VERSION
 COPY --from=build_amd64 /build/linux-${KERNEL_VERSION}/arch/x86/boot/bzImage /vmlinuz
 
@@ -73,10 +73,10 @@ RUN cd linux-${KERNEL_VERSION} && make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gn
 # Copy the kernel image to a separate step
 # Use alpine so that `cp` is available when loading custom kernels for the runner pod.
 # See the neonvm controller's pod creation logic for more detail.
-FROM --platform=linux/arm64 alpine:3.19 AS kernel_arm64
+FROM --platform=linux/arm64 alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377 AS kernel_arm64
 ARG KERNEL_VERSION
 COPY --from=build_arm64 /build/linux-${KERNEL_VERSION}/arch/arm64/boot/Image /vmlinuz
 
 # Dummy default target without target architecture
-FROM alpine:3.19
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377
 RUN echo "No target architecture specified, can't build kernel image" && exit 1

--- a/neonvm-kernel/Dockerfile
+++ b/neonvm-kernel/Dockerfile
@@ -1,5 +1,5 @@
 # Force initial check that KERNEL_VERSION is set appropriately
-FROM ubuntu:24.04 AS check-arg
+FROM ubuntu:24.04@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782 AS check-arg
 ARG KERNEL_VERSION
 WORKDIR /build
 
@@ -8,7 +8,7 @@ RUN set -e \
     && test -n "${KERNEL_VERSION}" \
     && echo "force this as a requirement for build-deps" > /build/arg-check-succeeded
 
-FROM ubuntu:24.04 AS build-deps
+FROM ubuntu:24.04@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782 AS build-deps
 WORKDIR /build
 
 RUN apt-get update && apt-get -y install \

--- a/neonvm-runner/Dockerfile
+++ b/neonvm-runner/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 # Build
 RUN CGO_ENABLED=0 go build -o /runner neonvm-runner/cmd/*.go
 
-FROM alpine:3.19
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377
 
 RUN apk add --no-cache \
     tini \

--- a/neonvm-vxlan-controller/Dockerfile
+++ b/neonvm-vxlan-controller/Dockerfile
@@ -4,7 +4,7 @@ FROM $GO_BASE_IMG AS builder
 COPY . .
 RUN CGO_ENABLED=0 go build -o /vxlan-controller neonvm-vxlan-controller/cmd/*.go
 
-FROM alpine:3.19
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377
 
 ARG TARGET_ARCH
 ENV TARGET_ARCH=$TARGET_ARCH

--- a/neonvm/hack/generate.Dockerfile
+++ b/neonvm/hack/generate.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23
+FROM golang:1.23.7@sha256:1acb493b9f9dfdfe705042ce09e8ded908ce4fb342405ecf3ca61ce7f3b168c7
 
 RUN apt-get update && apt-get install -y patch
 

--- a/neonvm/samples/vm-example/Dockerfile
+++ b/neonvm/samples/vm-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19 AS rootdisk
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377 AS rootdisk
 
 RUN set -e \
 	&& apk add --no-cache \
@@ -35,7 +35,7 @@ ADD postgresql.conf /etc/postgresql/
 ADD pg_hba.conf     /etc/postgresql/
 
 
-FROM alpine:3.19 AS image
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377 AS image
 
 ARG DISK_SIZE=2G
 
@@ -47,6 +47,6 @@ RUN set -e \
     && rm -f /disk.raw \
     && qemu-img info /disk.qcow2
 
-FROM alpine:3.19
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377
 
 COPY --from=image /disk.qcow2 /

--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -75,7 +75,7 @@ build: |
   # At time of writing (2023-03-14), debian bullseye has a version of cgroup-tools (technically
   # libcgroup) that doesn't support cgroup v2 (version 0.41-11). Unfortunately, the vm-monitor
   # requires cgroup v2, so we'll build cgroup-tools ourselves.
-  FROM debian:bullseye-slim AS libcgroup-builder
+  FROM debian:bullseye-slim@sha256:33b7c2e071c29e618182ec872c471f39d2dde3d8904d95f5b7a61acf3a592e7b AS libcgroup-builder
   ENV LIBCGROUP_VERSION v2.0.3
 
   RUN set -exu \
@@ -107,7 +107,7 @@ build: |
 
   # Build pgbouncer
   #
-  FROM debian:bullseye-slim AS pgbouncer
+  FROM debian:bullseye-slim@sha256:33b7c2e071c29e618182ec872c471f39d2dde3d8904d95f5b7a61acf3a592e7b AS pgbouncer
   RUN set -e \
       && apt-get update \
       && apt-get install -y \

--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -103,7 +103,7 @@ build: |
       # actually build the thing...
       && make install
 
-  FROM quay.io/prometheuscommunity/postgres-exporter:v0.12.0 AS postgres-exporter
+  FROM quay.io/prometheuscommunity/postgres-exporter:v0.12.0@sha256:f34d50a64a4d558ad118ffc73be45a359ac8f30b8daba4b241458bcb9f94e254 AS postgres-exporter
 
   # Build pgbouncer
   #

--- a/tests/e2e/image-spec.yaml
+++ b/tests/e2e/image-spec.yaml
@@ -51,7 +51,7 @@ files:
 
 build: |
   # Build vm-monitor
-  FROM rust:1.85-alpine AS monitor-builder
+  FROM rust:1.85-alpine@sha256:1030547bd568497d69e41771ada279179f0613369dc54779e46a3f6f376b3020 AS monitor-builder
   WORKDIR /workspace
 
   RUN apk add musl-dev git openssl-dev

--- a/vm-builder/files/img.Dockerfile
+++ b/vm-builder/files/img.Dockerfile
@@ -11,7 +11,7 @@ FROM {{.NeonvmDaemonImage}} AS neonvm-daemon-loader
 
 FROM busybox:1.35.0-musl AS busybox-loader
 
-FROM alpine:3.19 AS vm-runtime
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377 AS vm-runtime
 ARG TARGET_ARCH
 RUN set -e && mkdir -p /neonvm/bin /neonvm/runtime /neonvm/config 
 # add busybox
@@ -109,7 +109,7 @@ RUN set -e \
     && /neonvm/bin/id -g sshd > /dev/null 2>&1 || /neonvm/bin/addgroup sshd \
     && /neonvm/bin/id -u sshd > /dev/null 2>&1 || /neonvm/bin/adduser -D -H -G sshd -g 'sshd privsep' -s /neonvm/bin/nologin sshd
 
-FROM alpine:3.19 AS builder
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377 AS builder
 ARG DISK_SIZE
 COPY --from=rootdisk-mod / /rootdisk
 
@@ -128,5 +128,5 @@ RUN set -e \
     && mkfs.ext4 -L vmroot -d /rootdisk /disk.raw ${DISK_SIZE} \
     && qemu-img convert -f raw -O qcow2 -o cluster_size=2M,lazy_refcounts=on /disk.raw /disk.qcow2
 
-FROM alpine:3.19
+FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377
 COPY --from=builder /disk.qcow2 /

--- a/vm-builder/files/img.Dockerfile
+++ b/vm-builder/files/img.Dockerfile
@@ -9,7 +9,7 @@ USER root
 
 FROM {{.NeonvmDaemonImage}} AS neonvm-daemon-loader
 
-FROM busybox:1.35.0-musl AS busybox-loader
+FROM busybox:1.35.0-musl@sha256:1602e40bcbe33b2424709f35005c974bb8de80a11e2722316535f38af3036da8 AS busybox-loader
 
 FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377 AS vm-runtime
 ARG TARGET_ARCH

--- a/vm-examples/pg16-disk-test/image-spec.yaml
+++ b/vm-examples/pg16-disk-test/image-spec.yaml
@@ -56,7 +56,7 @@ build: |
   RUN cargo clean --release --manifest-path neon/libs/vm_monitor/Cargo.toml
 
   # Build the allocation tester:
-  FROM alpine:3.19 AS allocate-loop-builder
+  FROM alpine:3.19.7@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377 AS allocate-loop-builder
   RUN set -e \
       && apk add gcc musl-dev
   COPY allocate-loop.c allocate-loop.c


### PR DESCRIPTION
This PR pins all docker images to their SHA checksums to prevent unintentional updates, improve build reproducibility, and improve their "cachability".

SHAs are generated using the following command:
```
docker buildx imagetools inspect --raw ${DOCKER_IMAGE} | openssl dgst -sha256
``` 
For example
```
$ docker buildx imagetools inspect --raw alpine:3.19 | openssl dgst -sha256
SHA2-256(stdin)= e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377

# And to double check that the value is correct:
$ docker buildx imagetools inspect --raw alpine:3.19@sha256:e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377 | openssl dgst -sha256
SHA2-256(stdin)= e5d0aea7f7d2954678a9a6269ca2d06e06591881161961ea59e974dff3f12377
```

All changes are noop. Where possible, I've added a patch version to image tags.