### PR TITLE
neonvm: Remove neonvm-runner version [2/2]

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -38,9 +38,6 @@ const (
 	// the VM's name).
 	VirtualMachineNameLabel string = "vm.neon.tech/name"
 
-	// Label that determines the version of runner pod. May be missing on older runners
-	RunnerPodVersionLabel string = "vm.neon.tech/runner-version"
-
 	// VirtualMachineUsageAnnotation is the annotation added to each runner Pod, mirroring
 	// information about the resource allocations of the VM running in the pod.
 	//

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -487,18 +487,6 @@ type VCPUCgroup struct {
 	VCPUs vmv1.MilliCPU
 }
 
-// this a similar version type for controller <-> runner communications
-// see PluginProtoVersion comment for details
-type RunnerProtoVersion uint32
-
-const (
-	RunnerProtoV1 RunnerProtoVersion = iota + 1
-)
-
-func (v RunnerProtoVersion) SupportsCgroupFractionalCPU() bool {
-	return v >= RunnerProtoV1
-}
-
 ////////////////////////////////////
 //   Agent <-> Monitor Messages   //
 ////////////////////////////////////

--- a/pkg/neonvm/controllers/vm_controller.go
+++ b/pkg/neonvm/controllers/vm_controller.go
@@ -876,14 +876,10 @@ func updatePodMetadataIfNecessary(ctx context.Context, c client.Client, vm *vmv1
 		ignoreExtra map[string]bool // use bool here so `if ignoreExtra[key] { ... }` works
 	}{
 		{
-			metaField: "labels",
-			expected:  labelsForVirtualMachine(vm, nil), // don't include runner version
-			actual:    runnerPod.Labels,
-			ignoreExtra: map[string]bool{
-				// Don't override the runner pod version - we need to keep it around without
-				// changing it; otherwise it's not useful!
-				vmv1.RunnerPodVersionLabel: true,
-			},
+			metaField:   "labels",
+			expected:    labelsForVirtualMachine(vm), // don't include runner version
+			actual:      runnerPod.Labels,
+			ignoreExtra: map[string]bool{},
 		},
 		{
 			metaField: "annotations",
@@ -1135,7 +1131,7 @@ func (r *VMReconciler) certSecretForVirtualMachine(
 
 // labelsForVirtualMachine returns the labels for selecting the resources
 // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
-func labelsForVirtualMachine(vm *vmv1.VirtualMachine, runnerVersion *api.RunnerProtoVersion) map[string]string {
+func labelsForVirtualMachine(vm *vmv1.VirtualMachine) map[string]string {
 	l := make(map[string]string, len(vm.Labels)+3)
 	for k, v := range vm.Labels {
 		l[k] = v
@@ -1143,9 +1139,6 @@ func labelsForVirtualMachine(vm *vmv1.VirtualMachine, runnerVersion *api.RunnerP
 
 	l["app.kubernetes.io/name"] = "NeonVM"
 	l[vmv1.VirtualMachineNameLabel] = vm.Name
-	if runnerVersion != nil {
-		l[vmv1.RunnerPodVersionLabel] = fmt.Sprintf("%d", *runnerVersion)
-	}
 	return l
 }
 
@@ -1223,8 +1216,7 @@ func podSpec(
 	sshSecret *corev1.Secret,
 	config *ReconcilerConfig,
 ) (*corev1.Pod, error) {
-	runnerVersion := api.RunnerProtoV1
-	labels := labelsForVirtualMachine(vm, &runnerVersion)
+	labels := labelsForVirtualMachine(vm)
 	annotations := annotationsForVirtualMachine(vm)
 	affinity := affinityForVirtualMachine(vm)
 


### PR DESCRIPTION
We no longer use it anywhere, so we should probably remove it to get rid of unnecessary code.

This PR is the second of two changes, removing the remaining places where we set the neonvm-runner version label. It must be a separate change so that neonvm-controller can first be updated to ignore whether the label is present, for rollback safety.

See #1380 for more.

---

**NOTE: This PR must not be merged until #1380 has been released!**