### PR TITLE
vm-builder: Suport docker contexts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -130,6 +130,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.6 // indirect
 	github.com/go-ldap/ldap/v3 v3.4.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/fvbommel/sortorder v1.1.0 h1:fUmoe+HLsBTctBDoaBwpQo5N+nrCp8g/BjKb/6ZQmYw=
+github.com/fvbommel/sortorder v1.1.0/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/vm-builder/main.go
+++ b/vm-builder/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/alessio/shellescape"
 	"github.com/distribution/reference"
 	cliconfig "github.com/docker/cli/cli/config"
+	dockercontext "github.com/docker/cli/cli/context"
+	contextstore "github.com/docker/cli/cli/context/store"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"
@@ -200,10 +202,39 @@ func main() {
 		authConfigs[key] = registry.AuthConfig(value)
 	}
 
+	dockerClientOpts := []client.Opt{
+		client.FromEnv,
+		client.WithAPIVersionNegotiation(),
+	}
+
+	if dockerConfig.CurrentContext != "" {
+		store := contextstore.New(
+			cliconfig.ContextStoreDir(),
+			contextstore.NewConfig(
+				contextstore.TypeGetter(func() any { return new(contextstore.Metadata) }),
+				contextstore.EndpointTypeGetter("docker", contextstore.TypeGetter(func() any { return new(dockercontext.EndpointMetaBase) })),
+			),
+		)
+
+		meta, err := store.GetMetadata(dockerConfig.CurrentContext)
+		if err != nil {
+			log.Fatalf("failed to get metadata for docker context %q: %s", dockerConfig.CurrentContext, err)
+		} else if _, ok := meta.Endpoints["docker"]; !ok {
+			log.Fatalf("metadata for docker context %q missing \"docker\" endpoint", dockerConfig.CurrentContext)
+		}
+
+		endpointMeta := meta.Endpoints["docker"].(dockercontext.EndpointMetaBase)
+		if endpointMeta.Host == "" {
+			log.Fatalf("docker endpoint host for context %q is missing", dockerConfig.CurrentContext)
+		}
+
+		dockerClientOpts = append(dockerClientOpts, client.WithHost(endpointMeta.Host))
+	}
+
 	ctx := context.Background()
 
 	log.Println("Setup docker connection")
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.NewClientWithOpts(dockerClientOpts...)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
Colima on MacOS uses a docker context to redirect to the socket at `~/.colima/default/docker.sock`.

If you look in `~/.docker/contexts/meta/.../meta.json`, the content of the context looks something like:

```json
{"Name":"colima","Metadata":{"Description":"colima"},"Endpoints":{"docker":{"Host":"unix:///<HOME>/.colima/default/docker.sock","SkipTLSVerify":false}}}
```

So, in order to allow vm-builder to work with colima, use docker contexts.