### PR TITLE
ci: enable misspell linter in golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,7 @@ linters:
     - nolintlint       # bad "nolint" directives
     - predeclared      # no identifiers in Go's list of predeclared identifiers, see <https://go.dev/ref/spec#Predeclared_identifiers>
     - unparam          # no unused function parameters or return values
+    - misspell         # checks commonly misspelled English words
 
 linters-settings:
   # see: <https://golangci-lint.run/usage/linters/#dupword>, <https://github.com/Abirdcfly/dupword>
@@ -116,3 +117,8 @@ linters-settings:
     allow-unused: false
     require-explanation: true
     require-specific: true
+
+  # see: <https://golangci-lint.run/usage/linters/#misspell>
+  misspell:
+    locale: US
+    ignore-words: []

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -411,7 +411,7 @@ func buildQEMUCmd(
 }
 
 const (
-	// this loglevel is used only during startup, later it is overriden during vminit
+	// this loglevel is used only during startup, later it is overridden during vminit
 	baseKernelCmdline          = "panic=-1 init=/neonvm/bin/init loglevel=6 root=/dev/vda rw"
 	kernelCmdlineVirtioMemTmpl = "memhp_default_state=online memory_hotplug.online_policy=auto-movable memory_hotplug.auto_movable_ratio=%s"
 )

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -35,7 +35,7 @@ type RateThresholdConfig struct {
 type MonitorConfig struct {
 	ResponseTimeoutSeconds uint `json:"responseTimeoutSeconds"`
 	// ConnectionTimeoutSeconds gives how long we may take to connect to the
-	// monitor before cancelling.
+	// monitor before canceling.
 	ConnectionTimeoutSeconds uint `json:"connectionTimeoutSeconds"`
 	// ConnectionRetryMinWaitSeconds gives the minimum amount of time we must wait between attempts
 	// to connect to the vm-monitor, regardless of whether they're successful.

--- a/pkg/agent/dispatcher.go
+++ b/pkg/agent/dispatcher.go
@@ -699,8 +699,8 @@ func (disp *Dispatcher) run(ctx context.Context, logger *zap.Logger, upscaleRequ
 		err := disp.HandleMessage(ctx, logger, handlers)
 		if err != nil {
 			if ctx.Err() != nil {
-				// The context is already cancelled, so this error is mostly likely
-				// expected. For example, if the context is cancelled because the
+				// The context is already canceled, so this error is mostly likely
+				// expected. For example, if the context is canceled because the
 				// runner exited, we should expect to fail to read off the connection,
 				// which is closed by the server exit.
 				logger.Warn("Error handling message", zap.Error(err))

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -324,7 +324,7 @@ func (r *Runner) Run(ctx context.Context, logger *zap.Logger, vmInfoUpdated util
 	r.spawnBackgroundWorker(ctx, execLogger.Named("vm-monitor-downscale"), "executor: vm-monitor downscale", ecwc.DoMonitorDownscales)
 	r.spawnBackgroundWorker(ctx, execLogger.Named("vm-monitor-upscale"), "executor: vm-monitor upscale", ecwc.DoMonitorUpscales)
 
-	// Note: Run doesn't terminate unless the parent context is cancelled - either because the VM
+	// Note: Run doesn't terminate unless the parent context is canceled - either because the VM
 	// pod was deleted, or the autoscaler-agent is exiting.
 	select {
 	case <-ctx.Done():
@@ -742,7 +742,7 @@ func (r *Runner) doNeonVMRequest(
 
 	patchPayload, err := json.Marshal(patches)
 	if err != nil {
-		panic(fmt.Errorf("Error marshalling JSON patch: %w", err))
+		panic(fmt.Errorf("Error marshaling JSON patch: %w", err))
 	}
 
 	timeout := time.Second * time.Duration(r.global.config.NeonVM.RequestTimeoutSeconds)

--- a/pkg/neonvm/controllers/vm_controller.go
+++ b/pkg/neonvm/controllers/vm_controller.go
@@ -1002,7 +1002,7 @@ func updatePodMetadataIfNecessary(ctx context.Context, c client.Client, vm *vmv1
 
 	patchData, err := json.Marshal(patches)
 	if err != nil {
-		panic(fmt.Errorf("error marshalling JSON patch: %w", err))
+		panic(fmt.Errorf("error marshaling JSON patch: %w", err))
 	}
 
 	if len(removedMessageParts) != 0 {
@@ -1037,7 +1037,7 @@ func extractVirtualMachineUsageJSON(spec vmv1.VirtualMachineSpec) string {
 
 	usageJSON, err := json.Marshal(usage)
 	if err != nil {
-		panic(fmt.Errorf("error marshalling JSON: %w", err))
+		panic(fmt.Errorf("error marshaling JSON: %w", err))
 	}
 
 	return string(usageJSON)
@@ -1046,7 +1046,7 @@ func extractVirtualMachineUsageJSON(spec vmv1.VirtualMachineSpec) string {
 func extractVirtualMachineResourcesJSON(spec vmv1.VirtualMachineSpec) string {
 	resourcesJSON, err := json.Marshal(spec.Resources())
 	if err != nil {
-		panic(fmt.Errorf("error marshalling JSON: %w", err))
+		panic(fmt.Errorf("error marshaling JSON: %w", err))
 	}
 
 	return string(resourcesJSON)
@@ -1059,7 +1059,7 @@ func extractVirtualMachineOvercommitSettingsJSON(spec vmv1.VirtualMachineSpec) *
 
 	settingsJSON, err := json.Marshal(*spec.Overcommit)
 	if err != nil {
-		panic(fmt.Errorf("error marshalling JSON: %w", err))
+		panic(fmt.Errorf("error marshaling JSON: %w", err))
 	}
 	return lo.ToPtr(string(settingsJSON))
 }

--- a/pkg/neonvm/ipam/ipam.go
+++ b/pkg/neonvm/ipam/ipam.go
@@ -253,7 +253,7 @@ func (i *IPAM) runIPAMRange(ctx context.Context, ipRange RangeConfiguration, act
 		case <-ctx.Done():
 			return net.IPNet{}, ctx.Err()
 		default:
-			// live in retry loop until context not cancelled
+			// live in retry loop until context not canceled
 		}
 
 		// read IPPool from ipppols.vm.neon.tech custom resource

--- a/pkg/util/chanmutex.go
+++ b/pkg/util/chanmutex.go
@@ -52,9 +52,9 @@ func (m *ChanMutex) WaitLock() <-chan struct{} {
 	return m.ch
 }
 
-// TryLock blocks until locking m succeeds or the context is cancelled
+// TryLock blocks until locking m succeeds or the context is canceled
 //
-// If the context is cancelled while waiting to lock m, the lock will be left unchanged and
+// If the context is canceled while waiting to lock m, the lock will be left unchanged and
 // ctx.Err() will be returned.
 func (m *ChanMutex) TryLock(ctx context.Context) error {
 	if m.ch == nil {

--- a/pkg/util/checksum.go
+++ b/pkg/util/checksum.go
@@ -25,7 +25,7 @@ func ChecksumFlatDir(path string) (string, error) {
 	sort.Strings(keys)
 
 	// note: any changes to the hash need to be sychronised between neonvm-runner and neonvm-daemon.
-	// Since they are updated independantly, this is not trivial.
+	// Since they are updated independently, this is not trivial.
 	// If in doubt, make a new function and don't touch this one.
 	hasher, err := blake2b.New256(nil)
 	if err != nil {

--- a/pkg/util/signal.go
+++ b/pkg/util/signal.go
@@ -1,6 +1,6 @@
 package util
 
-// Signalling primitives: single-signal sender/receiver pair and sync.Cond-ish exposed over a
+// Signaling primitives: single-signal sender/receiver pair and sync.Cond-ish exposed over a
 // channel instead
 
 import (
@@ -75,7 +75,7 @@ func (c *CondChannelSender) Send() {
 
 // Unsend cancels an existing signal that has been sent but not yet received.
 //
-// It returns whether there was a signal to be cancelled.
+// It returns whether there was a signal to be canceled.
 func (c *CondChannelSender) Unsend() bool {
 	select {
 	case <-c.ch:

--- a/pkg/util/watch/watch.go
+++ b/pkg/util/watch/watch.go
@@ -214,7 +214,7 @@ func Watch[C Client[L], L metav1.ListMetaAccessor, T any, P Object[T]](
 			store.objects[uid] = obj
 			store.handlers.AddFunc(obj, true)
 
-			// Check if the context has been cancelled. This can happen in practice if AddFunc may
+			// Check if the context has been canceled. This can happen in practice if AddFunc may
 			// take a long time to complete.
 			if err := ctx.Err(); err != nil {
 				return nil, err
@@ -681,7 +681,7 @@ func (w *Store[T]) Relist() <-chan struct{} {
 // Why does this exist? Well, watch events are often going to be handled by adding the object to a
 // queue. And sometimes you want to re-inject something into the queue. But it's tricky for that to
 // be synchronized unless it's guaranteed to agree with the ongoing watch -- so this method allows
-// one to re-inject something into the queue if and only if the watch still belives it exists in
+// one to re-inject something into the queue if and only if the watch still believes it exists in
 // kubernetes.
 func (w *Store[T]) NopUpdate(uid types.UID) (ok bool) {
 	w.mutex.Lock()


### PR DESCRIPTION
Add misspell linter to catch common spelling mistakes in comments, strings, and documentation. Configure with US locale to maintain consistent spelling across the codebase.

This helps maintain code quality by preventing common typos and ensuring consistent spelling in the codebase documentation.

NOTE: vibe-coded with Cursor.