### PR TITLE
vm-builder: allow to set `alpine` and `busybox` from custom sources

### DIFF
--- a/vm-builder/files/img.Dockerfile
+++ b/vm-builder/files/img.Dockerfile
@@ -9,17 +9,17 @@ USER root
 
 FROM {{.NeonvmDaemonImage}} AS neonvm-daemon-loader
 
-FROM busybox:{{.BusyboxImageTag}}{{.BusyboxImageSha}} AS busybox-loader
+FROM {{.BusyboxImage}}:{{.BusyboxImageTag}}{{.BusyboxImageSha}} AS busybox-loader
 
-FROM alpine:{{.AlpineImageTag}}{{.AlpineImageSha}} AS vm-runtime
+FROM {{.AlpineImage}}:{{.AlpineImageTag}}{{.AlpineImageSha}} AS vm-runtime
 ARG VM_BUILDER_TARGET_ARCH
-RUN set -e && mkdir -p /neonvm/bin /neonvm/runtime /neonvm/config 
+RUN set -e && mkdir -p /neonvm/bin /neonvm/runtime /neonvm/config
 # add busybox
 COPY --from=busybox-loader /bin/busybox /neonvm/bin/busybox
 
 RUN set -e \
     chmod +x /neonvm/bin/busybox \
-    && /neonvm/bin/busybox --install -s /neonvm/bin 
+    && /neonvm/bin/busybox --install -s /neonvm/bin
 
 COPY helper.move-bins.sh /helper.move-bins.sh
 
@@ -109,7 +109,7 @@ RUN set -e \
     && /neonvm/bin/id -g sshd > /dev/null 2>&1 || /neonvm/bin/addgroup sshd \
     && /neonvm/bin/id -u sshd > /dev/null 2>&1 || /neonvm/bin/adduser -D -H -G sshd -g 'sshd privsep' -s /neonvm/bin/nologin sshd
 
-FROM alpine:{{.AlpineImageTag}}{{.AlpineImageSha}} AS builder
+FROM {{.AlpineImage}}:{{.AlpineImageTag}}{{.AlpineImageSha}} AS builder
 ARG VM_BUILDER_DISK_SIZE
 COPY --from=rootdisk-mod / /rootdisk
 
@@ -128,5 +128,5 @@ RUN set -e \
     && mkfs.ext4 -L vmroot -d /rootdisk /disk.raw ${VM_BUILDER_DISK_SIZE} \
     && qemu-img convert -f raw -O qcow2 -o cluster_size=2M,lazy_refcounts=on /disk.raw /disk.qcow2
 
-FROM alpine:{{.AlpineImageTag}}{{.AlpineImageSha}}
+FROM {{.AlpineImage}}:{{.AlpineImageTag}}{{.AlpineImageSha}}
 COPY --from=builder /disk.qcow2 /

--- a/vm-builder/main.go
+++ b/vm-builder/main.go
@@ -87,8 +87,10 @@ var (
 	forcePull = flag.Bool("pull", false, `Pull src image even if already present locally`)
 	version   = flag.Bool("version", false, `Print vm-builder version`)
 
-	daemonImageFlag = flag.String("daemon-image", "", `Specify the neonvm-daemon image: --daemon-image=neonvm-daemon:dev`)
-	targetArch      = flag.String("target-arch", "", fmt.Sprintf("Target architecture: --arch %s | %s", targetArchLinuxAmd64, targetArchLinuxArm64))
+	daemonImageFlag  = flag.String("daemon-image", "", `Specify the neonvm-daemon image: --daemon-image=neonvm-daemon:dev`)
+	alpineImageFlag  = flag.String("alpine-image", "alpine", `Specify the alpine image: --alpine-image=docker.io/library/alpine`)
+	busyboxImageFlag = flag.String("busybox-image", "busybox", `Specify the busybox image: --busybox-image=docker.io/library/busybox`)
+	targetArch       = flag.String("target-arch", "", fmt.Sprintf("Target architecture: --arch %s | %s", targetArchLinuxAmd64, targetArchLinuxArm64))
 )
 
 func AddTemplatedFileToTar(tw *tar.Writer, tmplArgs any, filename string, tmplString string) error {
@@ -130,8 +132,10 @@ type TemplatesContext struct {
 
 	NeonvmDaemonImage string
 
+	BusyboxImage    string
 	BusyboxImageTag string
 	BusyboxImageSha string
+	AlpineImage     string
 	AlpineImageTag  string
 	AlpineImageSha  string
 
@@ -160,6 +164,9 @@ func main() {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
+
+	alpineImage := *alpineImageFlag
+	busyboxImage := *busyboxImageFlag
 
 	if targetArch == nil || *targetArch == "" {
 		log.Println("Target architecture not set, see usage info:")
@@ -349,9 +356,11 @@ func main() {
 
 		NeonvmDaemonImage: neonvmDaemonImage,
 
+		BusyboxImage:    busyboxImage,
 		BusyboxImageTag: BusyboxImageTag,
 		BusyboxImageSha: getImageSha(*targetArch, BusyboxImageShaAmd64, BusyboxImageShaArm64),
 
+		AlpineImage:    alpineImage,
 		AlpineImageTag: AlpineImageTag,
 		AlpineImageSha: getImageSha(*targetArch, AlpineImageShaAmd64, AlpineImageShaArm64),
 


### PR DESCRIPTION
In some cases, we need pull base images for `vm-builder` from different registries.
This PR adds `alpine-image` and `busybox-image` flags to make it possible to specify that.

Note: These new flags are a bit inconsistent with `daemon-image`, which allows a full image string (including tag/SHA). The new ones only take registry + image. We can unify this later