### PR TITLE
neonvm: drop generated default value in CRD

### DIFF
--- a/neonvm-controller/deployment.yaml
+++ b/neonvm-controller/deployment.yaml
@@ -55,6 +55,7 @@ spec:
         - "--concurrency-limit=128"
         - "--skip-update-validation-for="
         - "--disable-runner-cgroup"
+        - "--default-cpu-scaling-mode=QmpScaling"
         # See #775 and its links.
         # * cache.writeback=on - don't set O_DSYNC (don't flush every write)
         # * cache.direct=on    - use O_DIRECT (don't abuse host's page cache!)

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -242,7 +242,7 @@ func (p *CpuScalingMode) FlagFunc(value string) error {
 		string(CpuScalingModeSysfs),
 	}
 
-	if !slices.Contains(possibleValues, value) {
+	if !slices.Contains(possibleValues, value) || value == "" {
 		return fmt.Errorf("Unknown CpuScalingMode %q, must be one of %v", value, possibleValues)
 	}
 

--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -169,7 +169,6 @@ type VirtualMachineSpec struct {
 	TargetRevision *RevisionWithTime `json:"targetRevision,omitempty"`
 
 	// Controls how CPU scaling is performed, either hotplug new CPUs with QMP, or enable them in sysfs.
-	// +kubebuilder:default:=QmpScaling
 	// +optional
 	CpuScalingMode *CpuScalingMode `json:"cpuScalingMode,omitempty"`
 

--- a/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -998,7 +998,6 @@ spec:
                     type: object
                 type: object
               cpuScalingMode:
-                default: QmpScaling
                 description: Controls how CPU scaling is performed, either hotplug
                   new CPUs with QMP, or enable them in sysfs.
                 enum:


### PR DESCRIPTION
We use kubebuilder:default annotation for scaling mode fields, which effiectively means we never allow it to be non set and that bypasses the logic with --default-cpu-scaling-mode controller argument