### PR TITLE
neonvm: do not use targetArchitecture in affinity, if not set

### DIFF
--- a/neonvm/apis/neonvm/v1/virtualmachine_types.go
+++ b/neonvm/apis/neonvm/v1/virtualmachine_types.go
@@ -113,7 +113,6 @@ type VirtualMachineSpec struct {
 
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
-	// +kubebuilder:default:=amd64
 	// +optional
 	TargetArchitecture *CPUArchitecture `json:"targetArchitecture,omitempty"`
 

--- a/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
+++ b/neonvm/config/crd/bases/vm.neon.tech_virtualmachines.yaml
@@ -2962,7 +2962,6 @@ spec:
               serviceAccountName:
                 type: string
               targetArchitecture:
-                default: amd64
                 enum:
                 - amd64
                 - arm64

--- a/tests/e2e/default-values/00-assert.yaml
+++ b/tests/e2e/default-values/00-assert.yaml
@@ -6,7 +6,6 @@ apiVersion: vm.neon.tech/v1
 kind: VirtualMachine
 metadata:
   name: example
-# default values for cpuScalingMode and cpuArchitecture
+# default values for cpuScalingMode
 spec:
   cpuScalingMode: QmpScaling
-  targetArchitecture: amd64


### PR DESCRIPTION
Do not add affinity if targetArchitecture is nil.

Should imrove quality of live with local development not on x86 and should simplify import jobs spec.

Issue https://github.com/neondatabase/cloud/issues/30328