### PR TITLE
vm-deploy.yaml: fix TLS fields in the example

### DIFF
--- a/vm-deploy.yaml
+++ b/vm-deploy.yaml
@@ -14,9 +14,11 @@ spec:
   schedulerName: autoscale-scheduler
   enableNetworkMonitoring: true
   enableSSH: true
-  tlsCertificateIssuer: "neon-ca-issuer"
-  tlsExpiration: 5m
-  tlsRenewal: 3m
+  tls:
+    certificateIssuer: "neon-ca-issuer"
+    expireAfter: 5m
+    renewBefore: 3m
+    serverName: "example.local"
   guest:
     cpus: { min: 0.25, use: 0.25, max: 1.25 }
     memorySlotSize: 1Gi


### PR DESCRIPTION
Without the change the `vm-deploy.yaml` fails with 

```
Error from server (BadRequest): error when creating "vm-deploy.yaml": VirtualMachine in version "v1" cannot be handled as a VirtualMachine: strict decoding error: unknown field "spec.tlsCertificateIssuer", unknown field "spec.tlsExpiration", unknown field "spec.tlsRenewal"
```