### PR TITLE
ci/build-images: fix push to ECR

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -413,9 +413,12 @@ jobs:
           "${IMG_CLUSTER_AUTOSCALER}")
 
           for image in "${images[@]}"; do
+            # Remove "neondatabase/" prefix from image name
+            image_without_prefix=${image#neondatabase/}
+
             image_from=${image}:${TAG}
-            image_ecr_dev=${ECR_DEV}/${image#neondatabase/}:${TAG}
-            image_ecr_prod=${ECR_PROD}/${image#neondatabase/}:${TAG}
+            image_ecr_dev="${ECR_DEV}/${image_without_prefix}:${TAG}"
+            image_ecr_prod="${ECR_PROD}/${image_without_prefix}:${TAG}"
 
             echo "Copy ${image_from} to ${image_ecr_dev} (dev), and ${image_ecr_prod} (prod)"
 

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -401,6 +401,8 @@ jobs:
 
       - name: Copy all merged images to ECR
         if: ${{ format('{0}', inputs.upload-to-ecr) == 'true' }}
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
           # note: excludes neonvm-daemon because we only need it during CI, to build compute images.
           images=("${IMG_CONTROLLER}" \
@@ -411,10 +413,13 @@ jobs:
           "${IMG_CLUSTER_AUTOSCALER}")
 
           for image in "${images[@]}"; do
-            echo Copy ${image}:${{ inputs.tag }} to dev ECR
-            docker buildx imagetools create -t ${{ env.ECR_DEV }}/${image}:${{ inputs.tag }} \
-                                               neondatabase/${image}:${{ inputs.tag }}
-            echo Copy ${image}:${{ inputs.tag }} to prod ECR
-            docker buildx imagetools create -t ${{ env.ECR_PROD }}/${image}:${{ inputs.tag }} \
-                                               neondatabase/${image}:${{ inputs.tag }}
+            image_from=${image}:${TAG}
+            image_ecr_dev=${ECR_DEV}/${image#neondatabase/}:${TAG}
+            image_ecr_prod=${ECR_PROD}/${image#neondatabase/}:${TAG}
+
+            echo "Copy ${image_from} to ${image_ecr_dev} (dev), and ${image_ecr_prod} (prod)"
+
+            docker buildx imagetools create -t ${image_ecr_dev} \
+                                            -t ${image_ecr_prod} \
+                                               ${image_from}
           done


### PR DESCRIPTION
Push to ECR started to fail after https://github.com/neondatabase/autoscaling/pull/1312 changes:

```
Copy neondatabase/neonvm-controller:testrelease-20250311.1c7bb48.13791913752 to dev ECR
ERROR: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```
Spotted in [link](https://github.com/neondatabase/autoscaling/actions/runs/13791913752/job/38574226461?pr=1311#step:11:36)

It tries to push images to `<ECR>/neondatabase/<IMAGE_NAME>` instead of `<ECR>/<IMAGE_NAME>`