### PR TITLE
agent,plugin: Cancel orca ctx before wait

### DIFF
--- a/autoscale-scheduler/cmd/main.go
+++ b/autoscale-scheduler/cmd/main.go
@@ -53,12 +53,14 @@ func runProgram(logger *zap.Logger) (err error) {
 	// services and be able to more coherently wait for shutdown
 	// without needing a sleep.
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
-	defer cancel()
 	ctx = srv.SetShutdownSignal(ctx)
 	ctx = srv.WithOrchestrator(ctx)
 	ctx = srv.SetBaseContext(ctx)
 	orca := srv.GetOrchestrator(ctx)
-	defer func() { err = orca.Service().Wait() }()
+	defer func() {
+		cancel()
+		err = orca.Service().Wait()
+	}()
 
 	if err := orca.Add(srv.HTTP("scheduler-pprof", time.Second, util.MakePPROF("0.0.0.0:7777"))); err != nil {
 		return err

--- a/autoscaler-agent/cmd/main.go
+++ b/autoscaler-agent/cmd/main.go
@@ -63,11 +63,11 @@ func main() {
 	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
-	defer cancel()
 	ctx = srv.SetShutdownSignal(ctx)
 	ctx = srv.SetBaseContext(ctx)
 	ctx = srv.WithOrchestrator(ctx)
 	defer func() {
+		cancel()
 		if err := srv.GetOrchestrator(ctx).Wait(); err != nil {
 			logger.Panic("Failed to shut down orchestrator", zap.Error(err))
 		}


### PR DESCRIPTION
In [LKB-2414](https://databricks.atlassian.net/browse/LKB-2414), we found that the autoscaler-agent can deadlock after a failure during startup. This is because the deferred call to `srv.GetOrchestrator().Wait()` is *before* the canceling of the context, which means that it just blocks forever.

To fix the immediate issue, move the `cancel()` into the same deferred function.

---

I reproduced the issue locally - and confirmed that this fixes it - by modifying the autoscaler-agent's main function to always panic.