### PR TITLE
plugin: Add new reconcile metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,7 +75,7 @@ linters-settings:
       - '^github\.com/docker/docker/api/types/container\.Config$'
       - '^github\.com/docker/docker/api/types\.\w+Options$'
       - '^github\.com/opencontainers/runtime-spec/specs-go\.\w+$' # Exempt the entire package. Too many big structs.
-      - '^github\.com/prometheus/client_golang/prometheus(/.*)?\.\w+Opts$'
+      - '^github\.com/prometheus/client_golang/prometheus(/.*)?\.\w*Opts$'
       - '^github\.com/tychoish/fun/pubsub\.BrokerOptions$'
       - '^github\.com/vishvananda/netlink\.\w+$' # Exempt the entire package. Too many big structs.
       # vmapi.{VirtualMachine,VirtualMachineSpec,VirtualMachineMigration,VirtualMachineMigrationSpec}

--- a/pkg/plugin/entrypoint.go
+++ b/pkg/plugin/entrypoint.go
@@ -84,6 +84,9 @@ func NewAutoscaleEnforcerPlugin(
 		reconcile.WithQueueWaitDurationCallback(func(duration time.Duration) {
 			pluginState.reconcileQueueWaitCallback(duration)
 		}),
+		reconcile.WithQueueStatusCallback(func(waiting bool) {
+			pluginState.reconcileQueueStatusCallback(waiting)
+		}),
 		reconcile.WithResultCallback(func(params reconcile.ObjectParams, duration time.Duration, err error) {
 			pluginState.reconcileResultCallback(params, duration, err)
 		}),

--- a/pkg/plugin/globalstate.go
+++ b/pkg/plugin/globalstate.go
@@ -90,6 +90,7 @@ func NewPluginState(
 	indexedNodeStore := watch.NewIndexedStore(nodeWatchStore, watch.NewFlatNameIndex[corev1.Node]())
 
 	metrics := metrics.BuildPluginMetrics(config.NodeMetricLabels, reg)
+	metrics.Reconcile.Workers.Set(float64(config.ReconcileWorkers))
 
 	return &PluginState{
 		mu: sync.Mutex{},

--- a/pkg/plugin/metrics/reconcile.go
+++ b/pkg/plugin/metrics/reconcile.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Reconcile struct {
+	Workers          prometheus.Gauge
 	WaitDurations    prometheus.Histogram
 	ProcessDurations *prometheus.HistogramVec
 	Failing          *prometheus.GaugeVec
@@ -15,6 +16,12 @@ type Reconcile struct {
 
 func buildReconcileMetrics(reg prometheus.Registerer) Reconcile {
 	return Reconcile{
+		Workers: util.RegisterMetric(reg, prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "autoscaling_plugin_reconcile_workers",
+				Help: "Number of worker threads used for reconcile operations",
+			},
+		)),
 		WaitDurations: util.RegisterMetric(reg, prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name: "autoscaling_plugin_reconcile_queue_wait_durations",

--- a/pkg/plugin/metrics/reconcile.go
+++ b/pkg/plugin/metrics/reconcile.go
@@ -1,6 +1,9 @@
 package metrics
 
 import (
+	"sync"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/neondatabase/autoscaling/pkg/util"
@@ -9,6 +12,7 @@ import (
 type Reconcile struct {
 	Workers          prometheus.Gauge
 	WaitDurations    prometheus.Histogram
+	WaitingTimer     *WaitingReconcilesTimer
 	ProcessDurations *prometheus.HistogramVec
 	Failing          *prometheus.GaugeVec
 	Panics           *prometheus.CounterVec
@@ -34,6 +38,12 @@ func buildReconcileMetrics(reg prometheus.Registerer) Reconcile {
 					// 1s, 2.5s, 5s, 10s, 20s, 45s
 					1.0, 2.5, 5, 10, 20, 45,
 				},
+			},
+		)),
+		WaitingTimer: util.RegisterMetric(reg, NewWaitingReconcilesTimer(
+			prometheus.Opts{
+				Name: "autoscaling_plugin_reconcile_waiting_seconds_total",
+				Help: "Total duration that there were some reconcile operations waiting to be picked up",
 			},
 		)),
 		ProcessDurations: util.RegisterMetric(reg, prometheus.NewHistogramVec(
@@ -66,4 +76,71 @@ func buildReconcileMetrics(reg prometheus.Registerer) Reconcile {
 			[]string{"kind"},
 		)),
 	}
+}
+
+type WaitingReconcilesTimer struct {
+	mu sync.Mutex
+
+	waiting        bool
+	lastTransition time.Time
+	totalTime      time.Duration
+
+	gauge prometheus.GaugeFunc
+}
+
+func NewWaitingReconcilesTimer(opts prometheus.Opts) *WaitingReconcilesTimer {
+	t := &WaitingReconcilesTimer{
+		mu:             sync.Mutex{},
+		waiting:        false,
+		lastTransition: time.Now(),
+		totalTime:      0,
+		gauge:          nil, // set below
+	}
+
+	t.gauge = prometheus.NewGaugeFunc(prometheus.GaugeOpts(opts), func() float64 {
+		return t.getTotal().Seconds()
+	})
+
+	return t
+}
+
+func (t *WaitingReconcilesTimer) SetWaiting(waiting bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.waiting == waiting {
+		return
+	}
+
+	now := time.Now()
+	// If it was previously marked as waiting (but now no longer), then add the time since we
+	// started waiting to the running total.
+	if t.waiting {
+		t.totalTime += now.Sub(t.lastTransition)
+	}
+	// Otherwise, we'll mark ourselves as waiting (or not), and set the last change to now so that
+	// the next switch records the time since now.
+	t.waiting = waiting
+	t.lastTransition = now
+}
+
+func (t *WaitingReconcilesTimer) getTotal() time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	total := t.totalTime
+	if t.waiting {
+		total += time.Since(t.lastTransition)
+	}
+	return total
+}
+
+// Describe implements prometheus.Collector
+func (t *WaitingReconcilesTimer) Describe(ch chan<- *prometheus.Desc) {
+	t.gauge.Describe(ch)
+}
+
+// Collect implements prometheus.Collector
+func (t *WaitingReconcilesTimer) Collect(ch chan<- prometheus.Metric) {
+	t.gauge.Collect(ch)
 }

--- a/pkg/plugin/reconcile.go
+++ b/pkg/plugin/reconcile.go
@@ -14,6 +14,12 @@ func (s *PluginState) reconcileQueueWaitCallback(duration time.Duration) {
 	s.metrics.Reconcile.WaitDurations.Observe(duration.Seconds())
 }
 
+func (s *PluginState) reconcileQueueStatusCallback(waiting bool) {
+	// update the timer so we record the amount of time during which at least some items were
+	// waiting in the queue.
+	s.metrics.Reconcile.WaitingTimer.SetWaiting(waiting)
+}
+
 func (s *PluginState) reconcileResultCallback(params reconcile.ObjectParams, duration time.Duration, err error) {
 	outcome := "success"
 	if err != nil {

--- a/pkg/plugin/reconcile/options.go
+++ b/pkg/plugin/reconcile/options.go
@@ -16,6 +16,7 @@ type queueSettings struct {
 	baseContext    context.Context
 	middleware     []Middleware
 	waitCallback   QueueWaitDurationCallback
+	statusCallback QueueStatusCallback
 	resultCallback ResultCallback
 	errorCallback  ErrorStatsCallback
 	panicCallback  PanicCallback
@@ -26,6 +27,7 @@ func defaultQueueSettings() *queueSettings {
 		baseContext:    context.Background(),
 		middleware:     []Middleware{},
 		waitCallback:   nil,
+		statusCallback: nil,
 		resultCallback: nil,
 		errorCallback:  nil,
 		panicCallback:  nil,
@@ -64,6 +66,23 @@ func WithQueueWaitDurationCallback(cb QueueWaitDurationCallback) QueueOption {
 	return QueueOption{
 		apply: func(s *queueSettings) {
 			s.waitCallback = cb
+		},
+	}
+}
+
+// QueueStatusCallback represents the signature of the callback that may be provided to add
+// observability for the amount of time that there are at least some items waiting in the queue.
+//
+// Whenever the queue changes between empty and non-empty, this function will be called, with
+// 'waiting' indicating whether there are items in the queue.
+type QueueStatusCallback = func(waiting bool)
+
+// WithQueueStatusCallback sets the QueueStatusCallback that will be called with the current status
+// of the queue (whether items are waiting) whenever the queue changes between empty and non-empty.
+func WithQueueStatusCallback(cb QueueStatusCallback) QueueOption {
+	return QueueOption{
+		apply: func(s *queueSettings) {
+			s.statusCallback = cb
 		},
 	}
 }

--- a/pkg/plugin/reconcile/queue.go
+++ b/pkg/plugin/reconcile/queue.go
@@ -55,6 +55,9 @@ type Queue struct {
 
 	// if not nil, a callback that records how long each item was waiting to be reconciled
 	queueWaitCallback QueueWaitDurationCallback
+
+	// if not nil, a callback that records whether there are currently any items in the queue
+	queueStatusCallback QueueStatusCallback
 }
 
 type kv struct {
@@ -150,10 +153,16 @@ func NewQueue(handlers map[Object]HandlerFunc, opts ...QueueOption) (*Queue, err
 
 		handlers: enrichedHandlers,
 
-		queueWaitCallback: settings.waitCallback,
+		queueWaitCallback:   settings.waitCallback,
+		queueStatusCallback: settings.statusCallback,
 	}
 
 	go q.handleNotifications(ctx, next, enqueuedRcvr)
+
+	// Register the initial status of the queue:
+	if q.queueStatusCallback != nil {
+		q.queueStatusCallback(false /* waiting? no */)
+	}
 
 	return q, nil
 }
@@ -297,12 +306,20 @@ func (q *Queue) Enqueue(eventKind EventKind, obj Object) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	// Is the queue empty beforehand? if so, we'll need to call the status update callback to
+	// inform that it's now not empty.
+	wasEmpty := q.queue.Len() == 0
+
 	// If the object is already being reconciled, we should store the update in 'pending'
 	_, ongoingReconcile := q.ongoing[k]
 	if ongoingReconcile {
 		q.enqueuePendingChange(k, v)
 	} else {
 		q.enqueueInactive(k, v)
+	}
+
+	if wasEmpty && q.queueStatusCallback != nil {
+		q.queueStatusCallback(true /* waiting? yes */)
 	}
 }
 
@@ -324,6 +341,11 @@ func (q *Queue) Next() (_ ReconcileCallback, ok bool) {
 
 	callback := func(logger *zap.Logger) {
 		q.reconcile(logger, kv.k, kv.v)
+	}
+
+	// If the queue is now empty, we need to call the status update callback to inform it:
+	if q.queue.Len() == 0 && q.queueStatusCallback != nil {
+		q.queueStatusCallback(false /* waiting? no */)
 	}
 
 	return callback, true


### PR DESCRIPTION
There's two metrics added here:

1. Number of reconcile workers
   This mirrors the existing `controller_runtime_max_concurrent_reconciles` metric we have from neonvm-controller, which allows us to determine the fraction of total worker-time that we're using (a measure of saturation).

2. Total duration with items in the queue
   This is roughly analogous to the Linux kernel's CPU PSI metric — other metrics of saturation (using total time spent reconciling or total time in the queue) are useful, but they tend to be easy to misinterpret when the amount of saturation is very skewed across the duration between metric samples. So the idea here is to help get a more accurate picture.

Resolves neondatabase/cloud#27613.