### PR TITLE
cluster-autoscaler: fix command chaining in Dockerfile RUN instruction

### DIFF
--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -12,7 +12,7 @@ COPY ca.commit ca.commit
 
 # Download the repo. It's... quite large, but thankfully this should get cached
 RUN git clone -b `cat ca.branch` https://github.com/kubernetes/autoscaler
-RUN CA_GIT_TAG=`cat ca.commit` cd autoscaler && git reset --hard $CA_GIT_TAG
+RUN CA_GIT_TAG=`cat ca.commit` && cd autoscaler && git reset --hard $CA_GIT_TAG
 
 # Only ADD the patch after downloading, to avoid wrecking the cache
 COPY ca.patch ca.patch


### PR DESCRIPTION
The git reset command was not properly chained with the cd command, which caused version pinning not to work properly.