### PR TITLE
neonvm-controller: Cleanup owners while deleting pod

### DIFF
--- a/pkg/neonvm/controllers/vm_controller.go
+++ b/pkg/neonvm/controllers/vm_controller.go
@@ -700,6 +700,7 @@ func (r *VMReconciler) doReconcile(ctx context.Context, vm *vmv1.VirtualMachine)
 				if err != nil && !apierrors.IsNotFound(err) {
 					return fmt.Errorf("failed to remove ownerReferences from runner pod after deletion: %w", err)
 				}
+				return nil // return early to avoid conflicts from double-reconciling.
 			}
 		} else if !apierrors.IsNotFound(err) {
 			return err


### PR DESCRIPTION
Currently, neonvm-controller is allowed to create a replacement pod without waiting for the old one to be fully deleted. This allows us to recover from node failure without waiting for 25+ minutes for the node to be removed from k8s and object garbage collection to take place.

Unfortunately, because we don't *also* un-link those old pods from the VM object, cascading deletion of the VM object can end up blocked on the deletion of those old pods.

So, after requesting deletion, let's also remove the owner references from the pod so that it doesn't block deletion of the VM object.

ref https://go/es-1529530