### PR TITLE
neonvm-controller: Don't emit k8s events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,6 @@ require (
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -365,8 +365,6 @@ github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8w
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/neonvm-controller/cmd/main.go
+++ b/neonvm-controller/cmd/main.go
@@ -219,12 +219,11 @@ func main() {
 	defer ipam.Close()
 
 	vmReconciler := &controllers.VMReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("virtualmachine-controller"),
-		Config:   rc,
-		Metrics:  reconcilerMetrics,
-		IPAM:     ipam,
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Config:  rc,
+		Metrics: reconcilerMetrics,
+		IPAM:    ipam,
 	}
 	vmReconcilerMetrics, err := vmReconciler.SetupWithManager(mgr)
 	if err != nil {
@@ -241,11 +240,10 @@ func main() {
 	}
 
 	migrationReconciler := &controllers.VirtualMachineMigrationReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("virtualmachinemigration-controller"),
-		Config:   rc,
-		Metrics:  reconcilerMetrics,
+		Client:  mgr.GetClient(),
+		Scheme:  mgr.GetScheme(),
+		Config:  rc,
+		Metrics: reconcilerMetrics,
 	}
 	migrationReconcilerMetrics, err := migrationReconciler.SetupWithManager(mgr)
 	if err != nil {

--- a/pkg/neonvm/controllers/functests/vm_controller_test.go
+++ b/pkg/neonvm/controllers/functests/vm_controller_test.go
@@ -102,9 +102,8 @@ var _ = Describe("VirtualMachine controller", func() {
 
 			By("Reconciling the custom resource created")
 			virtualmachineReconciler := &controllers.VMReconciler{
-				Client:   k8sClient,
-				Scheme:   k8sClient.Scheme(),
-				Recorder: nil,
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
 				Config: &controllers.ReconcilerConfig{
 					DisableRunnerCgroup:     false,
 					MaxConcurrentReconciles: 1,

--- a/pkg/neonvm/controllers/vmmigration_controller_test.go
+++ b/pkg/neonvm/controllers/vmmigration_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,11 +22,10 @@ import (
 )
 
 type migrationTestParams struct {
-	t            *testing.T
-	ctx          context.Context
-	r            *VirtualMachineMigrationReconciler
-	client       client.Client
-	mockRecorder *mockRecorder
+	t      *testing.T
+	ctx    context.Context
+	r      *VirtualMachineMigrationReconciler
+	client client.Client
 }
 
 func newMigrationTestParams(t *testing.T) *migrationTestParams {
@@ -50,15 +48,12 @@ func newMigrationTestParams(t *testing.T) *migrationTestParams {
 			WithStatusSubresource(&vmv1.VirtualMachine{}).
 			WithStatusSubresource(&vmv1.VirtualMachineMigration{}).
 			Build(),
-		//nolint:exhaustruct // This is a mock
-		mockRecorder: &mockRecorder{},
-		r:            nil,
+		r: nil,
 	}
 
 	params.r = &VirtualMachineMigrationReconciler{
-		Client:   params.client,
-		Recorder: params.mockRecorder,
-		Scheme:   scheme,
+		Client: params.client,
+		Scheme: scheme,
 		Config: &ReconcilerConfig{
 			DisableRunnerCgroup:     false,
 			MaxConcurrentReconciles: 10,
@@ -245,8 +240,6 @@ func Test_VMM_to_Pending_then_removed(t *testing.T) {
 
 	err := params.client.Delete(params.ctx, vmm)
 	require.NoError(t, err)
-
-	params.mockRecorder.On("Event", mock.Anything, "Warning", "Deleting", "Running Migration (test-migration) is being deleted")
 
 	req := reconcile.Request{
 		NamespacedName: client.ObjectKeyFromObject(vmm),


### PR DESCRIPTION
On larger clusters with a lot of churn, we see substantial amounts of space in etcd taken up by events from neonvm-controller, even with a relatively short TTL.

So, let's completely remove event reporting in the short term to mitigate risks of running out of space in EKS.

In the meantime, all the relevant information should still be available in the neonvm-controller logs, and we can re-add select events if we think it's worthwhile.

Closes neondatabase/cloud#27262.
Ref https://neondb.slack.com/archives/C08N5D2CF7A/p1744224210018349
Ref https://neondb.slack.com/archives/C03TN5G758R/p1744225420614349

---

**Notes for review:** I haven't examined the logs yet, will do that with the output from e2e tests on CI. I think there's also a lot of cleanup we should to make our log lines more structured, but better to leave that for a follow-up IMO.