### PR TITLE
agent: Make path to prometheus metrics endpoints configurable

### DIFF
--- a/autoscaler-agent/config_map.yaml
+++ b/autoscaler-agent/config_map.yaml
@@ -54,11 +54,13 @@ data:
       "metrics": {
         "system": {
           "port": 9100,
+          "path": "/metrics",
           "requestTimeoutSeconds": 2,
           "secondsBetweenRequests": 5
         },
         "lfc": {
           "port": 9499,
+          "path": "/metrics",
           "requestTimeoutSeconds": 5,
           "secondsBetweenRequests": 15
         }

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -93,10 +93,11 @@ type MetricsConfig struct {
 }
 
 type MetricsSourceConfig struct {
-	// Port is the port that VMs are expected to provide the metrics on
+	// Port and Path define the HTTP endpoint that VMs are expected to provide the metrics on
 	//
-	// For system metrics, vm-builder installs vector (from vector.dev) to expose them on port 9100.
+	// For system metrics, vm-builder installs vector (from vector.dev) to expose them on port 9100, path "/metrics".
 	Port uint16 `json:"port"`
+	Path string `json:"path"`
 	// RequestTimeoutSeconds gives the timeout duration, in seconds, for metrics requests
 	RequestTimeoutSeconds uint `json:"requestTimeoutSeconds"`
 	// SecondsBetweenRequests sets the number of seconds to wait between metrics requests
@@ -221,6 +222,7 @@ func (c *Config) validate() error {
 
 	validateMetricsConfig := func(cfg MetricsSourceConfig, key string) {
 		erc.Whenf(ec, cfg.Port == 0, zeroTmpl, fmt.Sprintf(".metrics.%s.port", key))
+		erc.Whenf(ec, cfg.Path == "", emptyTmpl, fmt.Sprintf(".metrics.%s.path", key))
 		erc.Whenf(ec, cfg.RequestTimeoutSeconds == 0, zeroTmpl, fmt.Sprintf(".metrics.%s.requestTimeoutSeconds", key))
 		erc.Whenf(ec, cfg.SecondsBetweenRequests == 0, zeroTmpl, fmt.Sprintf(".metrics.%s.secondsBetweenRequests", key))
 	}

--- a/pkg/agent/runner.go
+++ b/pkg/agent/runner.go
@@ -689,7 +689,7 @@ func doMetricsRequest(
 	metrics core.FromPrometheus,
 	config MetricsSourceConfig,
 ) error {
-	url := fmt.Sprintf("http://%s:%d/metrics", r.podIP, config.Port)
+	url := fmt.Sprintf("http://%s:%d%s", r.podIP, config.Port, config.Path)
 
 	timeout := time.Second * time.Duration(config.RequestTimeoutSeconds)
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)


### PR DESCRIPTION
This allows switching to the new `/autoscaling_metrics` endpoint for LFC metrics that is introduced in
https://github.com/neondatabase/neon/pull/12591.