### PR TITLE
reporting/batch: Remove newlines in JSONArrayBuilder

### DIFF
--- a/pkg/reporting/batch_jsonarray.go
+++ b/pkg/reporting/batch_jsonarray.go
@@ -51,7 +51,7 @@ func NewJSONArrayBuilder[E any](buf IOBuffer, nestedFields ...string) *JSONArray
 
 func (b *JSONArrayBuilder[E]) Add(event E) {
 	if b.started {
-		if _, err := b.buf.Write([]byte("\n\t,")); err != nil {
+		if _, err := b.buf.Write([]byte(",")); err != nil {
 			panic(fmt.Sprintf("failed to write: %s", err))
 		}
 	}
@@ -70,7 +70,7 @@ func (b *JSONArrayBuilder[E]) Add(event E) {
 }
 
 func (b *JSONArrayBuilder[E]) Finish() []byte {
-	if _, err := b.buf.Write([]byte("\n]")); err != nil {
+	if _, err := b.buf.Write([]byte("]")); err != nil {
 		panic(fmt.Sprintf("failed to write: %s", err))
 	}
 	for i := 0; i < b.nestingCount; i++ {

--- a/pkg/reporting/batch_jsonarray_test.go
+++ b/pkg/reporting/batch_jsonarray_test.go
@@ -1,0 +1,81 @@
+package reporting_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/neondatabase/autoscaling/pkg/reporting"
+)
+
+func TestJSONArrayBuilder(t *testing.T) {
+	type testType struct {
+		X int
+		Y int
+	}
+
+	// check the exact output of the JSONArrayBatcher
+	cases := []struct {
+		name         string
+		nestedFields []string
+		input        []testType
+		output       string
+	}{
+		{
+			name:         "empty",
+			nestedFields: nil,
+			input:        []testType{},
+			output:       `[]`,
+		},
+		{
+			name:         "single-element",
+			nestedFields: nil,
+			input: []testType{
+				{X: 1, Y: 2},
+			},
+			output: `[{"X":1,"Y":2}]`,
+		},
+		{
+			name:         "many-elements",
+			nestedFields: nil,
+			input: []testType{
+				{X: 1, Y: 2},
+				{X: 2, Y: 3},
+				{X: 3, Y: 4},
+				{X: 4, Y: 5},
+			},
+			output: `[{"X":1,"Y":2},{"X":2,"Y":3},{"X":3,"Y":4},{"X":4,"Y":5}]`,
+		},
+		{
+			name:         "some-nested-1",
+			nestedFields: []string{"foo"},
+			input: []testType{
+				{X: 1, Y: 2},
+				{X: 2, Y: 3},
+			},
+			output: `{"foo":[{"X":1,"Y":2},{"X":2,"Y":3}]}`,
+		},
+		{
+			name:         "some-nested-2",
+			nestedFields: []string{"foo", "bar"},
+			input: []testType{
+				{X: 1, Y: 2},
+				{X: 2, Y: 3},
+			},
+			output: `{"foo":{"bar":[{"X":1,"Y":2},{"X":2,"Y":3}]}}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			builder := reporting.NewJSONArrayBuilder[testType](reporting.NewByteBuffer(), c.nestedFields...)
+
+			for _, v := range c.input {
+				builder.Add(v)
+			}
+
+			output := string(builder.Finish())
+			assert.Equal(t, c.output, output)
+		})
+	}
+}


### PR DESCRIPTION
The sink we're sending it to reads input as JSONL, which means that it expects each line to have a complete JSON object. Breaking up the object across lines causes issues.

ref https://neondb.slack.com/archives/C08HDEK2WFL/p1741787069351919?thread_ts=1741786042.532179