### PR TITLE
neonvm-controller: Improve VM starts observability

### DIFF
--- a/pkg/neonvm/controllers/metrics.go
+++ b/pkg/neonvm/controllers/metrics.go
@@ -38,6 +38,12 @@ func MakeReconcilerMetrics() ReconcilerMetrics {
 		1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60,
 	}
 
+	// This time is almost never less than 10 seconds, but sometimes goes above several minutes.
+	vmCreationToVMRunningBuckets := []float64{
+		1, 5, 10, 12, 14, 16, 18, 20, 25, 30, 40, 50, 60,
+		80, 100, 120, 140, 160, 200, 300,
+	}
+
 	m := ReconcilerMetrics{
 		failing: util.RegisterMetric(metrics.Registry, prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -57,14 +63,14 @@ func MakeReconcilerMetrics() ReconcilerMetrics {
 			prometheus.HistogramOpts{
 				Name:    "vm_runner_creation_to_vm_running_duration_seconds",
 				Help:    "Time duration from runner Pod.CreationTimestamp to the moment when VirtualMachine.Status.Phase becomes Running",
-				Buckets: buckets,
+				Buckets: vmCreationToVMRunningBuckets,
 			},
 		)),
 		vmCreationToVMRunningTime: util.RegisterMetric(metrics.Registry, prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name:    "vm_creation_to_vm_running_duration_seconds",
 				Help:    "Time duration from VirtualMachine.CreationTimeStamp to the moment when VirtualMachine.Status.Phase becomes Running",
-				Buckets: buckets,
+				Buckets: vmCreationToVMRunningBuckets,
 			},
 		)),
 		vmRestartCounts: util.RegisterMetric(metrics.Registry, prometheus.NewCounter(

--- a/pkg/neonvm/controllers/vm_controller.go
+++ b/pkg/neonvm/controllers/vm_controller.go
@@ -445,6 +445,7 @@ func (r *VMReconciler) doReconcile(ctx context.Context, vm *vmv1.VirtualMachine)
 			if !vm.HasRestarted() {
 				d := pod.CreationTimestamp.Time.Sub(vm.CreationTimestamp.Time)
 				r.Metrics.vmCreationToRunnerCreationTime.Observe(d.Seconds())
+				log.Info("VM creation to runner pod creation time", "duration_sec", d.Seconds())
 			}
 		} else if err != nil {
 			log.Error(err, "Failed to get vm-runner Pod")


### PR DESCRIPTION
We currently use a lot of buckets < 10s for VM running, but our p50-p99 times are 15s-80s+. This PR updates the buckets for better observability around VM startup times.

Also, `vmCreationToRunnerCreationTime` can be slow in some cases, so it makes sense to log this duration as well.

ref https://neonprod.grafana.net/goto/UCugfLANR?orgId=1