### PR TITLE
neonvm-runner: Append `_total` to counter metric names

### DIFF
--- a/neonvm-runner/cmd/net.go
+++ b/neonvm-runner/cmd/net.go
@@ -336,13 +336,13 @@ func NewMonitoringMetrics(reg *prometheus.Registry) *NetworkMonitoringMetrics {
 	m := &NetworkMonitoringMetrics{
 		IngressBytes: util.RegisterMetric(reg, prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "runner_vm_ingress_bytes",
+				Name: "runner_vm_ingress_bytes_total",
 				Help: "Number of bytes received by the VM from the open internet",
 			},
 		)),
 		EgressBytes: util.RegisterMetric(reg, prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "runner_vm_egress_bytes",
+				Name: "runner_vm_egress_bytes_total",
 				Help: "Number of bytes sent by the VM to the open internet",
 			},
 		)),


### PR DESCRIPTION
The convention in prometheus metrics is to have counters named `*_total`; this change just appends that to the existing `runner_vm_{ingress,egress}_bytes` metrics.

ref https://neondb.slack.com/archives/C04DGM6SMTM/p1743597387189079

---

For rollout: This is only used internally in a single dashboard panel, so I think it's ok to modify that query to accept both names.