### PR TITLE
billing: Remove S3 prefix check and modify S3 key

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -215,7 +215,6 @@ func (c *Config) validate() error {
 	if c.ScalingEvents.Clients.S3 != nil {
 		validateBaseReportingConfig(&c.ScalingEvents.Clients.S3.BaseClientConfig, "scalingEvents.clients.s3")
 		validateS3ReportingConfig(&c.ScalingEvents.Clients.S3.S3ClientConfig, ".scalingEvents.clients.s3")
-		erc.Whenf(ec, c.ScalingEvents.Clients.S3.PrefixInBucket == "", emptyTmpl, ".scalingEvents.clients.s3.prefixInBucket")
 	}
 
 	erc.Whenf(ec, c.DumpState != nil && c.DumpState.Port == 0, zeroTmpl, ".dumpState.port")

--- a/pkg/agent/scalingevents/clients.go
+++ b/pkg/agent/scalingevents/clients.go
@@ -3,6 +3,7 @@ package scalingevents
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/lithammer/shortuuid"
@@ -81,13 +82,17 @@ func jsonLinesBatch[B reporting.IOBuffer](buf func() B) func() reporting.BatchBu
 // uses for its reporting.
 func newBlobStorageKeyGenerator(prefix string) func() string {
 	return func() string {
-		now := time.Now().UTC()
+		now := time.Now()
 		id := shortuuid.New()
 
-		return fmt.Sprintf(
-			"%s/%d/%02d/%02d/%02d/events_%s.ndjson.gz",
+		if prefix != "" {
+			prefix = strings.TrimRight(prefix, "/") + "/"
+		}
+
+		return fmt.Sprintf("%syear=%d/month=%02d/day=%02d/hour=%02d/%s_%s.ndjson.gz",
 			prefix,
 			now.Year(), now.Month(), now.Day(), now.Hour(),
+			now.Format("15:04:05Z"),
 			id,
 		)
 	}


### PR DESCRIPTION
Remove the S3 prefix requirement and modify the S3 key. We will use regional buckets from now on and do not need the region prefix there, but we would like to partition data by hours instead of days.

Relates: https://github.com/neondatabase/cloud/issues/29993