### PR TITLE
vxlan-controller: don't delete bridge on stop

### DIFF
--- a/neonvm-vxlan-controller/daemonset.yaml
+++ b/neonvm-vxlan-controller/daemonset.yaml
@@ -63,10 +63,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-        lifecycle:
-          preStop:
-            exec:
-              command: ["vxlan-controller", "-delete"]
         volumeMounts:
           - mountPath: /host/opt/cni/bin
             name: cni-bin-dir


### PR DESCRIPTION
This causes virtual devices to be recreated on every restart, and everything what was attached to the old device stops being able to be reached over the overlay network.

The fact that we can't easily recreate vxlan device is concerning. I see a few ways forward:
1. Maybe that's fine, we don't ever need to recreate it.
2. Maybe we can fix multus to reattach device.
3. Do we need a kill switch to disable overlay network in the whole cluster?