### PR TITLE
neonvm-runner: Support QEMU EFI for apple silicon

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -207,6 +207,13 @@ jobs:
           docker cp ${ID}:/vmlinuz neonvm-kernel/vmlinuz
           docker rm -f ${ID}
 
+      - name: Get QEMU BIOS for platform
+        env:
+          ARCH: ${{ matrix.arch }}
+          OS: linux
+        run: |
+          neonvm-runner/get-qemu-bios.sh "$ARCH" "$OS"
+
       - name: Build go dependencies image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         id: build-go-dependencies-image
@@ -233,6 +240,8 @@ jobs:
           tags: ${{ steps.tags.outputs.runner }}
           build-args: |
             GO_BASE_IMG=${{ env.GO_BASE_IMG }}
+            FIRMWARE_ARCH=${{ matrix.arch }}
+            FIRMWARE_OS=linux
 
       - name: Build and push neonvm-controller image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0

--- a/Makefile
+++ b/Makefile
@@ -205,10 +205,12 @@ docker-build-controller: docker-build-go-base ## Build docker image for NeonVM c
 		.
 
 .PHONY: docker-build-runner
-docker-build-runner: docker-build-go-base ## Build docker image for NeonVM runner
-	docker build \
+docker-build-runner: docker-build-go-base download-qemu-bios ## Build docker image for NeonVM runner
+	docker buildx build \
 		--tag $(IMG_RUNNER) \
 		--build-arg GO_BASE_IMG=$(GO_BASE_IMG) \
+		--build-arg FIRMWARE_ARCH="$(TARGET_ARCH)" \
+		--build-arg FIRMWARE_OS="$(GOOS)" \
 		--file neonvm-runner/Dockerfile \
 		.
 
@@ -282,6 +284,9 @@ docker-build-pg16-disk-test: bin/vm-builder ## Build a VM image for testing
 ifndef ignore-not-found
   ignore-not-found = false
 endif
+
+download-qemu-bios:
+	neonvm-runner/get-qemu-bios.sh "$(TARGET_ARCH)" "$(GOOS)"
 
 # Build the kernel for the target architecture.
 # The builder image platform is not specified because the kernel is built for the target architecture using crosscompilation.

--- a/neonvm-runner/.gitignore
+++ b/neonvm-runner/.gitignore
@@ -1,0 +1,2 @@
+# these are large binary blobs
+external-firmware

--- a/neonvm-runner/Dockerfile
+++ b/neonvm-runner/Dockerfile
@@ -29,10 +29,15 @@ RUN apk add --no-cache \
     tcpdump \
     tini
 
-COPY --from=builder /runner /usr/bin/runner
-COPY neonvm-kernel/vmlinuz /vm/kernel/vmlinuz
 COPY neonvm-runner/ssh_config /etc/ssh/ssh_config
-# QEMU_EFI used only by runner running on the arm architecture
-RUN wget https://releases.linaro.org/components/kernel/uefi-linaro/16.02/release/qemu64/QEMU_EFI.fd -O /vm/QEMU_EFI_ARM.fd
+COPY neonvm-kernel/vmlinuz    /vm/kernel/vmlinuz
+
+# Specialized firmware is only required for ARM, so we copy the directory, which will be empty if
+# there is no firmware needed. If not empty, there will be a QEMU_EFI.fd file.
+ARG FIRMWARE_ARCH
+ARG FIRMWARE_OS
+COPY neonvm-runner/external-firmware/$FIRMWARE_ARCH-$FIRMWARE_OS /vm/firmware
+
+COPY --from=builder /runner /usr/bin/runner
 
 ENTRYPOINT ["/sbin/tini", "--", "runner"]

--- a/neonvm-runner/cmd/main.go
+++ b/neonvm-runner/cmd/main.go
@@ -330,7 +330,7 @@ func buildQEMUCmd(
 	switch cfg.architecture {
 	case architectureArm64:
 		// add custom firmware to have ACPI working
-		qemuCmd = append(qemuCmd, "-bios", "/vm/QEMU_EFI_ARM.fd")
+		qemuCmd = append(qemuCmd, "-bios", "/vm/firmware/QEMU_EFI.fd")
 		// arm virt has only one UART, setup virtio-serial to add more /dev/hvcX
 		qemuCmd = append(qemuCmd,
 			"-chardev", "stdio,id=virtio-console",

--- a/neonvm-runner/get-qemu-bios.sh
+++ b/neonvm-runner/get-qemu-bios.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+USAGE="$0 <arch> <OS>"
+#
+# Helper script for fetching the appropriate firmware. If firmware is required for the arch/OS, the
+# file will be placed into "./external-firmware/$arch-$os/QEMU_EFI.fd".
+#
+# If the required file is already present, with the correct SHA256 hash, nothing will change.
+
+ARM_LINARO_SHA='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+ARM64_DARWIN_BIOS_SHA='47765fe344818cbc464b1c14ae658fb4b854f5c2ceffa982411731eb4865594d'
+ARM64_DARWIN_QEMU_VERSION='10.0.2_2'
+# sha via:  curl https://formulae.brew.sh/api/formula/qemu.json | jq '.bottle.stable.files["arm64_sequoia"]'
+ARM64_DARWIN_QEMU_SHA='adb87194ee5c7d14f3ab91c1013113cae741b6b35b74ca7d228b5e583e987d8a'
+
+set -eu -o pipefail
+
+main () {
+    if [ "$#" -ne 2 ]; then
+        echo "$USAGE" >/dev/stderr
+        exit 1
+    fi
+
+    arch="$1"
+    check_arg_value 'architecture' "$arch" 'amd64' 'arm64' # NOTE: these are provided by the makefile, we only accept a limited set.
+    os="$2"
+    check_arg_value 'OS' "$os" 'linux' 'darwin' # NOTE: these are provided by the makefile, we only accept a limited set.
+
+    cd -P -- "$(dirname "$(realpath "$0")")"
+
+    target_dir="external-firmware/$arch-$os"
+    target_file="$target_dir/QEMU_EFI.fd"
+    mkdir -p "$target_dir"
+
+    if [ "$arch" = 'amd64' ]; then
+        echo "No extra BIOS needed on x86_64"
+        exit
+    fi
+
+    test_bins curl mktemp
+
+    if [ "$os" = 'linux' ]; then
+        download_linaro_aarch64 "$target_file"
+    elif [ "$os" = 'darwin' ]; then
+        download_qemu_applesilicon_aarch64 "$target_file"
+    else
+        echo "Internal error: unexpected OS" >/dev/stderr
+        exit 1
+    fi
+}
+
+# Usage: check_arg_value <name> <value> <potential values...>
+check_arg_value () {
+    name="$1"
+    value="$2"
+    shift; shift
+
+    for v in "$@"; do
+        if [ "$value" = "$v" ]; then
+            return
+        fi
+    done
+
+    printf -v values "'%s', " "$@"
+    values="${values%, }"
+    echo "Unexpected $name '$value', expected one of $values" >/dev/stderr
+    echo "$USAGE" >/dev/stderr
+    exit 1
+}
+
+test_bins () {
+    for bin in "$@"; do
+        if ! which "$bin" >/dev/null; then
+            echo "Unable to find '$bin' in path" >/dev/stderr
+            exit 1
+        fi
+    done
+}
+
+# Usage: download_linaro_aarch64 <target-file>
+download_linaro_aarch64 () {
+    file="$1"
+
+    if [ -f "$file" ]; then
+        sha256="$(sha256sum "$file" | cut -d' ' -f1)"
+        if [ "$sha256" = "$ARM_LINARO_SHA" ]; then
+            echo "File $file already exists with correct SHA. Nothing to do."
+            return
+        else
+            echo "File $file already exists, but has incorrect SHA ($sha256 vs $ARM_LINARO_SHA)" >/dev/stderr
+            exit 1
+        fi
+    fi
+
+    curl -f "https://releases.linaro.org/components/kernel/uefi-linaro/16.02/release/qemu64/QEMU_EFI.fd" -o "$file"
+
+    sha256="$(sha256sum "$file" | cut -d' ' -f1)"
+    if [ "$sha256" = "$ARM_LINARO_SHA" ]; then
+        echo "File downloaded and SHA matches expected ($ARM_LINARO_SHA)"
+    else
+        echo "File downloaded but SHA is incorrect ($sha256 vs $ARM_LINARO_SHA)" >/dev/stderr
+        exit 1
+    fi
+}
+
+# Usage: download_qemu_applesilicon_aarch64 <target-file>
+download_qemu_applesilicon_aarch64 () {
+    file="$1"
+
+    if [ -f "$file" ]; then
+        sha256="$(sha256sum "$file" | cut -d' ' -f1)"
+        if [ "$sha256" = "$ARM64_DARWIN_BIOS_SHA" ]; then
+            echo "File $file already exists with correct SHA. Nothing to do."
+            return
+        else
+            echo "File $file already exists, but has incorrect SHA ($sha256 vs $ARM64_DARWIN_BIOS_SHA)" >/dev/stderr
+            exit 1
+        fi
+    fi
+
+    tmpfile="$(mktemp "/tmp/qemu_arm64_sequoia-XXXXXXX.tar.gz")"
+    trap "rm -f $tmpfile" EXIT
+
+    url="https://ghcr.io/v2/homebrew/core/qemu/blobs/sha256:$ARM64_DARWIN_QEMU_SHA"
+
+    echo "Fetching '$url' -> "$tmpfile""
+    curl -fL \
+        -H 'Authorization: Bearer QQ==' \
+        "$url" \
+        -o "$tmpfile"
+
+    sha256="$(sha256sum "$tmpfile" | cut -d' ' -f1)"
+    if [ "$sha256" != "$ARM64_DARWIN_QEMU_SHA" ]; then
+        echo "Blob for homebrew qemu download has incorrect SHA ($sha256 vs $ARM64_DARWIN_QEMU_SHA)" >/dev/stderr
+        exit 1
+    fi
+
+    echo "Extracting 'qemu/$ARM64_DARWIN_QEMU_VERSION/share/qemu/edk2-aarch64-code.fd' from tar"
+    tar -zxv --to-stdout -f "$tmpfile" "qemu/$ARM64_DARWIN_QEMU_VERSION/share/qemu/edk2-aarch64-code.fd" > "$file"
+
+    sha256="$(sha256sum "$file" | cut -d' ' -f1)"
+    if [ "$sha256" = "$ARM64_DARWIN_BIOS_SHA" ]; then
+        echo "File downloaded and SHA matches expected ($ARM64_DARWIN_BIOS_SHA)"
+    else
+        echo "File downloaded but SHA is incorrect ($sha256 vs $ARM64_DARWIN_BIOS_SHA)" >/dev/stderr
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Currently running autoscaling on apple silicon fails - the VM fails to boot up, even when nested virtualization is disabled.

This is because the firmware that we currently use is unfit for apple silicon. To fix it, use the QEMU EFI firmware built by homebrew.

Currently this requires exact version matching with the latest homebrew formula, so running autoscaling locally will unfortunately fail whenever there's a new version.

Long-term, there's better options -- building QEMU ourselves, finding another place to pull the firmware from, etc. But for now, this should get us off the ground.