### PR TITLE
CI: set environment for Azure to push images on tags

### DIFF
--- a/.github/workflows/_push-to-container-registry.yml
+++ b/.github/workflows/_push-to-container-registry.yml
@@ -54,6 +54,8 @@ jobs:
     permissions:
       id-token: write  # Required for aws/azure login
       packages: write  # required for pushing to GHCR
+    # Azure OIDC configuration requires the environment to be set to push images on git tags
+    environment: ${{ inputs.azure-client-id == vars.AZURE_PROD_CLIENT_ID && 'prod' || 'dev' }}-azure-eastus2
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0


### PR DESCRIPTION
Azure OICD is configured for GitHub environments to make it possible to push docker images on tag creation (otherwise we have to list all tags which is not possible to do — Azure doesn't support wildcards https://github.com/Azure/azure-workload-identity/issues/373).

`environment` was lost from the workflow in https://github.com/neondatabase/autoscaling/pull/1283

This PR adds `environment` back to `_push-to-container-registry.yml` workflow.