### PR TITLE
scheduler: Disable some plugins

### DIFF
--- a/autoscale-scheduler/config_map.yaml
+++ b/autoscale-scheduler/config_map.yaml
@@ -15,6 +15,12 @@ data:
           multiPoint:
             enabled:
               - name: AutoscaleEnforcer
+          score:
+            # Score() for some plugins is disabled to avoid conflicts with AutoscaleEnforcer
+            disabled:
+              - name: ImageLocality
+              - name: NodeResourcesBalancedAllocation
+              - name: NodeResourcesFit
 ---
 # TODO: put this in the KubeSchedulerConfiguration's plugin config, rather than a separate configmap
 apiVersion: v1


### PR DESCRIPTION
Some default plugins can interfere with score calculated by our AutoscaleEnforcer plugin:
- ImageLocality returns score based on image presence
- NodeResourcesBalancedAllocation scores how balanced the resources are
- NodeResourcesFit scores to favor nodes with more free capacity

Let's disable these plugins. Other default plugins are either useful or shouldn't have any effect.

More info: https://neondb.slack.com/archives/C08T2CKLTE3/p1747937332728809