### PR TITLE
neonvm-controller: Move CLI flags to separate file

### DIFF
--- a/neonvm-controller/cmd/cli.go
+++ b/neonvm-controller/cmd/cli.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	vmv1 "github.com/neondatabase/autoscaling/neonvm/apis/neonvm/v1"
+)
+
+type cliFlags struct {
+	metricsAddr             string
+	probeAddr               string
+	enableLeaderElection    bool
+	concurrencyLimit        int
+	skipUpdateValidationFor map[types.NamespacedName]struct{}
+	disableRunnerCgroup     bool
+	defaultCpuScalingMode   vmv1.CpuScalingMode
+	qemuDiskCacheSettings   string
+	memhpAutoMovableRatio   string
+	failurePendingPeriod    time.Duration
+	failingRefreshInterval  time.Duration
+	atMostOnePod            bool
+	useVirtioConsole        bool
+}
+
+func getCli() cliFlags {
+	metricsAddr := flag.String("metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	probeAddr := flag.String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	enableLeaderElection := flag.Bool("leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	concurrencyLimit := flag.Int("concurrency-limit", 1, "Maximum number of concurrent reconcile operations")
+	skipUpdateValidationFor := namespacedNameSetFlag(
+		"skip-update-validation-for",
+		"Comma-separated list of object names to skip webhook validation, like 'foo' or 'default/bar'",
+	)
+	var defaultCpuScalingMode vmv1.CpuScalingMode
+	flag.Func("default-cpu-scaling-mode", "Set default cpu scaling mode to use for new VMs", defaultCpuScalingMode.FlagFunc)
+	disableRunnerCgroup := flag.Bool("disable-runner-cgroup", false, "Disable creation of a cgroup in neonvm-runner for fractional CPU limiting")
+	qemuDiskCacheSettings := flag.String("qemu-disk-cache-settings", "cache=none", "Set neonvm-runner's QEMU disk cache settings")
+	memhpAutoMovableRatio := flag.String("memhp-auto-movable-ratio", "301", "For virtio-mem, set VM kernel's memory_hotplug.auto_movable_ratio")
+	failurePendingPeriod := flag.Duration("failure-pending-period", 1*time.Minute,
+		"the period for the propagation of reconciliation failures to the observability instruments")
+	failingRefreshInterval := flag.Duration("failing-refresh-interval", 1*time.Minute,
+		"the interval between consecutive updates of metrics and logs, related to failing reconciliations")
+	atMostOnePod := flag.Bool("at-most-one-pod", false,
+		"If true, the controller will ensure that at most one pod is running at a time. "+
+			"Otherwise, the outdated pod might be left to terminate, while the new one is already running.")
+	useVirtioConsole := flag.Bool("use-virtio-console", false,
+		"If true, the controller will set up the runner to use virtio console instead of serial console.")
+
+	flag.Parse()
+
+	return cliFlags{
+		metricsAddr:             *metricsAddr,
+		probeAddr:               *probeAddr,
+		enableLeaderElection:    *enableLeaderElection,
+		concurrencyLimit:        *concurrencyLimit,
+		skipUpdateValidationFor: *skipUpdateValidationFor,
+		disableRunnerCgroup:     *disableRunnerCgroup,
+		defaultCpuScalingMode:   defaultCpuScalingMode,
+		qemuDiskCacheSettings:   *qemuDiskCacheSettings,
+		memhpAutoMovableRatio:   *memhpAutoMovableRatio,
+		failurePendingPeriod:    *failurePendingPeriod,
+		failingRefreshInterval:  *failingRefreshInterval,
+		atMostOnePod:            *atMostOnePod,
+		useVirtioConsole:        *useVirtioConsole,
+	}
+}
+
+func namespacedNameSetFlag(name string, usage string) *map[types.NamespacedName]struct{} {
+	set := new(map[types.NamespacedName]struct{})
+	flag.Func(name, usage, func(value string) error {
+		var err error
+		*set, err = parseNamespacedNameSet(value)
+		return err
+	})
+	return set
+}
+
+func parseNamespacedNameSet(value string) (map[types.NamespacedName]struct{}, error) {
+	objSet := make(map[types.NamespacedName]struct{})
+
+	if value != "" {
+		for _, name := range strings.Split(value, ",") {
+			if name == "" {
+				return nil, errors.New("name must not be empty")
+			}
+
+			var namespacedName types.NamespacedName
+			splitBySlash := strings.SplitN(name, "/", 1)
+			if len(splitBySlash) == 1 {
+				namespacedName = types.NamespacedName{Namespace: "default", Name: splitBySlash[0]}
+			} else {
+				namespacedName = types.NamespacedName{Namespace: splitBySlash[0], Name: splitBySlash[1]}
+			}
+			objSet[namespacedName] = struct{}{}
+		}
+	}
+	return objSet, nil
+}

--- a/neonvm-controller/cmd/main.go
+++ b/neonvm-controller/cmd/main.go
@@ -19,13 +19,10 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -41,7 +38,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -93,65 +89,7 @@ func run(mgr manager.Manager) error {
 }
 
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
-	var concurrencyLimit int
-	var skipUpdateValidationFor map[types.NamespacedName]struct{}
-	var disableRunnerCgroup bool
-	var defaultCpuScalingMode vmv1.CpuScalingMode
-	var qemuDiskCacheSettings string
-	var memhpAutoMovableRatio string
-	var failurePendingPeriod time.Duration
-	var failingRefreshInterval time.Duration
-	var atMostOnePod bool
-	var useVirtioConsole bool
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
-	flag.IntVar(&concurrencyLimit, "concurrency-limit", 1, "Maximum number of concurrent reconcile operations")
-	flag.Func(
-		"skip-update-validation-for",
-		"Comma-separated list of object names to skip webhook validation, like 'foo' or 'default/bar'",
-		func(value string) error {
-			objSet := make(map[types.NamespacedName]struct{})
-
-			if value != "" {
-				for _, name := range strings.Split(value, ",") {
-					if name == "" {
-						return errors.New("name must not be empty")
-					}
-
-					var namespacedName types.NamespacedName
-					splitBySlash := strings.SplitN(name, "/", 1)
-					if len(splitBySlash) == 1 {
-						namespacedName = types.NamespacedName{Namespace: "default", Name: splitBySlash[0]}
-					} else {
-						namespacedName = types.NamespacedName{Namespace: splitBySlash[0], Name: splitBySlash[1]}
-					}
-					objSet[namespacedName] = struct{}{}
-				}
-			}
-			skipUpdateValidationFor = objSet
-			return nil
-		},
-	)
-	flag.Func("default-cpu-scaling-mode", "Set default cpu scaling mode to use for new VMs", defaultCpuScalingMode.FlagFunc)
-	flag.BoolVar(&disableRunnerCgroup, "disable-runner-cgroup", false, "Disable creation of a cgroup in neonvm-runner for fractional CPU limiting")
-	flag.StringVar(&qemuDiskCacheSettings, "qemu-disk-cache-settings", "cache=none", "Set neonvm-runner's QEMU disk cache settings")
-	flag.StringVar(&memhpAutoMovableRatio, "memhp-auto-movable-ratio", "301", "For virtio-mem, set VM kernel's memory_hotplug.auto_movable_ratio")
-	flag.DurationVar(&failurePendingPeriod, "failure-pending-period", 1*time.Minute,
-		"the period for the propagation of reconciliation failures to the observability instruments")
-	flag.DurationVar(&failingRefreshInterval, "failing-refresh-interval", 1*time.Minute,
-		"the interval between consecutive updates of metrics and logs, related to failing reconciliations")
-	flag.BoolVar(&atMostOnePod, "at-most-one-pod", false,
-		"If true, the controller will ensure that at most one pod is running at a time. "+
-			"Otherwise, the outdated pod might be left to terminate, while the new one is already running.")
-	flag.BoolVar(&useVirtioConsole, "use-virtio-console", false,
-		"If true, the controller will set up the runner to use virtio console instead of serial console.")
-	flag.Parse()
+	cli := getCli()
 
 	logConfig := zap.NewProductionConfig()
 	logConfig.Sampling = nil // Disabling sampling; it's enabled by default for zap's production configs.
@@ -170,10 +108,10 @@ func main() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
-			BindAddress: metricsAddr,
+			BindAddress: cli.metricsAddr,
 		},
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
+		HealthProbeBindAddress: cli.probeAddr,
+		LeaderElection:         cli.enableLeaderElection,
 		LeaderElectionID:       "a3b22509.neon.tech",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
@@ -193,17 +131,17 @@ func main() {
 	reconcilerMetrics := controllers.MakeReconcilerMetrics()
 
 	rc := &controllers.ReconcilerConfig{
-		DisableRunnerCgroup:     disableRunnerCgroup,
-		MaxConcurrentReconciles: concurrencyLimit,
-		SkipUpdateValidationFor: skipUpdateValidationFor,
-		QEMUDiskCacheSettings:   qemuDiskCacheSettings,
-		MemhpAutoMovableRatio:   memhpAutoMovableRatio,
-		FailurePendingPeriod:    failurePendingPeriod,
-		FailingRefreshInterval:  failingRefreshInterval,
-		AtMostOnePod:            atMostOnePod,
-		DefaultCPUScalingMode:   defaultCpuScalingMode,
+		DisableRunnerCgroup:     cli.disableRunnerCgroup,
+		MaxConcurrentReconciles: cli.concurrencyLimit,
+		SkipUpdateValidationFor: cli.skipUpdateValidationFor,
+		QEMUDiskCacheSettings:   cli.qemuDiskCacheSettings,
+		MemhpAutoMovableRatio:   cli.memhpAutoMovableRatio,
+		FailurePendingPeriod:    cli.failurePendingPeriod,
+		FailingRefreshInterval:  cli.failingRefreshInterval,
+		AtMostOnePod:            cli.atMostOnePod,
+		DefaultCPUScalingMode:   cli.defaultCpuScalingMode,
 		NADConfig:               controllers.GetNADConfig(),
-		UseVirtioConsole:        useVirtioConsole,
+		UseVirtioConsole:        cli.useVirtioConsole,
 	}
 
 	ipam, err := ipam.New(ipam.IPAMParams{
@@ -212,7 +150,7 @@ func main() {
 
 		// Let's not have more than a quarter of reconcilliation workers stuck
 		// at IPAM mutex.
-		ConcurrencyLimit: max(1, concurrencyLimit/4),
+		ConcurrencyLimit: max(1, cli.concurrencyLimit/4),
 
 		MetricsReg: metrics.Registry,
 	})


### PR DESCRIPTION
I was looking at adding a few additional CLI flags, figured it's worth refactoring main beforehand, so it's at least a bit more manageable.